### PR TITLE
Fix pypandoc issue

### DIFF
--- a/collector/requirements.txt
+++ b/collector/requirements.txt
@@ -179,7 +179,7 @@ pyobjc-framework-VideoSubscriberAccount==9.1.1
 pyobjc-framework-VideoToolbox==9.1.1
 pyobjc-framework-Vision==9.1.1
 pyobjc-framework-WebKit==9.1.1
-pypandoc==1.11
+pypandoc==1.4
 pyppeteer==1.0.2
 pyquery==2.0.0
 python-dateutil==2.8.2


### PR DESCRIPTION
This PR addresses an issue with the pypandoc dependency that was causing install failures. The problem was due to an outdated usage of the pypandoc package in the requirements.txt file. A similar issue is also noticed [here](https://github.com/Mintplex-Labs/anything-llm/issues/18).