### PR TITLE
Fix Docker container exit issue by changing ownership

### DIFF
--- a/cloud-deployments/gcp/deployment/gcp_deploy_anything_llm.yaml
+++ b/cloud-deployments/gcp/deployment/gcp_deploy_anything_llm.yaml
@@ -32,6 +32,7 @@ resources:
 
               mkdir -p /home/anythingllm
               touch /home/anythingllm/.env
+              sudo chown -R ubuntu:ubuntu /home/anythingllm
                
               sudo docker pull mintplexlabs/anythingllm:master
               sudo docker run -d -p 3001:3001 --cap-add SYS_ADMIN -v /home/anythingllm:/app/server/storage -v /home/anythingllm/.env:/app/server/.env -e STORAGE_DIR="/app/server/storage" mintplexlabs/anythingllm:master


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #710
resolves #702
resolves #695

### What is in this change?

This PR addresses an issue where the Docker container would start but then exit due to the error "unable to open database file: ../storage/anythingllm.db". The fix involves modifying the `gcp_deploy_anything_llm.yaml` file to change the ownership of the /home/anythingllm directory using the command: sudo chown -R ubuntu:ubuntu /home/anythingllm. This solution was preferred over changing the Docker runner from using a user and running as root.

### Additional Information

This change was discussed with @timothycarambat and agreed upon as the preferred solution. It also addresses a similar issue (#702).

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
