### PR TITLE
Fixed docker-compose report error: Additional property name is not al…

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,5 @@
 version: "3.9"
 
-name: anythingllm
-
 networks:
   anything-llm:
     driver: bridge


### PR DESCRIPTION
…lowed


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

Remove invalid property in the docker-compose.yaml 

### Additional Information
When run `docker-compose up ` there's an error: Additional property name is not allowed.
This patch fix this.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
