### PR TITLE
fix vector cache not deleting cache after unembedding items with folders

### DIFF
--- a/collector/utils/extensions/YoutubeTranscript/index.js
+++ b/collector/utils/extensions/YoutubeTranscript/index.js
@@ -88,6 +88,7 @@ async function loadYouTubeTranscript({ url }) {
     data: {
       title: metadata.title,
       author: metadata.author,
+      destination: outFolder,
     },
   };
 }

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/index.jsx
@@ -91,7 +91,8 @@ export default function Directory({
             ) : !!files.items ? (
               files.items.map(
                 (item, index) =>
-                  item.type === "folder" && (
+                  (item.name === "custom-documents" ||
+                    (item.type === "folder" && item.items.length > 0)) && (
                     <FolderRow
                       key={index}
                       item={item}

--- a/server/utils/files/purgeDocument.js
+++ b/server/utils/files/purgeDocument.js
@@ -47,7 +47,9 @@ async function purgeFolder(folderName = null) {
 
   const filenames = fs
     .readdirSync(subFolderPath)
-    .map((file) => path.join(subFolderPath, file));
+    .map((file) =>
+      path.join(subFolderPath, file).replace(documentsPath + "/", "")
+    );
   const workspaces = await Workspace.where();
 
   const purgePromises = [];


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #628 


### What is in this change?

Describe the changes in this PR that are impactful to the repo.

- Fix a bug where when embedding anything using a data connector (Youtube video transcript/Github repo) the vector cache would not delete the cache files

### Additional Information

Add any other context about the Pull Request here that was not captured above.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
