### PR TITLE
Strict link protocol validation

### DIFF
--- a/collector/utils/url/index.js
+++ b/collector/utils/url/index.js
@@ -1,6 +1,9 @@
+const VALID_PROTOCOLS = ["https:", "http:"];
+
 function validURL(url) {
   try {
-    new URL(url);
+    const destination = new URL(url);
+    if (!VALID_PROTOCOLS.includes(destination.protocol)) return false;
     return true;
   } catch {}
   return false;


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### What is in this change?

Enforce strict link validation to only resolve `http` and `https:` type URLs for scraping.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
