### PR TITLE
Remove explicit Prisma step instruction in the development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,14 @@ Mintplex Labs & the community maintain a number of deployment methods, scripts, 
 
 
 ## How to setup for development
-- `yarn setup` from the project root directory.
-  - This will fill in the required `.env` files you'll need in each of the application sections. Go fill those out before proceeding or else things won't work right.
-- `yarn prisma:setup` To build the Prisma client and migrate the database.
+- `yarn setup` To fill in the required `.env` files you'll need in each of the application sections (from root of repo).
+  - Go fill those out before proceeding. Ensure `server/.env.development` is filled or else things won't work right.
+- `yarn dev:server` To boot the server locally (from root of repo).
+- `yarn dev:frontend` To boot the frontend locally (from root of repo).
+- `yarn dev:collector` To then run the document collector (from root of repo).
 
-To boot the server locally (from root of repo):
-- ensure `server/.env.development` is set and filled out.
-`yarn dev:server`
- 
-To boot the frontend locally (from root of repo):
-`yarn dev:frontend`
 
-To then run the document collector (from root of repo)
-`yarn dev:collector`
+
 
 [Learn about documents](./server/storage/documents/DOCUMENTS.md)
 


### PR DESCRIPTION
I did the setup for development on a Macbook today and noticed that the `yarn setup` also did the Prisma setup. So, in this PR I am removing the explict instruction in the documentation to run Prisma setup and migrate the database.

```bash
$ yarn setup
$ cd server && npx prisma migrate dev --name init
Prisma schema loaded from prisma/schema.prisma
Datasource "db": SQLite database "anythingllm.db" at "file:../storage/anythingllm.db"

SQLite database anythingllm.db created at file:../storage/anythingllm.db

Applying migration `20230921191814_init`
Applying migration `20231101001441_init`
Applying migration `20231101195421_init`
Applying migration `20231129012019_add`

The following migration(s) have been applied:

migrations/
  └─ 20230921191814_init/
    └─ migration.sql
  └─ 20231101001441_init/
    └─ migration.sql
  └─ 20231101195421_init/
    └─ migration.sql
  └─ 20231129012019_add/
    └─ migration.sql

Your database is now in sync with your schema.

✔ Generated Prisma Client (v5.3.0) to ./node_modules/@prisma/client in 64ms


Running seed command `node prisma/seed.js` ...

🌱  The seed command has been executed.


┌─────────────────────────────────────────────────────────┐
│  Update available 5.3.1 -> 5.7.1                        │
│  Run the following to update                            │
│    yarn add --dev prisma@latest                         │
│    yarn add @prisma/client@latest                       │
└─────────────────────────────────────────────────────────┘
$ cd server && npx prisma db seed
Running seed command `node prisma/seed.js` ...

🌱  The seed command has been executed.
```