### PR TITLE
Patch lanceDB not deleting vectors from workspace

### DIFF
--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -106,6 +106,9 @@ const Document = {
         await prisma.workspace_documents.delete({
           where: { id: document.id, workspaceId: workspace.id },
         });
+        await prisma.document_vectors.deleteMany({
+          where: { docId: document.docId },
+        });
       } catch (error) {
         console.error(error.message);
       }

--- a/server/utils/vectorDbProviders/lance/index.js
+++ b/server/utils/vectorDbProviders/lance/index.js
@@ -207,9 +207,9 @@ const LanceDb = {
 
           vectors.push(vectorRecord);
           submissions.push({
+            ...vectorRecord.metadata,
             id: vectorRecord.id,
             vector: vectorRecord.values,
-            ...vectorRecord.metadata,
           });
           documentVectors.push({ docId, vectorId: vectorRecord.id });
         }


### PR DESCRIPTION


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #594


### What is in this change?

- documentVectors self-sanitize on delete of parent document
- patch lanceDB not deleting vectors from workspace

RCA:
When adding a new document to a workspace for lanceDB that also created the table, the `submissions` item would have a different `id` given to it by the `collector` that would overwrite the known document id that was stored in the database - making deletion of it impossible.

This only impacted vectors that were totally new to the system (uncached) as cached documents would be able to be properly tracked. 

If users have this issue, the easiest full solve is just to delete the workspace and it will fully remove the vectors. They will persist in the DB, but be orphaned which is a negligible impact.


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
