### PR TITLE
fix: adjust return type of addDocuments in case of no additions

### DIFF
--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -36,7 +36,7 @@ const Document = {
 
   addDocuments: async function (workspace, additions = []) {
     const VectorDb = getVectorDbClass();
-    if (additions.length === 0) return;
+    if (additions.length === 0) return { failed: [], embedded: [] };
     const embedded = [];
     const failedToEmbed = [];
 


### PR DESCRIPTION
Fixing a bug when the _/v1/workspace/{slug}/update-embeddings_ endpoint was called with no additions to the documents.
Solves issue #352 