### PR TITLE
HOW_TO_USE_DOCKER.md - Missing -ItemType File for .env creation 

### DIFF
--- a/docker/HOW_TO_USE_DOCKER.md
+++ b/docker/HOW_TO_USE_DOCKER.md
@@ -75,7 +75,7 @@ mintplexlabs/anythingllm
 # Run this in powershell terminal
 $env:STORAGE_LOCATION="$HOME\Documents\anythingllm"; `
 If(!(Test-Path $env:STORAGE_LOCATION)) {New-Item $env:STORAGE_LOCATION -ItemType Directory}; `
-If(!(Test-Path "$env:STORAGE_LOCATION\.env")) {New-Item "$env:STORAGE_LOCATION\.env"}; `
+If(!(Test-Path "$env:STORAGE_LOCATION\.env")) {New-Item "$env:STORAGE_LOCATION\.env" -ItemType File}; `
 docker run -d -p 3001:3001 `
 --cap-add SYS_ADMIN `
 -v "$env:STORAGE_LOCATION`:/app/server/storage" `


### PR DESCRIPTION
Missing New-Item -ItemType for .env default to a folder when it should be a file (Docker won't run when that happen since a file is expected)




 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [X ] 📝 docs

### Relevant Issues

Here is the error without specifying -ItemType File for the docker mount of the .env file. 
This happen because .env get created as a folder on the local system. 

docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container
init: error mounting "/run/desktop/mnt/host/e/Docker/anythingllm/.env" to rootfs at "/app/server/.env": mount /run/desktop/mnt/host/e/Docker/anythingllm/.env:/app/server/.env (via /proc/self/fd/9), flags: 0
x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type.


