### PR TITLE
Build & Publish AnythingLLM for ARM and x86

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -2,7 +2,7 @@ name: Publish Docker image and Github Registry
 
 on:
   push:
-    branches: ['master', '539-amd64-support']
+    branches: ['master']
     paths-ignore:
       - '*.md'
       - 'cloud-deployments/*'
@@ -53,7 +53,6 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          # platforms: linux/amd64,linux/arm64
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -1,8 +1,8 @@
-name: Publish Docker image and Github Registry
+name: Publish AnythingLLM Docker image
 
 on:
   push:
-    branches: ['master', '539-amd64-support']
+    branches: ['master']
     paths-ignore:
       - '*.md'
       - 'cloud-deployments/*'
@@ -10,8 +10,48 @@ on:
       - '.vscode/*'
 
 jobs:
-  push_to_registries:
-    name: Push multi-platform Docker image to multiple registries
+  push_x86_to_registries:
+    name: Push Docker x86 image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            mintplexlabs/anythingllm
+            ghcr.io/${{ github.repository }}
+      
+      - name: Build and push x86 Docker image
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  push_arm64_to_registries:
+    name: Push Docker arm64 image to multiple registries
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -46,18 +86,8 @@ jobs:
           images: |
             mintplexlabs/anythingllm
             ghcr.io/${{ github.repository }}
-      
-      # - name: Build and push x86 Docker and GHCR images
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: .
-      #     file: ./docker/Dockerfile
-      #     push: true
-      #     platforms: linux/amd64
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Build and push arm86 Docker and GHCR images
+      - name: Build and push arm64 Docker and GHCR images
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -2,7 +2,7 @@ name: Publish Docker image and Github Registry
 
 on:
   push:
-    branches: ['master']
+    branches: ['master', '539-amd64-support']
     paths-ignore:
       - '*.md'
       - 'cloud-deployments/*'
@@ -11,7 +11,7 @@ on:
 
 jobs:
   push_to_registries:
-    name: Push Docker image to multiple registries
+    name: Push multi-platform Docker image to multiple registries
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -19,7 +19,13 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -41,11 +47,12 @@ jobs:
             mintplexlabs/anythingllm
             ghcr.io/${{ github.repository }}
       
-      - name: Build and push Docker images
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      - name: Build and push multi-platform Docker and GHCR images
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -2,7 +2,7 @@ name: Publish Docker image and Github Registry
 
 on:
   push:
-    branches: ['master']
+    branches: ['master', '539-amd64-support']
     paths-ignore:
       - '*.md'
       - 'cloud-deployments/*'
@@ -47,12 +47,22 @@ jobs:
             mintplexlabs/anythingllm
             ghcr.io/${{ github.repository }}
       
-      - name: Build and push multi-platform Docker and GHCR images
+      - name: Build and push x86 Docker and GHCR images
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push arm86 Docker and GHCR images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile.arm64
+          push: true
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -66,5 +66,5 @@ jobs:
           platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-        env:
-          BUILDARCH: arm64
+          build-args: |
+            BUILDARCH=arm64

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -53,6 +53,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -47,15 +47,15 @@ jobs:
             mintplexlabs/anythingllm
             ghcr.io/${{ github.repository }}
       
-      - name: Build and push x86 Docker and GHCR images
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      # - name: Build and push x86 Docker and GHCR images
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     file: ./docker/Dockerfile
+      #     push: true
+      #     platforms: linux/amd64
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push arm86 Docker and GHCR images
         uses: docker/build-push-action@v5
@@ -66,3 +66,5 @@ jobs:
           platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        env:
+          BUILDARCH: arm64

--- a/collector/package.json
+++ b/collector/package.json
@@ -34,7 +34,7 @@
     "multer": "^1.4.5-lts.1",
     "officeparser": "^4.0.5",
     "pdf-parse": "^1.1.1",
