### PR TITLE
Add support for CPU arch in Docker installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:jammy-20230522 AS base
 # Build arguments
 ARG ARG_UID
 ARG ARG_GID
+ARG ARCH=amd64 # Default to amd64 if not provided
 
 # Install system dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
@@ -19,9 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     curl -LO https://github.com/yarnpkg/yarn/releases/download/v1.22.19/yarn_1.22.19_all.deb \
         && dpkg -i yarn_1.22.19_all.deb \
         && rm yarn_1.22.19_all.deb && \
-    curl -LO https://github.com/jgm/pandoc/releases/download/3.1.3/pandoc-3.1.3-1-amd64.deb \
-        && dpkg -i pandoc-3.1.3-1-amd64.deb \
-        && rm pandoc-3.1.3-1-amd64.deb && \
+    curl -LO https://github.com/jgm/pandoc/releases/download/3.1.3/pandoc-3.1.3-1-${ARCH}.deb \
+        && dpkg -i pandoc-3.1.3-1-${ARCH}.deb \
+        && rm pandoc-3.1.3-1-${ARCH}.deb && \
     rm -rf /var/lib/apt/lists/* /usr/share/icons && \
     dpkg-reconfigure -f noninteractive tzdata && \
     python3 -m pip install --no-cache-dir virtualenv

--- a/docker/HOW_TO_USE_DOCKER.md
+++ b/docker/HOW_TO_USE_DOCKER.md
@@ -9,15 +9,30 @@ Use the Dockerized version of AnythingLLM for a much faster and complete startup
 - `git clone` this repo and `cd anything-llm` to get to the root directory.
 - `yarn setup:envs` from repo root & fill out the `.env` file that is then created in `./docker/`
 - `cd docker/`
-- `docker-compose up -d --build` to build the image - this will take a few moments.
+- To build the image, **use any of these commands based on your CPU architecture**.
+  
+  **This will use `amd64` (common on Windows/Intel Mac)**
 
-Your docker host will show the image as online one the build process is completed. This will build the app to `http://localhost:3001`.
+  ```
+  docker-compose up -d --build
+  ```
+  
+  **This will use `arm64` (M1/M2 Mac)**
+
+  ```
+  ARCH=arm64 docker-compose up -d --build
+  ```
+
+  This step will take a few moments on the first run.
+
+
+Your docker host will show the image as online once the build process is completed. This will build the app to `http://localhost:3001`.
 
 ## How to use the user interface
-- To access the full application visit `http://localhost:3001` in your browser.
+- To access the full application, visit `http://localhost:3001` in your browser.
 
 ## How to add files to my system
-- To run the collector scripts to grab external data (articles, URLs, etc)
+- To run the collector scripts to grab external data (articles, URLs, etc.)
   - `docker exec -it --workdir=/app/collector anything-llm python main.py`
 
 - To run the collector on local documents you want to provide to it
@@ -29,7 +44,7 @@ Your docker host will show the image as online one the build process is complete
 
 
 ## ⚠️ Vector DB support ⚠️
-Out of the box all vector databases are supported. Any vector databases requiring special configuration are listed below.
+Out of the box, all vector databases are supported. Any vector databases requiring special configuration are listed below.
 
 ### Using local ChromaDB with Dockerized AnythingLLM
 - Ensure in your `./docker/.env` file that you have

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       args:
         ARG_UID: ${UID}
         ARG_GID: ${GID}
+        ARCH: ${ARCH:-amd64}
     volumes:
       - "../server/storage:/app/server/storage"
       - "../collector/hotdir/:/app/collector/hotdir"


### PR DESCRIPTION
Currently, the `Dockerfile` installs `pandoc-3.1.3-1-amd64.deb`, but this produces an error on M1 Mac since it is based on `arm64`, not `amd64`

This PR adds support for that. Docs have also been updated accordingly.