### PR TITLE
Solving permissions issue with collector/outputs and server/storage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,13 +63,13 @@ RUN cd ./frontend/ && yarn build && yarn cache clean
 
 # Setup the server
 FROM server-deps as production-stage
-COPY ./server/ ./server/
+COPY --chown=anythingllm:anythingllm ./server/ ./server/
 
 # Copy built static frontend files to the server public directory
 COPY --from=build-stage /app/frontend/dist ./server/public
 
 # Copy the collector
-COPY ./collector/ ./collector/
+COPY --chown=anythingllm:anythingllm ./collector/ ./collector/
 
 # Install collector dependencies
 RUN cd /app/collector && \


### PR DESCRIPTION
When deploying freshly with docker-compose the permissions of files in `/app/collector/` and `/app/server/` are mixed, most files are owned by `root` and some are owned by `anythingllm`. This leads to various issues (possibly related: #117).

```
anythingllm@7207f4cd9512:~$ ls -l /app/server/
total 156
drwxrwxr-x   2 root        root          4096 Aug  9 10:16 endpoints
-rw-rw-r--   1 root        root          2799 Aug  9 10:16 index.js
drwxrwxr-x   2 root        root          4096 Aug  9 10:16 models
drwxr-xr-x 298 anythingllm anythingllm  12288 Aug  9 13:13 node_modules
-rw-rw-r--   1 root        root          1348 Aug  9 10:16 package.json
drwxr-xr-x   4 root        root          4096 Aug  9 13:13 public
drwxrwxr-x   5 anythingllm anythingllm   4096 Aug  9 11:57 storage
drwxrwxr-x  10 root        root          4096 Aug  9 10:16 utils
-rw-rw-r--   1 root        root        115692 Aug  9 10:16 yarn.lock
anythingllm@7207f4cd9512:~$ ls -l /app/collector
total 48
-rw-rw-r-- 1 root        root        3170 Aug  9 10:16 README.md
drwxr-xr-x 2 anythingllm anythingllm 4096 Aug  9 13:14 __pycache__
-rw-rw-r-- 1 root        root         820 Aug  9 10:16 api.py
drwxrwxr-x 2 anythingllm anythingllm 4096 Aug  9 11:56 hotdir
-rw-rw-r-- 1 root        root        2513 Aug  9 10:16 main.py
drwxr-xr-x 2 root        root        4096 Aug  9 11:55 outputs
-rw-rw-r-- 1 root        root        1927 Aug  9 10:16 requirements.txt
drwxrwxr-x 3 root        root        4096 Aug  9 10:16 scripts
drwxr-xr-x 1 anythingllm anythingllm 4096 Aug  9 13:14 v-env
-rw-rw-r-- 1 root        root         588 Aug  9 10:16 watch.py
-rw-rw-r-- 1 root        root          70 Aug  9 10:16 wsgi.py
```

This patch changes ownership of files in collector/ and server/ to anythingllm.