-    "puppeteer": "^21.6.1",
+    "puppeteer": "~21.5.2",
     "slugify": "^1.6.6",
     "url-pattern": "^1.0.3",
     "uuid": "^9.0.0",

--- a/collector/yarn.lock
+++ b/collector/yarn.lock
@@ -134,10 +134,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@puppeteer/browsers@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-1.9.0.tgz#dfd0aad0bdc039572f1b57648f189525d627b7ff"
-  integrity sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==
+"@puppeteer/browsers@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-1.8.0.tgz#fb6ee61de15e7f0e67737aea9f9bab1512dbd7d8"
+  integrity sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==
   dependencies:
     debug "4.3.4"
     extract-zip "2.0.1"
@@ -608,10 +608,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromium-bidi@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.5.1.tgz#390c1af350c4887824a33d82190de1cc5c5680fc"
-  integrity sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==
+chromium-bidi@0.4.33:
+  version "0.4.33"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-0.4.33.tgz#9a9aba5a5b07118c8e7d6405f8ee79f47418dd1d"
+  integrity sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==
   dependencies:
     mitt "3.0.1"
     urlpattern-polyfill "9.0.0"
@@ -2584,26 +2584,26 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-puppeteer-core@21.6.1:
-  version "21.6.1"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-21.6.1.tgz#10eccb4dc3167c8c26bc21122fabb45a9fda9ca7"
-  integrity sha512-0chaaK/RL9S1U3bsyR4fUeUfoj51vNnjWvXgG6DcsyMjwYNpLcAThv187i1rZCo7QhJP0wZN8plQkjNyrq2h+A==
+puppeteer-core@21.5.2:
+  version "21.5.2"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-21.5.2.tgz#6d3de4efb2ae65f1ee072043787b75594e88035f"
+  integrity sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==
   dependencies:
-    "@puppeteer/browsers" "1.9.0"
-    chromium-bidi "0.5.1"
+    "@puppeteer/browsers" "1.8.0"
+    chromium-bidi "0.4.33"
     cross-fetch "4.0.0"
     debug "4.3.4"
     devtools-protocol "0.0.1203626"
-    ws "8.15.1"
+    ws "8.14.2"
 
-puppeteer@^21.6.1:
-  version "21.6.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-21.6.1.tgz#2ec0878906ff90b3a424f19e5eb006592abe25b6"
-  integrity sha512-O+pbc61oj8ln6m8EJKncrsQFmytgRyFYERtk190PeLbJn5JKpmmynn2p1PiFrlhCitAQXLJ0MOy7F0TeyCRqBg==
+puppeteer@~21.5.2:
+  version "21.5.2"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-21.5.2.tgz#0a4a72175c0fd0944d6486f4734807e1671d527b"
+  integrity sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==
   dependencies:
-    "@puppeteer/browsers" "1.9.0"
+    "@puppeteer/browsers" "1.8.0"
     cosmiconfig "8.3.6"
-    puppeteer-core "21.6.1"
+    puppeteer-core "21.5.2"
 
 qs@6.11.0:
   version "6.11.0"
@@ -3259,10 +3259,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.15.1:
-  version "8.15.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.15.1.tgz#271ba33a45ca0cc477940f7f200cd7fba7ee1997"
-  integrity sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==
+ws@8.14.2:
+  version "8.14.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
+  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
 xmlbuilder@^10.0.0:
   version "10.1.1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,9 +50,7 @@ RUN cd ./frontend/ && yarn install && yarn cache clean
 # Install server dependencies
 FROM base as server-deps
 COPY ./server/package.json ./server/yarn.lock ./server/
-RUN cd ./server/ && yarn install --production && yarn cache clean && \
-    rm /app/server/node_modules/vectordb/x86_64-apple-darwin.node && \
-    rm /app/server/node_modules/vectordb/aarch64-apple-darwin.node
+RUN cd ./server/ && yarn install --production && yarn cache clean
 
 # Compile Llama.cpp bindings for node-llama-cpp for this operating system.
 USER root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,12 +45,12 @@ WORKDIR /app
 FROM base as frontend-deps
 
 COPY ./frontend/package.json ./frontend/yarn.lock ./frontend/
