### PR TITLE
fix success is not defined error

### DIFF
--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -792,7 +792,7 @@ function systemEndpoints(app) {
       try {
         const { id } = request.params;
         await WorkspaceChats.delete({ id: Number(id) });
-        response.status(200).json({ success, error });
+        response.sendStatus(200).end();
       } catch (e) {
         console.error(e);
         response.sendStatus(500).end();


### PR DESCRIPTION
resolves #481 

Fixes error "success is not defined" and sends status 200 instead.