### PR TITLE
chore: Better VectorDb and Embedder error messages

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -403,3 +403,7 @@ dialog::backdrop {
 .tooltip {
   @apply !bg-black !text-white !py-2 !px-3 !rounded-md;
 }
+
+.Toastify__toast-body {
+  white-space: pre-line;
+}

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -159,7 +159,7 @@ function workspaceEndpoints(app) {
         }
 
         await Document.removeDocuments(currWorkspace, deletes);
-        const { failedToEmbed = [], errors } = await Document.addDocuments(
+        const { failedToEmbed = [], errors = [] } = await Document.addDocuments(
           currWorkspace,
           adds
         );

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -159,7 +159,7 @@ function workspaceEndpoints(app) {
         }
 
         await Document.removeDocuments(currWorkspace, deletes);
-        const { failed = [] } = await Document.addDocuments(
+        const { failedToEmbed = [], errors } = await Document.addDocuments(
           currWorkspace,
           adds
         );
@@ -167,8 +167,10 @@ function workspaceEndpoints(app) {
         response.status(200).json({
           workspace: updatedWorkspace,
           message:
-            failed.length > 0
-              ? `${failed.length} documents could not be embedded.`
+            failedToEmbed.length > 0
+              ? `${failedToEmbed.length} documents failed to add.\n\n${errors
+                  .map((msg) => `${msg}`)
+                  .join("\n\n")}`
               : null,
         });
       } catch (e) {

--- a/server/utils/EmbeddingEngines/localAi/index.js
+++ b/server/utils/EmbeddingEngines/localAi/index.js
@@ -41,7 +41,12 @@ class LocalAiEmbedder {
               resolve({ data: res.data?.data, error: null });
             })
             .catch((e) => {
-              resolve({ data: [], error: e?.error });
+              e.type =
+                e?.response?.data?.error?.code ||
+                e?.response?.status ||
+                "failed_to_embed";
+              e.message = e?.response?.data?.error?.message || e.message;
+              resolve({ data: [], error: e });
             });
         })
       );
@@ -57,11 +62,14 @@ class LocalAiEmbedder {
         .map((res) => res.error)
         .flat();
       if (errors.length > 0) {
+        let uniqueErrors = new Set();
+        errors.map((error) =>
+          uniqueErrors.add(`[${error.type}]: ${error.message}`)
+        );
+
         return {
           data: [],
-          error: `(${errors.length}) Embedding Errors! ${errors
-            .map((error) => `[${error.type}]: ${error.message}`)
-            .join(", ")}`,
+          error: Array.from(uniqueErrors).join(", "),
         };
       }
       return {

--- a/server/utils/vectorDbProviders/chroma/index.js
+++ b/server/utils/vectorDbProviders/chroma/index.js
@@ -171,7 +171,7 @@ const Chroma = {
         }
 
         await DocumentVectors.bulkInsert(documentVectors);
-        return true;
+        return { vectorized: true, error: null };
       }
 
       // If we are here then we are going to embed and store a novel document.
@@ -242,11 +242,10 @@ const Chroma = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   deleteDocumentFromNamespace: async function (namespace, docId) {

--- a/server/utils/vectorDbProviders/lance/index.js
+++ b/server/utils/vectorDbProviders/lance/index.js
@@ -172,7 +172,7 @@ const LanceDb = {
 
         await this.updateOrCreateCollection(client, submissions, namespace);
         await DocumentVectors.bulkInsert(documentVectors);
-        return true;
+        return { vectorized: true, error: null };
       }
 
       // If we are here then we are going to embed and store a novel document.
@@ -229,11 +229,10 @@ const LanceDb = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   performSimilaritySearch: async function ({

--- a/server/utils/vectorDbProviders/milvus/index.js
+++ b/server/utils/vectorDbProviders/milvus/index.js
@@ -167,7 +167,7 @@ const Milvus = {
         }
         await DocumentVectors.bulkInsert(documentVectors);
         await client.flushSync({ collection_names: [namespace] });
-        return true;
+        return { vectorized: true, error: null };
       }
 
       const textSplitter = new RecursiveCharacterTextSplitter({
@@ -231,11 +231,10 @@ const Milvus = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   deleteDocumentFromNamespace: async function (namespace, docId) {

--- a/server/utils/vectorDbProviders/pinecone/index.js
+++ b/server/utils/vectorDbProviders/pinecone/index.js
@@ -125,7 +125,7 @@ const Pinecone = {
         }
 
         await DocumentVectors.bulkInsert(documentVectors);
-        return true;
+        return { vectorized: true, error: null };
       }
 
       // If we are here then we are going to embed and store a novel document.
@@ -183,11 +183,10 @@ const Pinecone = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   deleteDocumentFromNamespace: async function (namespace, docId) {

--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -190,7 +190,7 @@ const QDrant = {
         }
 
         await DocumentVectors.bulkInsert(documentVectors);
-        return true;
+        return { vectorized: true, error: null };
       }
 
       // If we are here then we are going to embed and store a novel document.
@@ -272,11 +272,10 @@ const QDrant = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   deleteDocumentFromNamespace: async function (namespace, docId) {

--- a/server/utils/vectorDbProviders/weaviate/index.js
+++ b/server/utils/vectorDbProviders/weaviate/index.js
@@ -233,7 +233,7 @@ const Weaviate = {
         }
 
         await DocumentVectors.bulkInsert(documentVectors);
-        return true;
+        return { vectorized: true, error: null };
       }
 
       // If we are here then we are going to embed and store a novel document.
@@ -316,11 +316,10 @@ const Weaviate = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   deleteDocumentFromNamespace: async function (namespace, docId) {

--- a/server/utils/vectorDbProviders/zilliz/index.js
+++ b/server/utils/vectorDbProviders/zilliz/index.js
@@ -168,7 +168,7 @@ const Zilliz = {
         }
         await DocumentVectors.bulkInsert(documentVectors);
         await client.flushSync({ collection_names: [namespace] });
-        return true;
+        return { vectorized: true, error: null };
       }
 
       const textSplitter = new RecursiveCharacterTextSplitter({
@@ -232,11 +232,10 @@ const Zilliz = {
       }
 
       await DocumentVectors.bulkInsert(documentVectors);
-      return true;
+      return { vectorized: true, error: null };
     } catch (e) {
-      console.error(e);
       console.error("addDocumentToNamespace", e.message);
-      return false;
+      return { vectorized: false, error: e.message };
     }
   },
   deleteDocumentFromNamespace: async function (namespace, docId) {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### What is in this change?

When a document is failed to embed or is failed to be inserted into a vector db we return a single generic error message that does not inform the user of why an error has occurred. 

Now we can return more descriptive error messages that can at least help determine the exact location and provider that caused a document to fail to be inserted into a workspace.

### Additional Information

Updated `toast` messages to now support `\n` newlines in the window.

### Developer Validations

- Test with all embedders + vector databases.

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
