### PR TITLE
[FIX] :  missing import for  `parseAuthHeader` in `server/utils/vectorDbProviders/chroma/index.js`

### DIFF
--- a/server/utils/vectorDbProviders/chroma/index.js
+++ b/server/utils/vectorDbProviders/chroma/index.js
@@ -7,6 +7,7 @@ const {
   getLLMProvider,
   getEmbeddingEngineSelection,
 } = require("../../helpers");
+const { parseAuthHeader } = require("../../http");
 
 const Chroma = {
   name: "Chroma",


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

Resolves an error when Chroma is set up with an API key.

![image](https://github.com/Mintplex-Labs/anything-llm/assets/16297877/7f86237b-b938-4eec-bf66-ee7354bb59f0)


### What is in this change?

Imports `parseAuthHeader` in `server/utils/vectorDbProviders/chroma/index.js`
so that `Chroma.connect` would no longer throw an error.

https://github.com/Mintplex-Labs/anything-llm/blob/fde905aac1812b84066ff72e5f2f90b56d4c3a59/server/utils/vectorDbProviders/chroma/index.js#L17-L29

### Additional Information

Add any other context about the Pull Request here that was not captured above.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
