### PR TITLE
Add ability for owner to reset just the workspace vector DB

### DIFF
--- a/frontend/src/models/workspace.js
+++ b/frontend/src/models/workspace.js
@@ -173,6 +173,14 @@ const Workspace = {
 
     return result;
   },
+  wipeVectorDb: async function (slug) {
+    return await fetch(`${API_BASE}/workspace/${slug}/reset-vector-db`, {
+      method: "DELETE",
+      headers: baseHeaders(),
+    })
+      .then((res) => res.ok)
+      .catch(() => false);
+  },
   uploadFile: async function (slug, formData) {
     const response = await fetch(`${API_BASE}/workspace/${slug}/upload`, {
       method: "POST",

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/ResetDatabase/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/ResetDatabase/index.jsx
@@ -34,7 +34,7 @@ export default function ResetDatabase({ workspace }) {
       disabled={deleting}
       onClick={resetVectorDatabase}
       type="button"
-      className="w-fit transition-all duration-300 border border-transparent rounded-lg whitespace-nowrap text-sm px-5 py-2.5 focus:z-10 bg-red-500/25 text-red-200 hover:text-white hover:bg-red-600 disabled:bg-red-600 disabled:text-red-200 disabled:animate-pulse"
+      className="border-none w-fit transition-all duration-300 border border-transparent rounded-lg whitespace-nowrap text-sm px-5 py-2.5 focus:z-10 bg-red-500/25 text-red-200 hover:text-white hover:bg-red-600 disabled:bg-red-600 disabled:text-red-200 disabled:animate-pulse"
     >
       {deleting ? "Clearing vectors..." : "Reset Workspace Vector Database"}
     </button>

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/ResetDatabase/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/ResetDatabase/index.jsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import Workspace from "@/models/workspace";
+import showToast from "@/utils/toast";
+
+export default function ResetDatabase({ workspace }) {
+  const [deleting, setDeleting] = useState(false);
+
+  const resetVectorDatabase = async () => {
+    if (
+      !window.confirm(
+        `You are about to reset this workspace's vector database. This will remove all vector embeddings currently embedded.\n\nThe original source files will remain untouched. This action is irreversible.`
+      )
+    )
+      return false;
+
+    setDeleting(true);
+    const success = await Workspace.wipeVectorDb(workspace.slug);
+    if (!success) {
+      showToast("Workspace vector database could not be reset!", "error", {
+        clear: true,
+      });
+      setDeleting(false);
+      return;
+    }
+
+    showToast("Workspace vector database was reset!", "success", {
+      clear: true,
+    });
+    setDeleting(false);
+  };
+
+  return (
+    <button
+      disabled={deleting}
+      onClick={resetVectorDatabase}
+      type="button"
+      className="w-fit transition-all duration-300 border border-transparent rounded-lg whitespace-nowrap text-sm px-5 py-2.5 focus:z-10 bg-red-500/25 text-red-200 hover:text-white hover:bg-red-600 disabled:bg-red-600 disabled:text-red-200 disabled:animate-pulse"
+    >
+      {deleting ? "Clearing vectors..." : "Reset Workspace Vector Database"}
+    </button>
+  );
+}

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/index.jsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react";
 import VectorDBIdentifier from "./VectorDBIdentifier";
 import MaxContextSnippets from "./MaxContextSnippets";
 import DocumentSimilarityThreshold from "./DocumentSimilarityThreshold";
+import ResetDatabase from "./ResetDatabase";
 
 export default function VectorDatabase({ workspace }) {
   const [hasChanges, setHasChanges] = useState(false);
@@ -43,6 +44,7 @@ export default function VectorDatabase({ workspace }) {
         workspace={workspace}
         setHasChanges={setHasChanges}
       />
+      <ResetDatabase workspace={workspace} />
       {hasChanges && (
         <button
           type="submit"


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

Add the ability to just reset the vector database for a workspace for various maintenance reasons without having to remove the entire workspace object and re-creating it.

### Additional Information

Add any other context about the Pull Request here that was not captured above.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
