### PR TITLE
[FIX] GitHub repo with periods in link fix

### DIFF
--- a/collector/utils/extensions/GithubRepo/RepoLoader/index.js
+++ b/collector/utils/extensions/GithubRepo/RepoLoader/index.js
@@ -13,7 +13,9 @@ class RepoLoader {
 
   #validGithubUrl() {
     const UrlPattern = require("url-pattern");
-    const pattern = new UrlPattern("https\\://github.com/(:author)/(:project)");
+    const pattern = new UrlPattern(
+      "https\\://github.com/(:author)/(:project(*))"
+    );
     const match = pattern.match(this.repo);
     if (!match) return false;
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1083 


### What is in this change?

Describe the changes in this PR that are impactful to the repo.

- Fix GitHub repos with periods in their links so that they do not throw an error when trying to import via the GitHub repo data connector

### Additional Information

Add any other context about the Pull Request here that was not captured above.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
