### PR TITLE
refactor: convert chunk embedding to one API call

### DIFF
--- a/server/utils/vectorDbProviders/chroma/index.js
+++ b/server/utils/vectorDbProviders/chroma/index.js
@@ -11,7 +11,7 @@ const { toChunks, curateSources } = require("../../helpers");
 
 const Chroma = {
   name: "Chroma",
-  connect: async function() {
+  connect: async function () {
     if (process.env.VECTOR_DB !== "chroma")
       throw new Error("Chroma::Invalid ENV settings");
 
@@ -26,11 +26,11 @@ const Chroma = {
       );
     return { client };
   },
-  heartbeat: async function() {
+  heartbeat: async function () {
     const { client } = await this.connect();
     return { heartbeat: await client.heartbeat() };
   },
-  totalIndicies: async function() {
+  totalIndicies: async function () {
     const { client } = await this.connect();
     const collections = await client.listCollections();
     var totalVectors = 0;
@@ -43,20 +43,20 @@ const Chroma = {
     }
     return totalVectors;
   },
-  embeddingFunc: function() {
+  embeddingFunc: function () {
     return new OpenAIEmbeddingFunction({
       openai_api_key: process.env.OPEN_AI_KEY,
     });
   },
-  embedder: function() {
+  embedder: function () {
     return new OpenAIEmbeddings({ openAIApiKey: process.env.OPEN_AI_KEY });
   },
-  openai: function() {
+  openai: function () {
     const config = new Configuration({ apiKey: process.env.OPEN_AI_KEY });
     const openai = new OpenAIApi(config);
     return openai;
   },
-  llm: function() {
+  llm: function () {
     const model = process.env.OPEN_MODEL_PREF || "gpt-3.5-turbo";
     return new OpenAI({
       openAIApiKey: process.env.OPEN_AI_KEY,
@@ -64,7 +64,7 @@ const Chroma = {
       modelName: model,
     });
   },
-  embedChunks: async function(openai, chunks) {
+  embedChunks: async function (openai, chunks) {
     const {
       data: { data },
     } = await openai.createEmbedding({
@@ -76,7 +76,7 @@ const Chroma = {
       ? data.map((embd) => embd.embedding)
       : null;
   },
-  namespace: async function(client, namespace = null) {
+  namespace: async function (client, namespace = null) {
     if (!namespace) throw new Error("No namespace value provided.");
     const collection = await client
       .getCollection({ name: namespace })
@@ -88,12 +88,12 @@ const Chroma = {
       vectorCount: await collection.count(),
     };
   },
-  hasNamespace: async function(namespace = null) {
+  hasNamespace: async function (namespace = null) {
     if (!namespace) return false;
     const { client } = await this.connect();
     return await this.namespaceExists(client, namespace);
   },
-  namespaceExists: async function(client, namespace = null) {
+  namespaceExists: async function (client, namespace = null) {
     if (!namespace) throw new Error("No namespace value provided.");
     const collection = await client
       .getCollection({ name: namespace })
@@ -103,11 +103,11 @@ const Chroma = {
       });
     return !!collection;
   },
-  deleteVectorsInNamespace: async function(client, namespace = null) {
+  deleteVectorsInNamespace: async function (client, namespace = null) {
     await client.deleteCollection({ name: namespace });
     return true;
   },
-  addDocumentToNamespace: async function(
+  addDocumentToNamespace: async function (
     namespace,
     documentData = {},
     fullFilePath = null
@@ -234,7 +234,7 @@ const Chroma = {
       return false;
     }
   },
-  deleteDocumentFromNamespace: async function(namespace, docId) {
+  deleteDocumentFromNamespace: async function (namespace, docId) {
     const { DocumentVectors } = require("../../../models/vectors");
     const { client } = await this.connect();
     if (!(await this.namespaceExists(client, namespace))) return;
@@ -253,7 +253,7 @@ const Chroma = {
     await DocumentVectors.deleteIds(indexes);
     return true;
   },
-  query: async function(reqBody = {}) {
+  query: async function (reqBody = {}) {
     const { namespace = null, input } = reqBody;
     if (!namespace || !input) throw new Error("Invalid request body");
 
@@ -282,7 +282,7 @@ const Chroma = {
       message: false,
     };
   },
-  "namespace-stats": async function(reqBody = {}) {
+  "namespace-stats": async function (reqBody = {}) {
     const { namespace = null } = reqBody;
     if (!namespace) throw new Error("namespace required");
     const { client } = await this.connect();
@@ -293,7 +293,7 @@ const Chroma = {
       ? stats
       : { message: "No stats were able to be fetched from DB for namespace" };
   },
-  "delete-namespace": async function(reqBody = {}) {
+  "delete-namespace": async function (reqBody = {}) {
     const { namespace = null } = reqBody;
     const { client } = await this.connect();
     if (!(await this.namespaceExists(client, namespace)))
@@ -305,7 +305,7 @@ const Chroma = {
       message: `Namespace ${namespace} was deleted along with ${details?.vectorCount} vectors.`,
     };
   },
-  reset: async function() {
+  reset: async function () {
     const { client } = await this.connect();
     await client.reset();
     return { reset: true };

--- a/server/utils/vectorDbProviders/pinecone/index.js
+++ b/server/utils/vectorDbProviders/pinecone/index.js
@@ -14,7 +14,7 @@ const { toChunks, curateSources } = require("../../helpers");
 
 const Pinecone = {
   name: "Pinecone",
-  connect: async function () {
+  connect: async function() {
     if (process.env.VECTOR_DB !== "pinecone")
       throw new Error("Pinecone::Invalid ENV settings");
 
@@ -31,26 +31,27 @@ const Pinecone = {
     if (!status.ready) throw new Error("Pinecode::Index not ready.");
     return { client, pineconeIndex, indexName: process.env.PINECONE_INDEX };
   },
-  embedder: function () {
+  embedder: function() {
     return new OpenAIEmbeddings({ openAIApiKey: process.env.OPEN_AI_KEY });
   },
-  openai: function () {
+  openai: function() {
     const config = new Configuration({ apiKey: process.env.OPEN_AI_KEY });
     const openai = new OpenAIApi(config);
     return openai;
   },
-  embedChunk: async function (openai, textChunk) {
+  embedChunks: async function(openai, chunks) {
     const {
       data: { data },
     } = await openai.createEmbedding({
       model: "text-embedding-ada-002",
-      input: textChunk,
+      input: chunks,
     });
-    return data.length > 0 && data[0].hasOwnProperty("embedding")
-      ? data[0].embedding
+    return data.length > 0 &&
+      data.every((embd) => embd.hasOwnProperty("embedding"))
+      ? data.map((embd) => embd.embedding)
       : null;
   },
-  llm: function () {
+  llm: function() {
     const model = process.env.OPEN_MODEL_PREF || "gpt-3.5-turbo";
     return new OpenAI({
       openAIApiKey: process.env.OPEN_AI_KEY,
@@ -58,7 +59,7 @@ const Pinecone = {
       modelName: model,
     });
   },
-  chatLLM: function () {
+  chatLLM: function() {
     const model = process.env.OPEN_MODEL_PREF || "gpt-3.5-turbo";
     return new ChatOpenAI({
       openAIApiKey: process.env.OPEN_AI_KEY,
@@ -66,7 +67,7 @@ const Pinecone = {
       modelName: model,
     });
   },
-  totalIndicies: async function () {
+  totalIndicies: async function() {
     const { pineconeIndex } = await this.connect();
     const { namespaces } = await pineconeIndex.describeIndexStats1();
     return Object.values(namespaces).reduce(
@@ -74,26 +75,26 @@ const Pinecone = {
       0
     );
   },
-  namespace: async function (index, namespace = null) {
+  namespace: async function(index, namespace = null) {
     if (!namespace) throw new Error("No namespace value provided.");
     const { namespaces } = await index.describeIndexStats1();
     return namespaces.hasOwnProperty(namespace) ? namespaces[namespace] : null;
   },
-  hasNamespace: async function (namespace = null) {
+  hasNamespace: async function(namespace = null) {
     if (!namespace) return false;
     const { pineconeIndex } = await this.connect();
     return await this.namespaceExists(pineconeIndex, namespace);
   },
-  namespaceExists: async function (index, namespace = null) {
+  namespaceExists: async function(index, namespace = null) {
     if (!namespace) throw new Error("No namespace value provided.");
     const { namespaces } = await index.describeIndexStats1();
     return namespaces.hasOwnProperty(namespace);
   },
-  deleteVectorsInNamespace: async function (index, namespace = null) {
+  deleteVectorsInNamespace: async function(index, namespace = null) {
     await index.delete1({ namespace, deleteAll: true });
     return true;
   },
-  addDocumentToNamespace: async function (
+  addDocumentToNamespace: async function(
     namespace,
     documentData = {},
     fullFilePath = null
@@ -147,25 +148,27 @@ const Pinecone = {
       const documentVectors = [];
       const vectors = [];
       const openai = this.openai();
-      for (const textChunk of textChunks) {
-        const vectorValues = await this.embedChunk(openai, textChunk);
 
-        if (!!vectorValues) {
+      const vectorValues = await this.embedChunks(openai, textChunks);
+
+      if (!!vectorValues) {
+        for (const [i, vector] of vectorValues.entries()) {
           const vectorRecord = {
             id: uuidv4(),
-            values: vectorValues,
+            values: vector,
             // [DO NOT REMOVE]
             // LangChain will be unable to find your text if you embed manually and dont include the `text` key.
             // https://github.com/hwchase17/langchainjs/blob/2def486af734c0ca87285a48f1a04c057ab74bdf/langchain/src/vectorstores/pinecone.ts#L64
-            metadata: { ...metadata, text: textChunk },
+            metadata: { ...metadata, text: textChunks[i] },
           };
+
           vectors.push(vectorRecord);
           documentVectors.push({ docId, vectorId: vectorRecord.id });
-        } else {
-          console.error(
-            "Could not use OpenAI to embed document chunk! This document will not be recorded."
-          );
         }
+      } else {
+        console.error(
+          "Could not use OpenAI to embed document chunks! This document will not be recorded."
+        );
       }
 
       if (vectors.length > 0) {
@@ -191,7 +194,7 @@ const Pinecone = {
       return false;
     }
   },
-  deleteDocumentFromNamespace: async function (namespace, docId) {
+  deleteDocumentFromNamespace: async function(namespace, docId) {
     const { DocumentVectors } = require("../../../models/vectors");
     const { pineconeIndex } = await this.connect();
     if (!(await this.namespaceExists(pineconeIndex, namespace))) return;
@@ -209,7 +212,7 @@ const Pinecone = {
     await DocumentVectors.deleteIds(indexes);
     return true;
   },
-  "namespace-stats": async function (reqBody = {}) {
+  "namespace-stats": async function(reqBody = {}) {
     const { namespace = null } = reqBody;
     if (!namespace) throw new Error("namespace required");
     const { pineconeIndex } = await this.connect();
@@ -220,7 +223,7 @@ const Pinecone = {
       ? stats
       : { message: "No stats were able to be fetched from DB" };
   },
-  "delete-namespace": async function (reqBody = {}) {
+  "delete-namespace": async function(reqBody = {}) {
     const { namespace = null } = reqBody;
     const { pineconeIndex } = await this.connect();
     if (!(await this.namespaceExists(pineconeIndex, namespace)))
@@ -232,7 +235,7 @@ const Pinecone = {
       message: `Namespace ${namespace} was deleted along with ${details.vectorCount} vectors.`,
     };
   },
-  query: async function (reqBody = {}) {
+  query: async function(reqBody = {}) {
     const { namespace = null, input } = reqBody;
     if (!namespace || !input) throw new Error("Invalid request body");
 
@@ -264,7 +267,7 @@ const Pinecone = {
   },
   // This implementation of chat also expands the memory of the chat itself
   // and adds more tokens to the PineconeDB instance namespace
-  chat: async function (reqBody = {}) {
+  chat: async function(reqBody = {}) {
     const { namespace = null, input } = reqBody;
     if (!namespace || !input) throw new Error("Invalid request body");
 

--- a/server/utils/vectorDbProviders/pinecone/index.js
+++ b/server/utils/vectorDbProviders/pinecone/index.js
@@ -14,7 +14,7 @@ const { toChunks, curateSources } = require("../../helpers");
 
 const Pinecone = {
   name: "Pinecone",
-  connect: async function() {
+  connect: async function () {
     if (process.env.VECTOR_DB !== "pinecone")
       throw new Error("Pinecone::Invalid ENV settings");
 
@@ -31,15 +31,15 @@ const Pinecone = {
     if (!status.ready) throw new Error("Pinecode::Index not ready.");
     return { client, pineconeIndex, indexName: process.env.PINECONE_INDEX };
   },
-  embedder: function() {
+  embedder: function () {
     return new OpenAIEmbeddings({ openAIApiKey: process.env.OPEN_AI_KEY });
   },
-  openai: function() {
+  openai: function () {
     const config = new Configuration({ apiKey: process.env.OPEN_AI_KEY });
     const openai = new OpenAIApi(config);
     return openai;
   },
-  embedChunks: async function(openai, chunks) {
+  embedChunks: async function (openai, chunks) {
     const {
       data: { data },
     } = await openai.createEmbedding({
@@ -51,7 +51,7 @@ const Pinecone = {
       ? data.map((embd) => embd.embedding)
       : null;
   },
-  llm: function() {
+  llm: function () {
     const model = process.env.OPEN_MODEL_PREF || "gpt-3.5-turbo";
     return new OpenAI({
       openAIApiKey: process.env.OPEN_AI_KEY,
@@ -59,7 +59,7 @@ const Pinecone = {
       modelName: model,
     });
   },
-  chatLLM: function() {
+  chatLLM: function () {
     const model = process.env.OPEN_MODEL_PREF || "gpt-3.5-turbo";
     return new ChatOpenAI({
       openAIApiKey: process.env.OPEN_AI_KEY,
@@ -67,7 +67,7 @@ const Pinecone = {
       modelName: model,
     });
   },
-  totalIndicies: async function() {
+  totalIndicies: async function () {
     const { pineconeIndex } = await this.connect();
     const { namespaces } = await pineconeIndex.describeIndexStats1();
     return Object.values(namespaces).reduce(
@@ -75,26 +75,26 @@ const Pinecone = {
       0
     );
   },
-  namespace: async function(index, namespace = null) {
+  namespace: async function (index, namespace = null) {
     if (!namespace) throw new Error("No namespace value provided.");
     const { namespaces } = await index.describeIndexStats1();
     return namespaces.hasOwnProperty(namespace) ? namespaces[namespace] : null;
   },
-  hasNamespace: async function(namespace = null) {
+  hasNamespace: async function (namespace = null) {
     if (!namespace) return false;
     const { pineconeIndex } = await this.connect();
     return await this.namespaceExists(pineconeIndex, namespace);
   },
-  namespaceExists: async function(index, namespace = null) {
+  namespaceExists: async function (index, namespace = null) {
     if (!namespace) throw new Error("No namespace value provided.");
     const { namespaces } = await index.describeIndexStats1();
     return namespaces.hasOwnProperty(namespace);
   },
-  deleteVectorsInNamespace: async function(index, namespace = null) {
+  deleteVectorsInNamespace: async function (index, namespace = null) {
     await index.delete1({ namespace, deleteAll: true });
     return true;
   },
-  addDocumentToNamespace: async function(
+  addDocumentToNamespace: async function (
     namespace,
     documentData = {},
     fullFilePath = null
@@ -194,7 +194,7 @@ const Pinecone = {
       return false;
     }
   },
-  deleteDocumentFromNamespace: async function(namespace, docId) {
+  deleteDocumentFromNamespace: async function (namespace, docId) {
     const { DocumentVectors } = require("../../../models/vectors");
     const { pineconeIndex } = await this.connect();
     if (!(await this.namespaceExists(pineconeIndex, namespace))) return;
@@ -212,7 +212,7 @@ const Pinecone = {
     await DocumentVectors.deleteIds(indexes);
     return true;
   },
-  "namespace-stats": async function(reqBody = {}) {
+  "namespace-stats": async function (reqBody = {}) {
     const { namespace = null } = reqBody;
     if (!namespace) throw new Error("namespace required");
     const { pineconeIndex } = await this.connect();
@@ -223,7 +223,7 @@ const Pinecone = {
       ? stats
       : { message: "No stats were able to be fetched from DB" };
   },
-  "delete-namespace": async function(reqBody = {}) {
+  "delete-namespace": async function (reqBody = {}) {
     const { namespace = null } = reqBody;
     const { pineconeIndex } = await this.connect();
     if (!(await this.namespaceExists(pineconeIndex, namespace)))
@@ -235,7 +235,7 @@ const Pinecone = {
       message: `Namespace ${namespace} was deleted along with ${details.vectorCount} vectors.`,
     };
   },
-  query: async function(reqBody = {}) {
+  query: async function (reqBody = {}) {
     const { namespace = null, input } = reqBody;
     if (!namespace || !input) throw new Error("Invalid request body");
 
@@ -267,7 +267,7 @@ const Pinecone = {
   },
   // This implementation of chat also expands the memory of the chat itself
   // and adds more tokens to the PineconeDB instance namespace
-  chat: async function(reqBody = {}) {
+  chat: async function (reqBody = {}) {
     const { namespace = null, input } = reqBody;
     if (!namespace || !input) throw new Error("Invalid request body");
 


### PR DESCRIPTION
I was having really long embed times for a couple large .docx documents ingested through the `/hotdir`. One had 256 chunks and took many minutes to fully embed, sometimes never finishing at all.

I converted the `embedChunk()` method to accept a list of chunks instead of just one chunk, and make a single call to OpenAI's embedding API endpoint, which seems to have sped up the embed process dramatically. The refactored `embedChunks()` required some changes to its usage in `addDocumentToNamespace()` as well. I included these changes for the 3 vector db options at `/server/utils/vectorDbProviders/[vectorDb]/index.js`

Let me know what you think and if this is helpful. Again, apologies for my editor's lsp changing some of the method signatures and line-length formatting, hope it is ok.