### PR TITLE
Omit Phosphor-icons ssr icons from build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,11 +11,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@metamask/jazzicon": "^2.0.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@phosphor-icons/react": "^2.0.13",
-    "buffer": "^6.0.3",
     "dompurify": "^3.0.8",
     "he": "^1.2.0",
     "highlight.js": "^11.9.0",
@@ -26,7 +24,6 @@
     "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
-    "react-loading-icons": "^1.1.0",
     "react-loading-skeleton": "^3.1.0",
     "react-router-dom": "^6.3.0",
     "react-tag-input-component": "^2.0.2",
@@ -37,11 +34,13 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@types/react": "^18.2.23",
     "@types/react-dom": "^18.2.8",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.0.0-beta.0",
     "autoprefixer": "^10.4.14",
+    "buffer": "^6.0.3",
     "eslint": "^8.50.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ft-flow": "^3.0.0",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -48,6 +48,12 @@ export default defineConfig({
     ]
   },
   build: {
+    rollupOptions: {
+      external: [
+        // Reduces transformation time by 50% and we don't even use this variant, so we can ignore.
+        /@phosphor-icons\/react\/dist\/ssr/,
+      ]
+    },
     commonjsOptions: {
       transformMixedEsModules: true
     }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2526,11 +2526,6 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-loading-icons@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-loading-icons/-/react-loading-icons-1.1.0.tgz#c37f2472936ab93c6a7f43c0a2c2fe8efc3ff7c8"
-  integrity sha512-Y9eZ6HAufmUd8DIQd6rFrx5Bt/oDlTM9Nsjvf8YpajTa3dI8cLNU8jUN5z7KTANU+Yd6/KJuBjxVlrU2dMw33g==
-
 react-loading-skeleton@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-3.3.1.tgz#cd6e3a626ee86c76a46c14e2379243f2f8834e1b"


### PR DESCRIPTION
move dev deps from prod build
remove unused deps


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs



### What is in this change?

Reduces production build size of frontend for faster speed and chunking strategy

### Additional Information

HighlightJS remains to be the largest chunk. We can do what we did with `embed` and only import a subset of languages we wish to support. Given this is a vite build for react we can include a larger subset then what is found in `embed`

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
