### PR TITLE
Change pwd check to O(1) check to prevent timing attacks - single user mode

### DIFF
--- a/frontend/src/components/Modals/Password/index.jsx
+++ b/frontend/src/components/Modals/Password/index.jsx
@@ -37,7 +37,7 @@ export default function PasswordModal({ mode = "single" }) {
 export function usePasswordModal() {
   const [auth, setAuth] = useState({
     loading: true,
-    required: false,
+    requiresAuth: false,
     mode: "single",
   });
 

--- a/frontend/src/pages/Login/index.jsx
+++ b/frontend/src/pages/Login/index.jsx
@@ -1,9 +1,13 @@
 import React from "react";
 import PasswordModal, { usePasswordModal } from "@/components/Modals/Password";
 import { FullScreenLoader } from "@/components/Preloader";
+import { Navigate } from "react-router-dom";
+import paths from "@/utils/paths";
 
 export default function Login() {
-  const { loading, mode } = usePasswordModal();
+  const { loading, requiresAuth, mode } = usePasswordModal();
   if (loading) return <FullScreenLoader />;
+  if (requiresAuth === false) return <Navigate to={paths.home()} />;
+
   return <PasswordModal mode={mode} />;
 }

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -107,6 +107,8 @@ function systemEndpoints(app) {
 
   app.post("/request-token", async (request, response) => {
     try {
+      const bcrypt = require("bcrypt");
+
       if (await SystemSettings.isMultiUserMode()) {
         const { username, password } = reqBody(request);
         const existingUser = await User.get({ username });
@@ -121,7 +123,6 @@ function systemEndpoints(app) {
           return;
         }
 
-        const bcrypt = require("bcrypt");
         if (!bcrypt.compareSync(password, existingUser.password)) {
           response.status(200).json({
             user: null,
@@ -159,7 +160,12 @@ function systemEndpoints(app) {
         return;
       } else {
         const { password } = reqBody(request);
-        if (password !== process.env.AUTH_TOKEN) {
+        if (
+          !bcrypt.compareSync(
+            password,
+            bcrypt.hashSync(process.env.AUTH_TOKEN, 10)
+          )
+        ) {
           response.status(401).json({
             valid: false,
             token: null,

--- a/server/utils/middleware/validatedRequest.js
+++ b/server/utils/middleware/validatedRequest.js
@@ -36,8 +36,9 @@ async function validatedRequest(request, response, next) {
     return;
   }
 
+  const bcrypt = require("bcrypt");
   const { p } = decodeJWT(token);
-  if (p !== process.env.AUTH_TOKEN) {
+  if (!bcrypt.compareSync(p, bcrypt.hashSync(process.env.AUTH_TOKEN, 10))) {
     response.status(401).json({
       error: "Invalid auth token found.",
     });


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### What is in this change?

For single-user mode, move `===` to `bcrypt` comparison to prevent efficacy of [timing attack potential](https://ropesec.com/articles/timing-attacks/). This is already covered for Multi-user.

The risk of this is low as the overhead for the HTTP response varies from request to request making this opportunity near-impossible to execute, but why not patch it 👍 

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