-RUN cd ./frontend/ && yarn install && yarn cache clean
+RUN cd ./frontend/ && yarn install --network-timeout 100000 && yarn cache clean
 
 # Install server dependencies
 FROM base as server-deps
 COPY ./server/package.json ./server/yarn.lock ./server/
-RUN cd ./server/ && yarn install --production && yarn cache clean
+RUN cd ./server/ && yarn install --production --network-timeout 100000 && yarn cache clean
 
 # Compile Llama.cpp bindings for node-llama-cpp for this operating system.
 USER root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,9 @@ FROM ubuntu:jammy-20230522 AS base
 # Build arguments
 ARG ARG_UID=1000
 ARG ARG_GID=1000
+ARG BUILDARCH
+
+RUN echo "Building AnythingLLM image for $BUILDARCH"
 
 # Install system dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
@@ -22,6 +25,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     curl -LO https://github.com/yarnpkg/yarn/releases/download/v1.22.19/yarn_1.22.19_all.deb \
         && dpkg -i yarn_1.22.19_all.deb \
         && rm yarn_1.22.19_all.deb
+
+RUN if [ "$BUILDARCH" = "arm64" ] ; then \
+    echo "Need to patch Chromium support for ARM - installing dep!" && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq chromium-browser; \
+fi
 
 # Create a group and user with specific UID and GID
 RUN groupadd -g $ARG_GID anythingllm && \
@@ -53,9 +62,9 @@ COPY ./server/package.json ./server/yarn.lock ./server/
 RUN cd ./server/ && yarn install --production --network-timeout 100000 && yarn cache clean
 
 # Compile Llama.cpp bindings for node-llama-cpp for this operating system.
-USER root
-RUN cd ./server && npx --no node-llama-cpp download
-USER anythingllm
+# USER root
+# RUN cd ./server && npx --no node-llama-cpp download
+# USER anythingllm
 
 # Build the frontend
 FROM frontend-deps as build-stage
@@ -73,7 +82,17 @@ COPY --from=build-stage /app/frontend/dist ./server/public
 COPY --chown=anythingllm:anythingllm ./collector/ ./collector/
 
 # Install collector dependencies
-RUN cd /app/collector && yarn install --production && yarn cache clean
+RUN if [ "$BUILDARCH" = "amd64" ] ; then \
+        export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true && \
+        export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium && \
+        cd /app/collector && \
+        yarn install --production && \
+        yarn cache clean; \
+    else \
+        cd /app/collector && yarn install --production && yarn cache clean; \
+fi
+
+# RUN cd /app/collector && yarn install --production && yarn cache clean
 
 # Migrate and Run Prisma against known schema
 RUN cd ./server && npx prisma generate --schema=./prisma/schema.prisma

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,8 @@ FROM ubuntu:jammy-20230522 AS base
 ARG ARG_UID=1000
 ARG ARG_GID=1000
 
+RUN echo "Building AnythingLLM image for non-ARM architecture"
+
 # Install system dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -6,7 +6,6 @@ ARG ARG_UID=1000
 ARG ARG_GID=1000
 ARG BUILDARCH
 
-RUN echo $BUILDARCH
 RUN if [ "$BUILDARCH" != "arm64" ] ; then echo "[ARCH INCOMPATIBLE] You can only run this Dockerfile on arm86 architecture - Aborting."; exit 1; fi
 RUN echo "Building AnythingLLM image for $BUILDARCH architecture"
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -52,7 +52,7 @@ RUN if [ "$BUILDARCH" = "arm64" ] ; then \
     echo "Need to patch Puppeteer x Chromium support for ARM86 - installing dep!" && \
     curl https://playwright.azureedge.net/builds/chromium/1088/chromium-linux-arm64.zip -o chrome-linux.zip && \
     unzip chrome-linux.zip && \
