### PR TITLE
Permit auto-refocus for win32 systems to prevent dead inputs on alert…

### DIFF
--- a/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FileRow/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FileRow/index.jsx
@@ -7,6 +7,7 @@ import {
 import { File, Trash } from "@phosphor-icons/react";
 import System from "@/models/system";
 import debounce from "lodash.debounce";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function FileRow({
   item,
@@ -27,10 +28,12 @@ export default function FileRow({
         "Are you sure you want to delete this document?\nThis will require you to re-upload and re-embed it.\nThis document will be removed from any workspace that is currently referencing it.\nThis action is not reversible."
       )
     ) {
+      refocusApplication();
       return false;
     }
 
     try {
+      refocusApplication();
       setLoading(true);
       setLoadingMessage("This may take a while for large documents");
       await System.deleteDocument(`${folderName}/${item.name}`);

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FolderRow/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FolderRow/index.jsx
@@ -3,6 +3,7 @@ import FileRow from "../FileRow";
 import { CaretDown, FolderNotch, Trash } from "@phosphor-icons/react";
 import { middleTruncate } from "@/utils/directories";
 import System from "@/models/system";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function FolderRow({
   item,
@@ -24,10 +25,12 @@ export default function FolderRow({
         "Are you sure you want to delete this folder?\nThis will require you to re-upload and re-embed it.\nAny documents in this folder will be removed from any workspace that is currently referencing it.\nThis action is not reversible."
       )
     ) {
+      refocusApplication();
       return false;
     }
 
     try {
+      refocusApplication();
       setLoading(true);
       setLoadingMessage("This may take a while for large folders");
       await System.deleteFolder(item.name);

--- a/frontend/src/components/Modals/MangeWorkspace/Settings/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Settings/index.jsx
@@ -8,6 +8,7 @@ import { useParams } from "react-router-dom";
 import showToast from "../../../../utils/toast";
 import ChatModelPreference from "./ChatModelPreference";
 import { Link } from "react-router-dom";
+import { refocusApplication } from "@/ipc/node-api";
 
 // Ensure that a type is correct before sending the body
 // to the backend.
@@ -72,9 +73,12 @@ export default function WorkspaceSettings({ active, workspace, settings }) {
       !window.confirm(
         `You are about to delete your entire ${workspace.name} workspace. This will remove all vector embeddings on your vector database.\n\nThe original source files will remain untouched. This action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
 
+    refocusApplication();
     setDeleting(true);
     const success = await Workspace.delete(workspace.slug);
     if (!success) {

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
@@ -1,5 +1,6 @@
 import ModalWrapper from "@/components/ModalWrapper";
 import { useModal } from "@/hooks/useModal";
+import { refocusApplication } from "@/ipc/node-api";
 import Workspace from "@/models/workspace";
 import paths from "@/utils/paths";
 import showToast from "@/utils/toast";
@@ -140,8 +141,12 @@ function OptionsMenu({
       !window.confirm(
         "Are you sure you want to delete this thread? All of its chats will be deleted. You cannot undo this."
       )
-    )
+    ) {
+      refocusApplication();
       return;
+    }
+
+    refocusApplication();
     const success = await Workspace.threads.delete(workspace.slug, thread.slug);
     if (!success) {
       showToast("Thread could not be deleted!", "error", { clear: true });

--- a/frontend/src/ipc/node-api.js
+++ b/frontend/src/ipc/node-api.js
@@ -27,3 +27,8 @@ ipcRenderer.on("backend-server-online", async (_evt, message) => {
   // postMessage({ payload: 'removeLoading' }, '*')
   API_BASE();
 });
+
+export function refocusApplication() {
+  ipcRenderer.send("focus-fix");
+  return;
+}

--- a/frontend/src/pages/Admin/Invitations/InviteRow/index.jsx
+++ b/frontend/src/pages/Admin/Invitations/InviteRow/index.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { titleCase } from "text-case";
 import Admin from "../../../../models/admin";
 import { Trash } from "@phosphor-icons/react";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function InviteRow({ invite }) {
   const rowRef = useRef(null);
@@ -12,8 +13,12 @@ export default function InviteRow({ invite }) {
       !window.confirm(
         `Are you sure you want to deactivate this invite?\nAfter you do this it will not longer be useable.\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     if (rowRef?.current) {
       rowRef.current.children[0].innerText = "Disabled";
     }

--- a/frontend/src/pages/Admin/Logging/index.jsx
+++ b/frontend/src/pages/Admin/Logging/index.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import * as Skeleton from "react-loading-skeleton";
 import LogRow from "./LogRow";
 import showToast from "@/utils/toast";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function AdminLogs() {
   const handleResetLogs = async () => {
@@ -12,8 +13,12 @@ export default function AdminLogs() {
       !window.confirm(
         "Are you sure you want to clear all event logs? This action is irreversible."
       )
-    )
+    ) {
+      refocusApplication();
       return;
+    }
+
+    refocusApplication();
     const { success, error } = await System.clearEventLogs();
     if (success) {
       showToast("Event logs cleared successfully.", "success");

--- a/frontend/src/pages/Admin/Users/UserRow/index.jsx
+++ b/frontend/src/pages/Admin/Users/UserRow/index.jsx
@@ -6,6 +6,7 @@ import { DotsThreeOutline } from "@phosphor-icons/react";
 import showToast from "@/utils/toast";
 import { useModal } from "@/hooks/useModal";
 import ModalWrapper from "@/components/ModalWrapper";
+import { refocusApplication } from "@/ipc/node-api";
 
 const ModMap = {
   admin: ["admin", "manager", "default"],
@@ -23,9 +24,12 @@ export default function UserRow({ currUser, user }) {
       !window.confirm(
         `Are you sure you want to suspend ${user.username}?\nAfter you do this they will be logged out and unable to log back into this instance of AnythingLLM until unsuspended by an admin.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
 
+    refocusApplication();
     const { success, error } = await Admin.updateUser(user.id, {
       suspended: suspended ? 0 : 1,
     });
@@ -44,8 +48,12 @@ export default function UserRow({ currUser, user }) {
       !window.confirm(
         `Are you sure you want to delete ${user.username}?\nAfter you do this they will be logged out and unable to use this instance of AnythingLLM.\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     const { success, error } = await Admin.deleteUser(user.id);
     if (!success) showToast(error, "error", { clear: true });
     if (success) {

--- a/frontend/src/pages/Admin/Workspaces/WorkspaceRow/index.jsx
+++ b/frontend/src/pages/Admin/Workspaces/WorkspaceRow/index.jsx
@@ -6,6 +6,7 @@ import { DotsThreeOutline, LinkSimple, Trash } from "@phosphor-icons/react";
 import { useModal } from "@/hooks/useModal";
 import { Link } from "react-router-dom";
 import ModalWrapper from "@/components/ModalWrapper";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function WorkspaceRow({ workspace, users }) {
   const rowRef = useRef(null);
@@ -15,8 +16,12 @@ export default function WorkspaceRow({ workspace, users }) {
       !window.confirm(
         `Are you sure you want to delete ${workspace.name}?\nAfter you do this it will be unavailable in this instance of AnythingLLM.\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     rowRef?.current?.remove();
     await Admin.deleteWorkspace(workspace.id);
   };

--- a/frontend/src/pages/GeneralSettings/ApiKeys/ApiKeyRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ApiKeys/ApiKeyRow/index.jsx
@@ -4,6 +4,7 @@ import showToast from "../../../../utils/toast";
 import { Trash } from "@phosphor-icons/react";
 import { userFromStorage } from "../../../../utils/request";
 import System from "../../../../models/system";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function ApiKeyRow({ apiKey }) {
   const rowRef = useRef(null);
@@ -13,8 +14,12 @@ export default function ApiKeyRow({ apiKey }) {
       !window.confirm(
         `Are you sure you want to deactivate this api key?\nAfter you do this it will not longer be useable.\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     if (rowRef?.current) {
       rowRef.current.remove();
     }

--- a/frontend/src/pages/GeneralSettings/Chats/ChatRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Chats/ChatRow/index.jsx
@@ -3,6 +3,7 @@ import { X, Trash } from "@phosphor-icons/react";
 import System from "@/models/system";
 import ModalWrapper from "@/components/ModalWrapper";
 import { useModal } from "@/hooks/useModal";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function ChatRow({ chat, onDelete }) {
   const {
@@ -21,8 +22,12 @@ export default function ChatRow({ chat, onDelete }) {
       !window.confirm(
         `Are you sure you want to delete this chat?\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     await System.deleteChat(chat.id);
     onDelete(chat.id);
   };

--- a/frontend/src/pages/GeneralSettings/EmbedChats/ChatRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbedChats/ChatRow/index.jsx
@@ -5,6 +5,7 @@ import { useModal } from "@/hooks/useModal";
 import paths from "@/utils/paths";
 import Embed from "@/models/embed";
 import { Link } from "react-router-dom";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function ChatRow({ chat, onDelete }) {
   const {
@@ -23,8 +24,12 @@ export default function ChatRow({ chat, onDelete }) {
       !window.confirm(
         `Are you sure you want to delete this chat?\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     await Embed.deleteChat(chat.id);
     onDelete(chat.id);
   };

--- a/frontend/src/pages/GeneralSettings/EmbedConfigs/EmbedRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbedConfigs/EmbedRow/index.jsx
@@ -8,6 +8,7 @@ import paths from "@/utils/paths";
 import { nFormatter } from "@/utils/numbers";
 import EditEmbedModal from "./EditEmbedModal";
 import CodeSnippetModal from "./CodeSnippetModal";
+import { refocusApplication } from "@/ipc/node-api";
 
 export default function EmbedRow({ embed }) {
   const rowRef = useRef(null);
@@ -28,9 +29,12 @@ export default function EmbedRow({ embed }) {
       !window.confirm(
         `Are you sure you want to disabled this embed?\nOnce disabled the embed will no longer respond to any chat requests.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
 
+    refocusApplication();
     const { success, error } = await Embed.updateEmbed(embed.id, {
       enabled: !enabled,
     });
@@ -49,8 +53,12 @@ export default function EmbedRow({ embed }) {
       !window.confirm(
         `Are you sure you want to delete this embed?\nOnce deleted this embed will no longer respond to chats or be active.\n\nThis action is irreversible.`
       )
-    )
+    ) {
+      refocusApplication();
       return false;
+    }
+
+    refocusApplication();
     const { success, error } = await Embed.deleteEmbed(embed.id);
     if (!success) showToast(error, "error", { clear: true });
     if (success) {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

Resolve windows issue where after a confirmation dialog was show all inputs would appear to be dead and not-focus.

https://github.com/electron/electron/issues/31917