### PR TITLE
Added support for host.docker.internal (ie: to use local chromadb ser…

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -21,7 +21,7 @@ OPEN_MODEL_PREF='gpt-3.5-turbo'
 ###########################################
 # Enable all below if you are using vector database: Chroma.
 # VECTOR_DB="chroma"
-# CHROMA_ENDPOINT='http://localhost:8000'
+# CHROMA_ENDPOINT='http://host.docker.internal:8000'
 
 # Enable all below if you are using vector database: Pinecone.
 VECTOR_DB="pinecone"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,3 +26,5 @@ services:
       - .env
     networks:
       - anything-llm
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Added CHROMA Endpoint example
`# CHROMA_ENDPOINT='http://host.docker.internal:8000'
`
Added in docker-compose
```
extra_hosts:
      - "host.docker.internal:host-gateway"
```

In relation to issue #127 