### PR TITLE
Implement dumpENV if in prod environment

### DIFF
--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -286,6 +286,7 @@ function systemEndpoints(app) {
       try {
         const body = reqBody(request);
         const { newValues, error } = updateENV(body);
+        if (process.env.NODE_ENV === "production") await dumpENV();
         response.status(200).json({ newValues, error });
       } catch (e) {
         console.log(e.message, e);


### PR DESCRIPTION
resolves #206

In production mode, if there are updates to the env it previously did not dump the .env file and if for any reason the system were to reboot all the env variables will be lost. This fix makes the backend dump the .env file on any environment variable change to ensure all .env variables are stored. 