### PR TITLE
[API] patch swagger host to be relative

### DIFF
--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "http:///api/"
+      "url": "/api"
     }
   ],
   "paths": {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #561 

### What is in this change?
Update API to use relative hostname

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
