### PR TITLE
Remove `maxLength` in chat input box to allow larger prompts

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -55,7 +55,6 @@ export default function PromptInput({
             onKeyDown={captureEnter}
             onChange={onChange}
             required={true}
-            maxLength={240}
             disabled={inputDisabled}
             onFocus={() => setFocused(true)}
             onBlur={(e) => {


### PR DESCRIPTION
Can't send larger messages because of this artificial limit.

ChatGPT also doesn't have any upper limit to what we can send as message.