### PR TITLE
Prevent external service localhost question

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "Dockerized",
     "Ollama",
     "openai",
     "Qdrant",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,7 @@ RUN cd ./server && npx prisma migrate deploy --schema=./prisma/schema.prisma
 
 # Setup the environment
 ENV NODE_ENV=production
+ENV ANYTHING_LLM_RUNTIME=docker
 
 # Expose the server port
 EXPOSE 3001

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -322,8 +322,8 @@ function validDockerizedUrl(input = "") {
   if (process.env.ANYTHING_LLM_RUNTIME !== "docker") return null;
   try {
     const { hostname } = new URL(input);
-    if (["localhost", "127.0.0.1"].includes(hostname.toLowerCase()))
-      return "Localhost or 127.0.0.1 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal or a real machine ip to connect to your external service.";
+    if (["localhost", "127.0.0.1", "0.0.0.0"].includes(hostname.toLowerCase()))
+      return "Localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal or a real machine ip to connect to your external service.";
     return null;
   } catch {}
   return null;

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -56,7 +56,7 @@ const KEY_MAPPING = {
   // LMStudio Settings
   LMStudioBasePath: {
     envKey: "LMSTUDIO_BASE_PATH",
-    checks: [isNotEmpty, validLLMExternalBasePath],
+    checks: [isNotEmpty, validLLMExternalBasePath, validDockerizedUrl],
   },
   LMStudioTokenLimit: {
     envKey: "LMSTUDIO_MODEL_TOKEN_LIMIT",
@@ -66,7 +66,7 @@ const KEY_MAPPING = {
   // LocalAI Settings
   LocalAiBasePath: {
     envKey: "LOCAL_AI_BASE_PATH",
-    checks: [isNotEmpty, validLLMExternalBasePath],
+    checks: [isNotEmpty, validLLMExternalBasePath, validDockerizedUrl],
   },
   LocalAiModelPref: {
     envKey: "LOCAL_AI_MODEL_PREF",
@@ -83,7 +83,7 @@ const KEY_MAPPING = {
 
   OllamaLLMBasePath: {
     envKey: "OLLAMA_BASE_PATH",
-    checks: [isNotEmpty, validOllamaLLMBasePath],
+    checks: [isNotEmpty, validOllamaLLMBasePath, validDockerizedUrl],
   },
   OllamaLLMModelPref: {
     envKey: "OLLAMA_MODEL_PREF",
@@ -106,7 +106,7 @@ const KEY_MAPPING = {
   },
   EmbeddingBasePath: {
     envKey: "EMBEDDING_BASE_PATH",
-    checks: [isNotEmpty, validLLMExternalBasePath],
+    checks: [isNotEmpty, validLLMExternalBasePath, validDockerizedUrl],
   },
   EmbeddingModelPref: {
     envKey: "EMBEDDING_MODEL_PREF",
@@ -126,7 +126,7 @@ const KEY_MAPPING = {
   // Chroma Options
   ChromaEndpoint: {
     envKey: "CHROMA_ENDPOINT",
-    checks: [isValidURL, validChromaURL],
+    checks: [isValidURL, validChromaURL, validDockerizedUrl],
   },
   ChromaApiHeader: {
     envKey: "CHROMA_API_HEADER",
@@ -140,7 +140,7 @@ const KEY_MAPPING = {
   // Weaviate Options
   WeaviateEndpoint: {
     envKey: "WEAVIATE_ENDPOINT",
-    checks: [isValidURL],
+    checks: [isValidURL, validDockerizedUrl],
   },
   WeaviateApiKey: {
     envKey: "WEAVIATE_API_KEY",
@@ -150,7 +150,7 @@ const KEY_MAPPING = {
   // QDrant Options
   QdrantEndpoint: {
     envKey: "QDRANT_ENDPOINT",
-    checks: [isValidURL],
+    checks: [isValidURL, validDockerizedUrl],
   },
   QdrantApiKey: {
     envKey: "QDRANT_API_KEY",
@@ -316,6 +316,17 @@ function isDownloadedModel(input = "") {
     .readdirSync(storageDir)
     .filter((file) => file.includes(".gguf"));
   return files.includes(input);
+}
+
+function validDockerizedUrl(input = "") {
+  if (process.env.ANYTHING_LLM_RUNTIME !== "docker") return null;
+  try {
+    const { hostname } = new URL(input);
+    if (["localhost", "127.0.0.1"].includes(hostname.toLowerCase()))
+      return "Localhost or 127.0.0.1 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal or a real machine ip to connect to your external service.";
+    return null;
+  } catch {}
+  return null;
 }
 
 // This will force update .env variables which for any which reason were not able to be parsed or

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -323,7 +323,7 @@ function validDockerizedUrl(input = "") {
   try {
     const { hostname } = new URL(input);
     if (["localhost", "127.0.0.1", "0.0.0.0"].includes(hostname.toLowerCase()))
-      return "Localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal or a real machine ip to connect to your external service.";
+      return "Localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal, a real machine ip, or domain to connect to your service.";
     return null;
   } catch {}
   return null;


### PR DESCRIPTION
Every time a potential user of AnythingLLM uses AnythingLLM in a dockerized context there is confusion on why some external service running on localhost/loopback [LocalAi, LMStudio, Ollama, Chroma, etc] cannot connect, resulting in failed messages or other problems during use.

This is because localhost or loopback IPs resolve within the AnythingLLM container while the service they wish to connect to uses the host machine network. The full fix is to simply replace `localhost` or `127.0.0.1` with `host.docker.internal` and the container can then reach the host machine network.

This is already outlined in the [Docker README](https://github.com/Mintplex-Labs/anything-llm/blob/master/docker/HOW_TO_USE_DOCKER.md#recommend-way-to-run-dockerized-anythingllm) as an important tag, but considering some may be pulling from remote and never consulting the README this detail gets missed nearly all the time.

This PR blocks localhost or 127.0.0.1 from being used for external services while running inside of Docker.

Hopefully, we never have to answer this question again 😵 


> AnythingLLM runs multiple services inside the container to support various functions so to prevent port conflicts we use a network bridge and not the host network.