### PR TITLE
Actually enable x-scrolling when citations overflow.

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Citation/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Citation/index.jsx
@@ -22,7 +22,7 @@ export default function Citations({ sources = [] }) {
 
   return (
     <div className="flex flex-col mt-4 justify-left">
-      <div className="no-scroll flex flex-col justify-left overflow-x-scroll ">
+      <div className="flex flex-col justify-left overflow-x-scroll ">
         <div className="w-full flex overflow-x-scroll items-center gap-4 mt-1 doc__source">
           {combineLikeSources(sources).map((source) => (
             <Citation id={source?.id || v4()} source={source} />


### PR DESCRIPTION
Only 3 and a half citations are displayed in the chat history. When there are more, there is no scroll bar to access them. Tiny fix to enable a horizontal scroll bar in this case. Obviously this was intended in the original code but the `no-scroll` was wrong.