### PR TITLE
Hide delete workspace button on non-admin users if setting is disabled

### DIFF
--- a/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
@@ -27,6 +27,7 @@ export default function DocumentSettings({ workspace }) {
       const hasAnyFiles = localFiles.items.some(
         (folder) => folder?.items?.length > 0
       );
+
       const canDelete = await System.getCanDeleteWorkspaces();
       setCanDelete(canDelete);
       setDirectories(localFiles);
@@ -95,13 +96,6 @@ export default function DocumentSettings({ workspace }) {
     return isFolder
       ? selectedFiles.some((doc) => doc.includes(filepath.split("/")[0]))
       : selectedFiles.some((doc) => doc.includes(filepath));
-  };
-
-  const isOriginalDoc = (filepath) => {
-    const isFolder = !filepath.includes("/");
-    return isFolder
-      ? originalDocuments.some((doc) => doc.includes(filepath.split("/")[0]))
-      : originalDocuments.some((doc) => doc.includes(filepath));
   };
 
   const toggleSelection = (filepath) => {
@@ -189,15 +183,14 @@ export default function DocumentSettings({ workspace }) {
           canDelete ? "justify-between" : "justify-end"
         } p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600`}
       >
-        {user && user?.role !== "admin" && canDelete && (
-          <button
-            onClick={deleteWorkspace}
-            type="button"
-            className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
-          >
-            Delete Workspace
-          </button>
-        )}
+        <button
+          hidden={!canDelete}
+          onClick={deleteWorkspace}
+          type="button"
+          className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
+        >
+          Delete Workspace
+        </button>
 
         <div className="flex items-center">
           <button

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
@@ -6,9 +6,11 @@ import { useParams } from "react-router-dom";
 import Directory from "./Directory";
 import ConfirmationModal from "./ConfirmationModal";
 import { AlertTriangle } from "react-feather";
+import useUser from "../../../../hooks/useUser";
 
 export default function DocumentSettings({ workspace }) {
   const { slug } = useParams();
+  const { user } = useUser();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
@@ -16,6 +18,7 @@ export default function DocumentSettings({ workspace }) {
   const [originalDocuments, setOriginalDocuments] = useState([]);
   const [selectedFiles, setSelectFiles] = useState([]);
   const [hasFiles, setHasFiles] = useState(true);
+  const [canDelete, setCanDelete] = useState(false);
 
   useEffect(() => {
     async function fetchKeys() {
@@ -24,6 +27,8 @@ export default function DocumentSettings({ workspace }) {
       const hasAnyFiles = localFiles.items.some(
         (folder) => folder?.items?.length > 0
       );
+      const canDelete = await System.getCanDeleteWorkspaces();
+      setCanDelete(canDelete);
       setDirectories(localFiles);
       setOriginalDocuments([...originalDocs]);
       setSelectFiles([...originalDocs]);
@@ -179,14 +184,21 @@ export default function DocumentSettings({ workspace }) {
           </div>
         </div>
       </div>
-      <div className="flex items-center justify-between p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600">
-        <button
-          onClick={deleteWorkspace}
-          type="button"
-          className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
-        >
-          Delete Workspace
-        </button>
+      <div
+        className={`flex items-center ${
+          canDelete ? "justify-between" : "justify-end"
+        } p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600`}
+      >
+        {user && user?.role !== "admin" && canDelete && (
+          <button
+            onClick={deleteWorkspace}
+            type="button"
+            className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
+          >
+            Delete Workspace
+          </button>
+        )}
+
         <div className="flex items-center">
           <button
             disabled={saving}

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
@@ -6,11 +6,9 @@ import { useParams } from "react-router-dom";
 import Directory from "./Directory";
 import ConfirmationModal from "./ConfirmationModal";
 import { AlertTriangle } from "react-feather";
-import useUser from "../../../../hooks/useUser";
 
 export default function DocumentSettings({ workspace }) {
   const { slug } = useParams();
-  const { user } = useUser();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
@@ -179,9 +177,8 @@ export default function DocumentSettings({ workspace }) {
         </div>
       </div>
       <div
-        className={`flex items-center ${
-          canDelete ? "justify-between" : "justify-end"
-        } p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600`}
+        className={`flex items-center ${canDelete ? "justify-between" : "justify-end"
+          } p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600`}
       >
         <button
           hidden={!canDelete}

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
@@ -18,7 +18,6 @@ export default function DocumentSettings({ workspace }) {
   const [originalDocuments, setOriginalDocuments] = useState([]);
   const [selectedFiles, setSelectFiles] = useState([]);
   const [hasFiles, setHasFiles] = useState(true);
-  const [canDelete, setCanDelete] = useState(false);
 
   useEffect(() => {
     async function fetchKeys() {
@@ -27,8 +26,6 @@ export default function DocumentSettings({ workspace }) {
       const hasAnyFiles = localFiles.items.some(
         (folder) => folder?.items?.length > 0
       );
-      const canDelete = await System.getCanDeleteWorkspaces();
-      setCanDelete(canDelete);
       setDirectories(localFiles);
       setOriginalDocuments([...originalDocs]);
       setSelectFiles([...originalDocs]);
@@ -184,21 +181,15 @@ export default function DocumentSettings({ workspace }) {
           </div>
         </div>
       </div>
-      <div
-        className={`flex items-center ${
-          canDelete ? "justify-between" : "justify-end"
-        } p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600`}
-      >
-        {user && user?.role !== "admin" && canDelete && (
-          <button
-            onClick={deleteWorkspace}
-            type="button"
-            className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
-          >
-            Delete Workspace
-          </button>
-        )}
-
+      <div className="flex items-center justify-between p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600">
+        <button
+          hidden={!!user && user?.role !== "admin"}
+          onClick={deleteWorkspace}
+          type="button"
+          className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
+        >
+          Delete Workspace
+        </button>
         <div className="flex items-center">
           <button
             disabled={saving}

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/index.jsx
@@ -18,6 +18,7 @@ export default function DocumentSettings({ workspace }) {
   const [originalDocuments, setOriginalDocuments] = useState([]);
   const [selectedFiles, setSelectFiles] = useState([]);
   const [hasFiles, setHasFiles] = useState(true);
+  const [canDelete, setCanDelete] = useState(false);
 
   useEffect(() => {
     async function fetchKeys() {
@@ -26,6 +27,8 @@ export default function DocumentSettings({ workspace }) {
       const hasAnyFiles = localFiles.items.some(
         (folder) => folder?.items?.length > 0
       );
+      const canDelete = await System.getCanDeleteWorkspaces();
+      setCanDelete(canDelete);
       setDirectories(localFiles);
       setOriginalDocuments([...originalDocs]);
       setSelectFiles([...originalDocs]);
@@ -181,15 +184,21 @@ export default function DocumentSettings({ workspace }) {
           </div>
         </div>
       </div>
-      <div className="flex items-center justify-between p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600">
-        <button
-          hidden={!!user && user?.role !== "admin"}
-          onClick={deleteWorkspace}
-          type="button"
-          className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
-        >
-          Delete Workspace
-        </button>
+      <div
+        className={`flex items-center ${
+          canDelete ? "justify-between" : "justify-end"
+        } p-4 md:p-6 space-x-2 border-t border-gray-200 rounded-b dark:border-gray-600`}
+      >
+        {user && user?.role !== "admin" && canDelete && (
+          <button
+            onClick={deleteWorkspace}
+            type="button"
+            className="border border-transparent text-gray-500 bg-white hover:bg-red-100 rounded-lg whitespace-nowrap text-sm font-medium px-5 py-2.5 hover:text-red-900 focus:z-10 dark:bg-transparent dark:text-gray-300 dark:hover:text-white dark:hover:bg-red-600"
+          >
+            Delete Workspace
+          </button>
+        )}
+
         <div className="flex items-center">
           <button
             disabled={saving}

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -192,15 +192,16 @@ const System = {
     return await fetch(`${API_BASE}/system/can-delete-workspaces`, {
       method: "GET",
       cache: "no-cache",
+      headers: baseHeaders(),
     })
       .then((res) => {
         if (!res.ok) throw new Error("Could not fetch can delete workspaces.");
         return res.json();
       })
-      .then((res) => res.canDelete)
+      .then((res) => res?.canDelete)
       .catch((e) => {
         console.error(e);
-        return null;
+        return false;
       });
   },
   getWelcomeMessages: async function () {

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -188,21 +188,6 @@ const System = {
         return { success: false, error: e.message };
       });
   },
-  getCanDeleteWorkspaces: async function () {
-    return await fetch(`${API_BASE}/system/can-delete-workspaces`, {
-      method: "GET",
-      cache: "no-cache",
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error("Could not fetch can delete workspaces.");
-        return res.json();
-      })
-      .then((res) => res.canDelete)
-      .catch((e) => {
-        console.error(e);
-        return null;
-      });
-  },
   getWelcomeMessages: async function () {
     return await fetch(`${API_BASE}/system/welcome-messages`, {
       method: "GET",

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -188,6 +188,21 @@ const System = {
         return { success: false, error: e.message };
       });
   },
+  getCanDeleteWorkspaces: async function () {
+    return await fetch(`${API_BASE}/system/can-delete-workspaces`, {
+      method: "GET",
+      cache: "no-cache",
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Could not fetch can delete workspaces.");
+        return res.json();
+      })
+      .then((res) => res.canDelete)
+      .catch((e) => {
+        console.error(e);
+        return null;
+      });
+  },
   getWelcomeMessages: async function () {
     return await fetch(`${API_BASE}/system/welcome-messages`, {
       method: "GET",

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -431,18 +431,6 @@ function systemEndpoints(app) {
     }
   );
 
-  app.get("/system/can-delete-workspaces", async function (request, response) {
-    try {
-      const canDelete = await SystemSettings.canDeleteWorkspaces();
-      response.status(200).json({ canDelete });
-    } catch (error) {
-      console.error("Error fetching can delete workspaces:", error);
-      response
-        .status(500)
-        .json({ success: false, message: "Internal server error" });
-    }
-  });
-
   app.get("/system/welcome-messages", async function (request, response) {
     try {
       const welcomeMessages = await WelcomeMessages.getMessages();

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -431,17 +431,33 @@ function systemEndpoints(app) {
     }
   );
 
-  app.get("/system/can-delete-workspaces", async function (request, response) {
-    try {
-      const canDelete = await SystemSettings.canDeleteWorkspaces();
-      response.status(200).json({ canDelete });
-    } catch (error) {
-      console.error("Error fetching can delete workspaces:", error);
-      response
-        .status(500)
-        .json({ success: false, message: "Internal server error" });
+  app.get(
+    "/system/can-delete-workspaces",
+    [validatedRequest],
+    async function (request, response) {
+      try {
+        if (!response.locals.multiUserMode) {
+          return response.status(200).json({ canDelete: true });
+        }
+
+        if (response.locals.user?.role === "admin") {
+          return response.status(200).json({ canDelete: true });
+        }
+
+        const canDelete = await SystemSettings.canDeleteWorkspaces();
+        response.status(200).json({ canDelete });
+      } catch (error) {
+        console.error("Error fetching can delete workspaces:", error);
+        response
+          .status(500)
+          .json({
+            success: false,
+            message: "Internal server error",
+            canDelete: false,
+          });
+      }
     }
-  });
+  );
 
   app.get("/system/welcome-messages", async function (request, response) {
     try {

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -431,6 +431,18 @@ function systemEndpoints(app) {
     }
   );
 
+  app.get("/system/can-delete-workspaces", async function (request, response) {
+    try {
+      const canDelete = await SystemSettings.canDeleteWorkspaces();
+      response.status(200).json({ canDelete });
+    } catch (error) {
+      console.error("Error fetching can delete workspaces:", error);
+      response
+        .status(500)
+        .json({ success: false, message: "Internal server error" });
+    }
+  });
+
   app.get("/system/welcome-messages", async function (request, response) {
     try {
       const welcomeMessages = await WelcomeMessages.getMessages();

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -180,6 +180,12 @@ const SystemSettings = {
     const result = await this.get(`label = 'logo_filename'`);
     return result ? result.value : null;
   },
+  canDeleteWorkspaces: async function () {
+    return (
+      (await this.get(`label = 'users_can_delete_workspaces'`))?.value ===
+      "true"
+    );
+  },
 };
 
 module.exports.SystemSettings = SystemSettings;

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -180,12 +180,6 @@ const SystemSettings = {
     const result = await this.get(`label = 'logo_filename'`);
     return result ? result.value : null;
   },
-  canDeleteWorkspaces: async function () {
-    return (
-      (await this.get(`label = 'users_can_delete_workspaces'`))?.value ===
-      "true"
-    );
-  },
 };
 
 module.exports.SystemSettings = SystemSettings;


### PR DESCRIPTION
resolves #226

• Added new endpoint to get the users_can_delete_workspaces system setting
• Hides Delete Workspace button on multiuser mode non-admin accounts if setting is disabled