### PR TITLE
changing the build behavior in the aws cloudformation template from […

### DIFF
--- a/cloud-deployments/aws/cloudformation/aws_build_from_source_no_credentials.json
+++ b/cloud-deployments/aws/cloudformation/aws_build_from_source_no_credentials.json
@@ -70,7 +70,7 @@
                 "\n",
                 "#cloud-config\n",
                 "cloud_final_modules:\n",
-                "- [scripts-user, always]\n",
+                "- [scripts-user, once-per-instance]\n",
                 "\n",
                 "\n",
                 "--//\n",

--- a/cloud-deployments/aws/cloudformation/cf_template.template
+++ b/cloud-deployments/aws/cloudformation/cf_template.template
@@ -70,7 +70,7 @@
                 "\n",
                 "#cloud-config\n",
                 "cloud_final_modules:\n",
-                "- [scripts-user, always]\n",
+                "- [scripts-user, once-per-instance]\n",
                 "\n",
                 "\n",
                 "--//\n",


### PR DESCRIPTION
…scripts-user, always] to [scripts-user, once-per-instance] so the userdata script is not run every time the server boots.