### PR TITLE
Prevent private octets from link collection for self-hosted

### DIFF
--- a/collector/utils/url/index.js
+++ b/collector/utils/url/index.js
@@ -1,9 +1,23 @@
 const VALID_PROTOCOLS = ["https:", "http:"];
+const INVALID_OCTETS = [192, 172, 10, 127];
+
+function isInvalidIp({ hostname }) {
+  const IPRegex = new RegExp(
+    /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/gi
+  );
+  if (!IPRegex.test(hostname)) return false;
+  const [octetOne, ..._rest] = hostname.split(".");
+
+  // If fails to validate to number - abort and return as invalid.
+  if (isNaN(Number(octetOne))) return true;
+  return INVALID_OCTETS.includes(Number(octetOne));
+}
 
 function validURL(url) {
   try {
     const destination = new URL(url);
     if (!VALID_PROTOCOLS.includes(destination.protocol)) return false;
+    if (isInvalidIp(destination)) return false;
     return true;
   } catch {}
   return false;

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -16,10 +16,7 @@ const {
   multiUserMode,
   queryParams,
 } = require("../utils/http");
-const {
-  setupLogoUploads,
-  setupPfpUploads,
-} = require("../utils/files/multer");
+const { setupLogoUploads, setupPfpUploads } = require("../utils/files/multer");
 const { v4 } = require("uuid");
 const { SystemSettings } = require("../models/systemSettings");
 const { User } = require("../models/user");


### PR DESCRIPTION
Block private octets of link-scraping & collection just in case a user self-hosts AnythingLLM on the same network as another service that has zero authentication or access controls on it. Attackers in this case would also need to explicitly be granted high-level permissions to accomplish this in addition to knowing valid internal IPs.