### PR TITLE
Disable prisma logs on prod

### DIFF
--- a/server/utils/prisma/index.js
+++ b/server/utils/prisma/index.js
@@ -5,9 +5,9 @@ const { PrismaClient } = require("@prisma/client");
 // npx prisma migrate dev --name init -> ensures that db is in sync with schema
 // npx prisma migrate reset -> resets the db
 
-const isProd = process.env.NODE_ENV === 'production';
+const isProd = process.env.NODE_ENV === "production";
 const prisma = new PrismaClient({
-  log: isProd ? ['error'] : ['query', 'info', 'warn'],
+  log: isProd ? ["error"] : ["query", "info", "warn"],
 });
 
 module.exports = prisma;

--- a/server/utils/prisma/index.js
+++ b/server/utils/prisma/index.js
@@ -6,8 +6,11 @@ const { PrismaClient } = require("@prisma/client");
 // npx prisma migrate reset -> resets the db
 
 const isProd = process.env.NODE_ENV === "production";
+const logLevels = isProd
+  ? ["error", "info", "warn"]
+  : ["query", "info", "warn", "error"];
 const prisma = new PrismaClient({
-  log: isProd ? ["error"] : ["query", "info", "warn"],
+  log: logLevels,
 });
 
 module.exports = prisma;

--- a/server/utils/prisma/index.js
+++ b/server/utils/prisma/index.js
@@ -5,8 +5,9 @@ const { PrismaClient } = require("@prisma/client");
 // npx prisma migrate dev --name init -> ensures that db is in sync with schema
 // npx prisma migrate reset -> resets the db
 
+const isProd = process.env.NODE_ENV === 'production';
 const prisma = new PrismaClient({
-  log: ["query", "info", "warn"],
+  log: isProd ? ['error'] : ['query', 'info', 'warn'],
 });
 
 module.exports = prisma;


### PR DESCRIPTION
resolves #368 

In production, we should only enable the prisma error messages to prevent an output that is too verbose.