### PR TITLE
Add support for all CPU architectures in docker compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,6 @@ FROM ubuntu:jammy-20230522 AS base
 ARG ARG_UID
 ARG ARG_GID
 ARG ARG_CLOUD_BUILD=0 # Default to local docker build
-ARG ARCH=amd64 # Default to amd64 if not provided
 
 # Install system dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
@@ -21,9 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     curl -LO https://github.com/yarnpkg/yarn/releases/download/v1.22.19/yarn_1.22.19_all.deb \
         && dpkg -i yarn_1.22.19_all.deb \
         && rm yarn_1.22.19_all.deb && \
-    curl -LO https://github.com/jgm/pandoc/releases/download/3.1.3/pandoc-3.1.3-1-${ARCH}.deb \
-        && dpkg -i pandoc-3.1.3-1-${ARCH}.deb \
-        && rm pandoc-3.1.3-1-${ARCH}.deb && \
+    curl -LO https://github.com/jgm/pandoc/releases/download/3.1.3/pandoc-3.1.3-1-amd64.deb \
+        && dpkg -i pandoc-3.1.3-1-amd64.deb \
+        && rm pandoc-3.1.3-1-amd64.deb && \
     rm -rf /var/lib/apt/lists/* /usr/share/icons && \
     dpkg-reconfigure -f noninteractive tzdata && \
     python3 -m pip install --no-cache-dir virtualenv
@@ -91,7 +90,7 @@ HEALTHCHECK --interval=1m --timeout=10s --start-period=1m \
   CMD /bin/bash /usr/local/bin/docker-healthcheck.sh || exit 1
 
 # Docker will still install deps as root so need to force chown
-# or else 
+# or else
 USER root
 RUN if [ "$ARG_CLOUD_BUILD" = 1 ] ; then \
     echo "Reowning all files as user!" && \

--- a/docker/HOW_TO_USE_DOCKER.md
+++ b/docker/HOW_TO_USE_DOCKER.md
@@ -9,22 +9,7 @@ Use the Dockerized version of AnythingLLM for a much faster and complete startup
 - `git clone` this repo and `cd anything-llm` to get to the root directory.
 - `yarn setup:envs` from repo root & fill out the `.env` file that is then created in `./docker/`
 - `cd docker/`
-- To build the image, **use any of these commands based on your CPU architecture**.
-  
-  **This will use `amd64` (common on Windows/Intel Mac)**
-
-  ```
-  docker-compose up -d --build
-  ```
-  
-  **This will use `arm64` (M1/M2 Mac)**
-
-  ```
-  ARCH=arm64 docker-compose up -d --build
-  ```
-
-  This step will take a few moments on the first run.
-
+- `docker-compose up -d --build` to build the image - this will take a few moments.
 
 Your docker host will show the image as online once the build process is completed. This will build the app to `http://localhost:3001`.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
   anything-llm:
     container_name: anything-llm
     image: anything-llm:latest
+    platform: linux/amd64
     build:
       context: ../.
       dockerfile: ./docker/Dockerfile
@@ -17,7 +18,6 @@ services:
         ARG_UID: ${UID}
         ARG_GID: ${GID}
         ARG_CLOUD_BUILD: ${CLOUD_BUILD}
-        ARCH: ${ARCH:-amd64}
     volumes:
       - "../server/storage:/app/server/storage"
       - "../collector/hotdir/:/app/collector/hotdir"


### PR DESCRIPTION
This PR reverts https://github.com/Mintplex-Labs/anything-llm/pull/48 and adds support for running Docker container on all CPU architectures (`arm64` or `amd64`)