### PR TITLE
handle expired token being null and prevent constant rerender

### DIFF
--- a/frontend/src/components/Modals/Password/index.jsx
+++ b/frontend/src/components/Modals/Password/index.jsx
@@ -34,7 +34,7 @@ export default function PasswordModal({ mode = "single" }) {
   );
 }
 
-export function usePasswordModal() {
+export function usePasswordModal(notry = false) {
   const [auth, setAuth] = useState({
     loading: true,
     requiresAuth: false,
@@ -47,7 +47,7 @@ export function usePasswordModal() {
 
       // If the last validity check is still valid
       // we can skip the loading.
-      if (!System.needsAuthCheck()) {
+      if (!System.needsAuthCheck() && notry === false) {
         setAuth({
           loading: false,
           requiresAuth: false,
@@ -60,7 +60,7 @@ export function usePasswordModal() {
       if (settings?.MultiUserMode) {
         const currentToken = window.localStorage.getItem(AUTH_TOKEN);
         if (!!currentToken) {
-          const valid = await System.checkAuth(currentToken);
+          const valid = notry ? false : await System.checkAuth(currentToken);
           if (!valid) {
             setAuth({
               loading: false,
@@ -102,7 +102,7 @@ export function usePasswordModal() {
 
         const currentToken = window.localStorage.getItem(AUTH_TOKEN);
         if (!!currentToken) {
-          const valid = await System.checkAuth(currentToken);
+          const valid = notry ? false : await System.checkAuth(currentToken);
           if (!valid) {
             setAuth({
               loading: false,
@@ -110,6 +110,8 @@ export function usePasswordModal() {
               mode: "single",
             });
             window.localStorage.removeItem(AUTH_TOKEN);
+            window.localStorage.removeItem(AUTH_USER);
+            window.localStorage.removeItem(AUTH_TIMESTAMP);
             return;
           } else {
             setAuth({

--- a/frontend/src/components/PrivateRoute/index.jsx
+++ b/frontend/src/components/PrivateRoute/index.jsx
@@ -136,6 +136,6 @@ export default function PrivateRoute({ Component }) {
       <Component />
     </UserMenu>
   ) : (
-    <Navigate to={paths.login()} />
+    <Navigate to={paths.login(true)} />
   );
 }

--- a/frontend/src/pages/Login/index.jsx
+++ b/frontend/src/pages/Login/index.jsx
@@ -3,9 +3,11 @@ import PasswordModal, { usePasswordModal } from "@/components/Modals/Password";
 import { FullScreenLoader } from "@/components/Preloader";
 import { Navigate } from "react-router-dom";
 import paths from "@/utils/paths";
+import useQuery from "@/hooks/useQuery";
 
 export default function Login() {
-  const { loading, requiresAuth, mode } = usePasswordModal();
+  const query = useQuery();
+  const { loading, requiresAuth, mode } = usePasswordModal(!!query.get("nt"));
   if (loading) return <FullScreenLoader />;
   if (requiresAuth === false) return <Navigate to={paths.home()} />;
 

--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -4,8 +4,8 @@ export default {
   home: () => {
     return "/";
   },
-  login: () => {
-    return "/login";
+  login: (noTry = false) => {
+    return `/login${noTry ? "?nt=1" : ""}`;
   },
   onboarding: {
     home: () => {

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -17,7 +17,7 @@ function queryParams(request) {
 function makeJWT(info = {}, expiry = "30d") {
   if (!process.env.JWT_SECRET)
     throw new Error("Cannot create JWT as JWT_SECRET is unset.");
-  return JWT.sign(info, process.env.JWT_SECRET, { expiresIn: expiry });
+  return JWT.sign(info, process.env.JWT_SECRET, { expiry });
 }
 
 // Note: Only valid for finding users in multi-user mode

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -17,7 +17,7 @@ function queryParams(request) {
 function makeJWT(info = {}, expiry = "30d") {
   if (!process.env.JWT_SECRET)
     throw new Error("Cannot create JWT as JWT_SECRET is unset.");
-  return JWT.sign(info, process.env.JWT_SECRET, { expiry });
+  return JWT.sign(info, process.env.JWT_SECRET, { expiresIn: expiry });
 }
 
 // Note: Only valid for finding users in multi-user mode

--- a/server/utils/middleware/validatedRequest.js
+++ b/server/utils/middleware/validatedRequest.js
@@ -11,7 +11,7 @@ async function validatedRequest(request, response, next) {
   // When in development passthrough auth token for ease of development.
   // Or if the user simply did not set an Auth token or JWT Secret
   if (
-    // process.env.NODE_ENV === "development" ||
+    process.env.NODE_ENV === "development" ||
     !process.env.AUTH_TOKEN ||
     !process.env.JWT_SECRET
   ) {

--- a/server/utils/middleware/validatedRequest.js
+++ b/server/utils/middleware/validatedRequest.js
@@ -11,7 +11,7 @@ async function validatedRequest(request, response, next) {
   // When in development passthrough auth token for ease of development.
   // Or if the user simply did not set an Auth token or JWT Secret
   if (
-    process.env.NODE_ENV === "development" ||
+    // process.env.NODE_ENV === "development" ||
     !process.env.AUTH_TOKEN ||
     !process.env.JWT_SECRET
   ) {
@@ -38,9 +38,17 @@ async function validatedRequest(request, response, next) {
 
   const bcrypt = require("bcrypt");
   const { p } = decodeJWT(token);
+
+  if (p === null) {
+    response.status(401).json({
+      error: "Token expired or failed validation.",
+    });
+    return;
+  }
+
   if (!bcrypt.compareSync(p, bcrypt.hashSync(process.env.AUTH_TOKEN, 10))) {
     response.status(401).json({
-      error: "Invalid auth token found.",
+      error: "Invalid auth credentials.",
     });
     return;
   }


### PR DESCRIPTION
When using AnythingLLM with a password or multi-user auth state the default token expiry is set to 30 days expiration (TBD custom config for this value).

If you are logged in and do not re-visit the system for some time where the token then expires on revisit the token will fail to verify and will return a `null` value, which will fatally crash the `bcrypt` `compareHash` function. Passing an empty `''` instead when invalid will then cause an infinite re-render on the login screen.

Additional work was required to have this work when the session is fully expired:
- Invalidate token as normal
- Send the user to log in, but **prevent** auto login via a query param set during redirect due to invalid auth.
- User can log in again and get a new session token.

---------
- Tested as all roles in multi-user
- Tested with just password
- Tested with no password instance


------
resolves #947