-    rm -rf chrome-linux.zip;
+    rm -rf chrome-linux.zip; \
 fi
 
 # Install frontend dependencies

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -6,7 +6,8 @@ ARG ARG_UID=1000
 ARG ARG_GID=1000
 ARG BUILDARCH
 
-RUN echo "Building AnythingLLM image for $BUILDARCH"
+RUN if [ "$BUILDARCH" != "arm64" ] ; then echo "[ARCH INCOMPATIBLE] You can only run this Dockerfile on arm86 architecture - Aborting."; exit 1; fi
+RUN echo "Building AnythingLLM image for $BUILDARCH architecture"
 
 # Install system dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
@@ -44,12 +45,14 @@ USER anythingllm
 
 WORKDIR /app
 
+# Puppeteer does not ship with an ARM86 compatible build for Chromium
+# so web-scraping would be broken in arm docker containers unless we patch it
+# by manually installing a compatible chromedriver.
 RUN if [ "$BUILDARCH" = "arm64" ] ; then \
-    echo "Need to patch Chromium support for ARM - installing dep!" && \
+    echo "Need to patch Puppeteer x Chromium support for ARM86 - installing dep!" && \
     curl https://playwright.azureedge.net/builds/chromium/1088/chromium-linux-arm64.zip -o chrome-linux.zip && \
     unzip chrome-linux.zip && \
-    rm -rf chrome-linux.zip && \
-    chmod -R 777 chrome-linux; \
+    rm -rf chrome-linux.zip;
 fi
 
 # Install frontend dependencies
@@ -64,9 +67,9 @@ COPY ./server/package.json ./server/yarn.lock ./server/
 RUN cd ./server/ && yarn install --production --network-timeout 100000 && yarn cache clean
 
 # Compile Llama.cpp bindings for node-llama-cpp for this operating system.
-# USER root
-# RUN cd ./server && npx --no node-llama-cpp download
-# USER anythingllm
+USER root
+RUN cd ./server && npx --no node-llama-cpp download
+USER anythingllm
 
 # Build the frontend
 FROM frontend-deps as build-stage

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -4,11 +4,14 @@ FROM ubuntu:jammy-20230522 AS base
 # Build arguments
 ARG ARG_UID=1000
 ARG ARG_GID=1000
+ARG BUILDARCH
+
+RUN echo "Building AnythingLLM image for $BUILDARCH"
 
 # Install system dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-        curl gnupg libgfortran5 libgbm1 tzdata netcat \
+        unzip curl gnupg libgfortran5 libgbm1 tzdata netcat \
         libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 \
         libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libx11-6 libx11-xcb1 libxcb1 \
         libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
@@ -41,21 +44,29 @@ USER anythingllm
 
 WORKDIR /app
 
+RUN if [ "$BUILDARCH" = "arm64" ] ; then \
+    echo "Need to patch Chromium support for ARM - installing dep!" && \
+    curl https://playwright.azureedge.net/builds/chromium/1088/chromium-linux-arm64.zip -o chrome-linux.zip && \
+    unzip chrome-linux.zip && \
+    rm -rf chrome-linux.zip && \
+    chmod -R 777 chrome-linux; \
+fi
+
 # Install frontend dependencies
 FROM base as frontend-deps
 
 COPY ./frontend/package.json ./frontend/yarn.lock ./frontend/
-RUN cd ./frontend/ && yarn install && yarn cache clean
+RUN cd ./frontend/ && yarn install --network-timeout 100000 && yarn cache clean
 
 # Install server dependencies
 FROM base as server-deps
 COPY ./server/package.json ./server/yarn.lock ./server/
