### PR TITLE
Fix sidebar hiding options on small height viewport

### DIFF
--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -106,7 +106,7 @@ export default function SettingsSidebar() {
               </div>
 
               {/* Primary Body */}
-              <div className="h-full flex flex-col w-full justify-between pt-4 overflow-y-hidden ">
+              <div className="h-full flex flex-col w-full justify-between pt-4 overflow-y-scroll no-scroll ">
                 <div className="h-auto md:sidebar-items md:dark:sidebar-items">
                   <div className=" flex flex-col gap-y-4 pb-8 overflow-y-scroll no-scroll">
                     <SidebarOptions user={user} />
@@ -154,7 +154,7 @@ export default function SettingsSidebar() {
             Settings
           </div>
           {/* Primary Body */}
-          <div className="h-full flex flex-col w-full justify-between pt-4 overflow-y-hidden">
+          <div className="h-full flex flex-col w-full justify-between pt-4 overflow-y-scroll no-scroll">
             <div className="h-auto sidebar-items">
               {/* Options */}
               <div className="flex flex-col gap-y-2 h-full pb-8 overflow-y-scroll no-scroll">

--- a/frontend/src/pages/GeneralSettings/DataConnectors/Connectors/Github/index.jsx
+++ b/frontend/src/pages/GeneralSettings/DataConnectors/Connectors/Github/index.jsx
@@ -46,7 +46,8 @@ export default function GithubConnectorSetup() {
       }
 
       showToast(
-        `${data.files} ${pluralize("file", data.files)} collected from ${data.author
+        `${data.files} ${pluralize("file", data.files)} collected from ${
+          data.author
         }/${data.repo}:${data.branch}. Output folder is ${data.destination}.`,
         "success",
         { clear: true }


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #703


### What is in this change?

Resolved issue with sidebar looking like it is hiding options when the viewport size is not of sufficient height


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
