### PR TITLE
prevent manager in multi-user from updatingENV via HTTP

### DIFF
--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -283,8 +283,18 @@ function systemEndpoints(app) {
     [validatedRequest, flexUserRoleValid],
     async (request, response) => {
       try {
+        const user = await userFromSession(request, response);
+        if (!!user && user.role !== "admin") {
+          response.sendStatus(401).end();
+          return;
+        }
+
         const body = reqBody(request);
-        const { newValues, error } = updateENV(body);
+        const { newValues, error } = updateENV(
+          body,
+          false,
+          response.locals?.user
+        );
         if (process.env.NODE_ENV === "production") await dumpENV();
         response.status(200).json({ newValues, error });
       } catch (e) {

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -290,11 +290,7 @@ function systemEndpoints(app) {
         }
 
         const body = reqBody(request);
-        const { newValues, error } = updateENV(
-          body,
-          false,
-          response.locals?.user
-        );
+        const { newValues, error } = updateENV(body);
         if (process.env.NODE_ENV === "production") await dumpENV();
         response.status(200).json({ newValues, error });
       } catch (e) {

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -20,6 +20,8 @@ function makeJWT(info = {}, expiry = "30d") {
   return JWT.sign(info, process.env.JWT_SECRET, { expiresIn: expiry });
 }
 
+// Note: Only valid for finding users in multi-user mode
+// as single-user mode with password is not a "user"
 async function userFromSession(request, response = null) {
   if (!!response && !!response.locals?.user) {
     return response.locals.user;


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### What is in this change?

Managers _could_ in theory send and HTTP request to update the LLM,Embedder, etc with their token and still update the envs. This was originally just a UI hide until we decided manager role should be fully scoped to stop this. Now it is just enforced in the backend as well.


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