-RUN cd ./server/ && yarn install --production && yarn cache clean
+RUN cd ./server/ && yarn install --production --network-timeout 100000 && yarn cache clean
 
 # Compile Llama.cpp bindings for node-llama-cpp for this operating system.
-USER root
-RUN cd ./server && npx --no node-llama-cpp download
-USER anythingllm
+# USER root
+# RUN cd ./server && npx --no node-llama-cpp download
+# USER anythingllm
 
 # Build the frontend
 FROM frontend-deps as build-stage
@@ -72,7 +83,10 @@ COPY --from=build-stage /app/frontend/dist ./server/public
 # Copy the collector
 COPY --chown=anythingllm:anythingllm ./collector/ ./collector/
 
-# Install collector dependencies
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV CHROME_PATH=/app/chrome-linux/chrome
+ENV PUPPETEER_EXECUTABLE_PATH=/app/chrome-linux/chrome
+
 RUN cd /app/collector && yarn install --production && yarn cache clean
 
 # Migrate and Run Prisma against known schema

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -6,6 +6,7 @@ ARG ARG_UID=1000
 ARG ARG_GID=1000
 ARG BUILDARCH
 
+RUN echo $BUILDARCH
 RUN if [ "$BUILDARCH" != "arm64" ] ; then echo "[ARCH INCOMPATIBLE] You can only run this Dockerfile on arm86 architecture - Aborting."; exit 1; fi
 RUN echo "Building AnythingLLM image for $BUILDARCH architecture"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,6 @@ services:
   anything-llm:
     container_name: anything-llm
     image: anything-llm:latest
-    platform: linux/amd64,linux/arm64
     build:
       context: ../.
       dockerfile: ./docker/Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   anything-llm:
     container_name: anything-llm
     image: anything-llm:latest
-    platform: linux/amd64
+    platform: linux/amd64,linux/arm64
     build:
       context: ../.
       dockerfile: ./docker/Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ networks:
 services:
   anything-llm:
     container_name: anything-llm
+    platform: linux/amd64 # We will assume all docker compose builds are using x86
     image: anything-llm:latest
     build:
       context: ../.

--- a/server/package.json
+++ b/server/package.json
@@ -59,7 +59,7 @@
     "swagger-ui-express": "^5.0.0",
     "uuid": "^9.0.0",
     "uuid-apikey": "^1.5.3",
