### PR TITLE
[FEAT] Check port access in docker before showing a default error

### DIFF
--- a/server/utils/helpers/portAvailabilityChecker.js
+++ b/server/utils/helpers/portAvailabilityChecker.js
@@ -1,0 +1,24 @@
+const net = require("net");
+
+function isPortInUse(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+
+    server.on("error", (err) => {
+      if (err.code === "EADDRINUSE") {
+        resolve(true);
+      } else {
+        reject(false);
+      }
+    });
+
+    server.on("listening", () => {
+      server.close();
+      resolve(false);
+    });
+
+    server.listen(port);
+  });
+}
+
+module.exports = isPortInUse;

--- a/server/utils/helpers/portAvailabilityChecker.js
+++ b/server/utils/helpers/portAvailabilityChecker.js
@@ -1,24 +1,46 @@
-const net = require("net");
+// Get all loopback addresses that are available for use or binding.
+function getLocalHosts() {
+  const os = require("os");
+  const interfaces = os.networkInterfaces();
+  const results = new Set([undefined, "0.0.0.0"]);
 
-function isPortInUse(port) {
+  for (const _interface of Object.values(interfaces)) {
+    for (const config of _interface) {
+      results.add(config.address);
+    }
+  }
+
+  return Array.from(results);
+}
+
+function checkPort(options = {}) {
+  const net = require("net");
   return new Promise((resolve, reject) => {
     const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
 
-    server.on("error", (err) => {
-      if (err.code === "EADDRINUSE") {
+    server.listen(options, () => {
+      server.close(() => {
         resolve(true);
-      } else {
-        reject(false);
-      }
+      });
     });
-
-    server.on("listening", () => {
-      server.close();
-      resolve(false);
-    });
-
-    server.listen(port);
   });
 }
 
-module.exports = isPortInUse;
+async function isPortInUse(port, host) {
+  try {
+    await checkPort({ port, host });
+    return true;
+  } catch (error) {
+    if (!["EADDRNOTAVAIL", "EINVAL"].includes(error.code)) {
+      return false;
+    }
+  }
+  return false;
+}
+
+module.exports = {
+  isPortInUse,
+  getLocalHosts,
+};

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -477,25 +477,14 @@ async function validDockerizedUrl(input = "") {
     const isPortAvailableFromDocker = await isPortInUse(port);
     if (!isPortAvailableFromDocker) {
       if (["localhost", "127.0.0.1", "0.0.0.0"].includes(hostname)) {
-        return "Localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal, a real machine ip, or domain to connect to your service.";
+        return "localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal (for linux use 172.17.0.1), a real machine ip, or domain to connect to your service.";
       }
     }
   } catch (error) {
-    console.error(error.message)
-    return "An error occurred while validating the URL"
+    console.error(error.message);
+    return "An error occurred while validating the URL";
   }
 
-  return null;
-}
-
-function validDockerizedUrl(input = "") {
-  if (process.env.ANYTHING_LLM_RUNTIME !== "docker") return null;
-  try {
-    const { hostname } = new URL(input);
-    if (["localhost", "127.0.0.1", "0.0.0.0"].includes(hostname.toLowerCase()))
-      return "Localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal, a real machine ip, or domain to connect to your service.";
-    return null;
-  } catch {}
   return null;
 }
 
@@ -513,7 +502,6 @@ async function wipeWorkspaceModelPreference(key, prev, next) {
   const { Workspace } = require("../../models/workspace");
   await Workspace.resetWorkspaceChatModels();
 }
-
 
 // This will force update .env variables which for any which reason were not able to be parsed or
 // read from an ENV file as this seems to be a complicating step for many so allowing people to write

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1,3 +1,5 @@
+const isPortInUse = require("./portAvailabilityChecker");
+
 const KEY_MAPPING = {
   LLMProvider: {
     envKey: "LLM_PROVIDER",
@@ -462,6 +464,30 @@ function isDownloadedModel(input = "") {
   return files.includes(input);
 }
 
+async function validDockerizedUrl(input = "") {
+  if (process.env.ANYTHING_LLM_RUNTIME !== "docker") return null;
+
+  try {
+    const url = new URL(input);
+    const hostname = url.hostname.toLowerCase();
+    const port = parseInt(url.port, 10);
+
+    if (isNaN(port)) return "Invalid URL: Port is not specified or invalid";
+
+    const isPortAvailableFromDocker = await isPortInUse(port);
+    if (!isPortAvailableFromDocker) {
+      if (["localhost", "127.0.0.1", "0.0.0.0"].includes(hostname)) {
+        return "Localhost, 127.0.0.1, or 0.0.0.0 origins cannot be reached from inside the AnythingLLM container. Please use host.docker.internal, a real machine ip, or domain to connect to your service.";
+      }
+    }
+  } catch (error) {
+    console.error(error.message)
+    return "An error occurred while validating the URL"
+  }
+
+  return null;
+}
+
 function validDockerizedUrl(input = "") {
   if (process.env.ANYTHING_LLM_RUNTIME !== "docker") return null;
   try {
@@ -488,6 +514,7 @@ async function wipeWorkspaceModelPreference(key, prev, next) {
   await Workspace.resetWorkspaceChatModels();
 }
 
+
 // This will force update .env variables which for any which reason were not able to be parsed or
 // read from an ENV file as this seems to be a complicating step for many so allowing people to write
 // to the process will at least alleviate that issue. It does not perform comprehensive validity checks or sanity checks
@@ -504,10 +531,8 @@ async function updateENV(newENVs = {}, force = false, userId = null) {
     const { envKey, checks, postUpdate = [] } = KEY_MAPPING[key];
     const prevValue = process.env[envKey];
     const nextValue = newENVs[key];
-    const errors = checks
-      .map((validityCheck) => validityCheck(nextValue, force))
-      .filter((err) => typeof err === "string");
 
+    const errors = await executeValidationChecks(checks, nextValue, force);
     if (errors.length > 0) {
       error += errors.join("\n");
       break;
@@ -522,6 +547,13 @@ async function updateENV(newENVs = {}, force = false, userId = null) {
 
   await logChangesToEventLog(newValues, userId);
   return { newValues, error: error?.length > 0 ? error : false };
+}
+
+async function executeValidationChecks(checks, value, force) {
+  const results = await Promise.all(
+    checks.map((validator) => validator(value, force))
+  );
+  return results.filter((err) => typeof err === "string");
 }
 
 async function logChangesToEventLog(newValues = {}, userId = null) {

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -478,7 +478,7 @@ async function validDockerizedUrl(input = "") {
 
     const isPortAvailableFromDocker = await isPortInUse(port, hostname);
     if (isPortAvailableFromDocker)
-      return "Port does not seem to running a service reachable on loopback address from inside the AnythingLLM container. Please use host.docker.internal (for linux use 172.17.0.1), a real machine ip, or domain to connect to your service.";
+      return "Port is not running a reachable service on loopback address from inside the AnythingLLM container. Please use host.docker.internal (for linux use 172.17.0.1), a real machine ip, or domain to connect to your service.";
   } catch (error) {
     console.error(error.message);
     return "An error occurred while validating the URL";


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #959 


### What is in this change?

In validDockerizedUrl (which only runs in docker environments) we now do a port check before we simply _assume_ that the user cannot connect to the port. When you run docker in host network mode, it is perfectly fine to use localhost URLs.


### Additional Information

- Since host.docker.internal is not available in Linux systems, I have added the Docker URL for Linux in the error message.
- Added handling of async functions in a separate method, so you can now make a validation function async if needed

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
