### PR TITLE
Issue #204 Added a check to ensure that 'chunk.payload' exists and contains the 'id' property

### DIFF
--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -152,9 +152,10 @@ const QDrant = {
 
           // Before sending to Qdrant and saving the records to our db
           // we need to assign the id of each chunk that is stored in the cached file.
+          // The id property must be defined or else it will be unable to be managed by ALLM.
           chunk.forEach((chunk) => {
             const id = uuidv4();
-            if (chunk.payload && chunk.payload.id) {
+            if (chunk?.payload?.hasOwnProperty("id")) {
               const { id: _id, ...payload } = chunk.payload;
               documentVectors.push({ docId, vectorId: id });
               submission.ids.push(id);
@@ -162,7 +163,7 @@ const QDrant = {
               submission.payloads.push(payload);
             } else {
               console.error(
-                "The 'id' property is not defined in chunk.payload"
+                "The 'id' property is not defined in chunk.payload - it will be omitted from being inserted in QDrant collection."
               );
             }
           });

--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -154,15 +154,16 @@ const QDrant = {
           // we need to assign the id of each chunk that is stored in the cached file.
           chunk.forEach((chunk) => {
             const id = uuidv4();
-            if(chunk.payload && chunk.payload.id){
+            if (chunk.payload && chunk.payload.id) {
               const { id: _id, ...payload } = chunk.payload;
               documentVectors.push({ docId, vectorId: id });
               submission.ids.push(id);
               submission.vectors.push(chunk.vector);
               submission.payloads.push(payload);
-            }
-            else{
-              console.error("The 'id' property is not defined in chunk.payload");
+            } else {
+              console.error(
+                "The 'id' property is not defined in chunk.payload"
+              );
             }
           });
 

--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -154,11 +154,16 @@ const QDrant = {
           // we need to assign the id of each chunk that is stored in the cached file.
           chunk.forEach((chunk) => {
             const id = uuidv4();
-            const { id: _id, ...payload } = chunk.payload;
-            documentVectors.push({ docId, vectorId: id });
-            submission.ids.push(id);
-            submission.vectors.push(chunk.vector);
-            submission.payloads.push(payload);
+            if(chunk.payload && chunk.payload.id){
+              const { id: _id, ...payload } = chunk.payload;
+              documentVectors.push({ docId, vectorId: id });
+              submission.ids.push(id);
+              submission.vectors.push(chunk.vector);
+              submission.payloads.push(payload);
+            }
+            else{
+              console.error("The 'id' property is not defined in chunk.payload");
+            }
           });
 
           const additionResult = await client.upsert(namespace, {


### PR DESCRIPTION
I added a check (if (chunk.payload && chunk.payload.id)) to ensure that 'chunk.payload' exists and contains the 'id' property before attempting to destructure it.
If the check fails, an error message is logged, and you can handle the situation accordingly.