-    "vectordb": "0.1.12",
+    "vectordb": "0.1.19",
     "weaviate-ts-client": "^1.4.0"
   },
   "devDependencies": {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -201,6 +201,31 @@
   resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
   integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
 
+"@lancedb/vectordb-darwin-arm64@0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@lancedb/vectordb-darwin-arm64/-/vectordb-darwin-arm64-0.1.19.tgz#f7e270623008446b2cdcedcc1badfba2d35ab8e8"
+  integrity sha512-efQhJkBKvMNhjFq3Sw3/qHo9D9gb9UqiIr98n3STsbNxBQjMnWemXn91Ckl40siRG1O8qXcINW7Qs/EGmus+kg==
+
+"@lancedb/vectordb-darwin-x64@0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@lancedb/vectordb-darwin-x64/-/vectordb-darwin-x64-0.1.19.tgz#0d1c271acfb832a5282ad24c2e77cb9a1cc0e9a3"
+  integrity sha512-r6OZNVyemAssABz2w7CRhe7dyREwBEfTytn+ux1zzTnzsgMgDovCQ0rQ3WZcxWvcy7SFCxiemA9IP1b/lsb4tQ==
+
+"@lancedb/vectordb-linux-arm64-gnu@0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@lancedb/vectordb-linux-arm64-gnu/-/vectordb-linux-arm64-gnu-0.1.19.tgz#47f36e1069182bce9b4143b5fe89963a335babb9"
+  integrity sha512-mL/hRmZp6Kw7hmGJBdOZfp/tTYiCdlOcs8DA/+nr2eiXERv0gIhyiKvr2P5DwbBmut3qXEkDalMHTo95BSdL2A==
+
+"@lancedb/vectordb-linux-x64-gnu@0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@lancedb/vectordb-linux-x64-gnu/-/vectordb-linux-x64-gnu-0.1.19.tgz#8612ce0969fd98ef2f166837d517bcfc32a45937"
+  integrity sha512-AG0FHksbbr+cHVKPi4B8cmBtqb6T9E0uaK4kyZkXrX52/xtv9RYVZcykaB/tSSm0XNFPWWRnx9R8UqNZV/hxMA==
+
+"@lancedb/vectordb-win32-x64-msvc@0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@lancedb/vectordb-win32-x64-msvc/-/vectordb-win32-x64-msvc-0.1.19.tgz#6e859949ac2e83546f275b65727eee31451884e9"
+  integrity sha512-PDWZ2hvLVXH4Z4WIO1rsWY8ev3NpNm7aXlaey32P+l1Iz9Hia9+F2GBpp2UiEQKfvbk82ucAvBLRmpSsHY8Tlw==
+
 "@langchain/core@~0.0.8":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.0.9.tgz#3b4e74693eddcfa5f6e649857b561d3a9b60d1d4"
@@ -230,6 +255,11 @@
     rimraf "^3.0.2"
     semver "^7.3.5"
     tar "^6.1.11"
+
+"@neon-rs/load@^0.0.74":
+  version "0.0.74"
+  resolved "https://registry.yarnpkg.com/@neon-rs/load/-/load-0.0.74.tgz#0f887144b0e3ea79e099b89bd83345004adedeb2"
+  integrity sha512-/cPZD907UNz55yrc/ud4wDgQKtU1TvkD9jeqZWG6J4IMmZkp6zgjkQcKA8UvpkZlcpPHvc8J17sGzLFbP/LUYg==
 
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
@@ -909,6 +939,15 @@ axios@^1.3.2:
   integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
     follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.4.0:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
+  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
+  dependencies:
+    follow-redirects "^1.15.4"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -1760,6 +1799,11 @@ follow-redirects@^1.15.0:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
   integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+follow-redirects@^1.15.4:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 form-data-encoder@1.7.2:
   version "1.7.2"
@@ -3944,13 +3988,21 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vectordb@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/vectordb/-/vectordb-0.1.12.tgz#b23b9938467415060e53d614e2a84458244eeb17"
-  integrity sha512-C7/4/n3kBiR2Z5Cgid08z9hUNfVpQaA5WKVyT4msdwmLoSZOltFeikCdx7OM5a6ekd9BwnPbzP8RhNTW8hBfNA==
+vectordb@0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/vectordb/-/vectordb-0.1.19.tgz#a36ea583cbc269c871edefa6a2abc5467e902d83"
+  integrity sha512-AS73SjteiLFM5qJQ9YwwYORd2vIVDseEq/vZmwZVbCwJAyD7M52uCiZir0cScRRAisovQZFoyvAKwZs2T4gOmw==
   dependencies:
     "@apache-arrow/ts" "^12.0.0"
+    "@neon-rs/load" "^0.0.74"
     apache-arrow "^12.0.0"
+    axios "^1.4.0"
+  optionalDependencies:
+    "@lancedb/vectordb-darwin-arm64" "0.1.19"
+    "@lancedb/vectordb-darwin-x64" "0.1.19"
+    "@lancedb/vectordb-linux-arm64-gnu" "0.1.19"
+    "@lancedb/vectordb-linux-x64-gnu" "0.1.19"
+    "@lancedb/vectordb-win32-x64-msvc" "0.1.19"
 
 weaviate-ts-client@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Bump @lancedb/vectordb to 0.1.19 for AMD compatibilty 
Patch puppeteer to support arm86 chromium installation
Break out x86 build from arm86 build for docker images

resolves #539

- users are unable to download models due to the emulator overhead and it times out when trying to install.