### PR TITLE
[FEAT] #1089 Collector: allow more file type extensions

### DIFF
--- a/collector/utils/constants.js
+++ b/collector/utils/constants.js
@@ -1,7 +1,7 @@
 const WATCH_DIRECTORY = require("path").resolve(__dirname, "../hotdir");
 
 const ACCEPTED_MIMES = {
-  "text/plain": [".txt", ".md", ".org", ".adoc", ".rst"],
+  "text/plain": [".txt", ".md", ".org", ".adoc", ".rst", ".c", ".cs", ".h", ".js", ".lua", ".pas", ".py", ".ts"],
   "text/html": [".html"],
 
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
@@ -31,6 +31,15 @@ const SUPPORTED_FILETYPE_CONVERTERS = {
   ".org": "./convert/asTxt.js",
   ".adoc": "./convert/asTxt.js",
   ".rst": "./convert/asTxt.js",
+
+  ".c": "./convert/asTxt.js",
+  ".cs": "./convert/asTxt.js",
+  ".h": "./convert/asTxt.js",
+  ".js": "./convert/asTxt.js",
+  ".lua": "./convert/asTxt.js",
+  ".pas": "./convert/asTxt.js",
+  ".py": "./convert/asTxt.js",
+  ".ts": "./convert/asTxt.js",
 
   ".html": "./convert/asTxt.js",
   ".pdf": "./convert/asPDF.js",


### PR DESCRIPTION
 ### Pull Request Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1089 


### What is in this change?

The constants.js file in the Collector contains a list of allowed file extensions/mimes.
These have been expanded for some common development languages, like C, C#, Javascript, Lua, Pascal, Python and Typescript.
They're all treated as text files.


### Additional Information

Tried yarn lint, but it fails in WSL2 with command prettier not found and I'm not a Linux guy.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
