### PR TITLE
[FIX] Add max height and scrolling to FolderSelectionPopup

### DIFF
--- a/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FolderSelectionPopup/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FolderSelectionPopup/index.jsx
@@ -7,7 +7,7 @@ export default function FolderSelectionPopup({ folders, onSelect, onClose }) {
   };
 
   return (
-    <div className="absolute bottom-full left-0 mb-2 bg-white rounded-lg shadow-lg">
+    <div className="absolute bottom-full left-0 mb-2 bg-white rounded-lg shadow-lg max-h-40 overflow-y-auto">
       <ul>
         {folders.map((folder) => (
           <li

--- a/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FolderSelectionPopup/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/FolderSelectionPopup/index.jsx
@@ -7,7 +7,7 @@ export default function FolderSelectionPopup({ folders, onSelect, onClose }) {
   };
 
   return (
-    <div className="absolute bottom-full left-0 mb-2 bg-white rounded-lg shadow-lg max-h-40 overflow-y-auto">
+    <div className="absolute bottom-full left-0 mb-2 bg-white rounded-lg shadow-lg max-h-40 overflow-y-auto no-scroll">
       <ul>
         {folders.map((folder) => (
           <li


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #981 


### What is in this change?

Describe the changes in this PR that are impactful to the repo.

- Add max height to FolderSelectionPopup and overflow scrolling so that if there are more than 7 folders, they are all visible

### Additional Information

Add any other context about the Pull Request here that was not captured above.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
