### PR TITLE
Support more plaintext filetypes

### DIFF
--- a/collector/utils/constants.js
+++ b/collector/utils/constants.js
@@ -1,7 +1,7 @@
 const WATCH_DIRECTORY = require("path").resolve(__dirname, "../hotdir");
 
 const ACCEPTED_MIMES = {
-  "text/plain": [".txt", ".md"],
+  "text/plain": [".txt", ".md", ".org", ".adoc", ".rst"],
   "text/html": [".html"],
 
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
@@ -25,8 +25,12 @@ const ACCEPTED_MIMES = {
 };
 
 const SUPPORTED_FILETYPE_CONVERTERS = {
-  ".txt": "./convert/asTxt.js",
-  ".md": "./convert/asTxt.js",
+  ".txt":  "./convert/asTxt.js",
+  ".md":   "./convert/asTxt.js",
+  ".org":  "./convert/asTxt.js",
+  ".adoc": "./convert/asTxt.js",
+  ".rst":  "./convert/asTxt.js",
+
   ".html": "./convert/asTxt.js",
   ".pdf": "./convert/asPDF.js",
 

--- a/collector/utils/constants.js
+++ b/collector/utils/constants.js
@@ -25,11 +25,11 @@ const ACCEPTED_MIMES = {
 };
 
 const SUPPORTED_FILETYPE_CONVERTERS = {
-  ".txt":  "./convert/asTxt.js",
-  ".md":   "./convert/asTxt.js",
-  ".org":  "./convert/asTxt.js",
+  ".txt": "./convert/asTxt.js",
+  ".md": "./convert/asTxt.js",
+  ".org": "./convert/asTxt.js",
   ".adoc": "./convert/asTxt.js",
-  ".rst":  "./convert/asTxt.js",
+  ".rst": "./convert/asTxt.js",
 
   ".html": "./convert/asTxt.js",
   ".pdf": "./convert/asPDF.js",


### PR DESCRIPTION
org-mode, asciidoc, and reStructuredText are all text formats


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat

resolves #750 

### What is in this change?

Treats org-mode, ascii-doc, and reStructuredText like Markdown and plain text.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (**not applicable**)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
