### PR TITLE
Warn user when changing embedder with current progress already

### DIFF
--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -105,8 +105,8 @@ const SystemSettings = {
       // Embedder Provider Selection Settings & Configs
       // --------------------------------------------------------
       EmbeddingEngine: process.env.EMBEDDING_ENGINE,
-      HasExistingEmbeddings: await this.hasEmbeddings(), // check if they have any currently embedded documents
-      HasCachedEmbeddings: hasVectorCachedFiles(), // check if they ever embedded any documents.
+      HasExistingEmbeddings: await this.hasEmbeddings(), // check if they have any currently embedded documents active in workspaces.
+      HasCachedEmbeddings: hasVectorCachedFiles(), // check if they any currently cached embedded docs.
       EmbeddingBasePath: process.env.EMBEDDING_BASE_PATH,
       EmbeddingModelPref: process.env.EMBEDDING_MODEL_PREF,
       EmbeddingModelMaxChunkLength:

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -87,6 +87,7 @@ const SystemSettings = {
     },
   },
   currentSettings: async function () {
+    const { hasVectorCachedFiles } = require("../utils/files");
     const llmProvider = process.env.LLM_PROVIDER;
     const vectorDB = process.env.VECTOR_DB;
     return {
@@ -104,7 +105,8 @@ const SystemSettings = {
       // Embedder Provider Selection Settings & Configs
       // --------------------------------------------------------
       EmbeddingEngine: process.env.EMBEDDING_ENGINE,
-      HasExistingEmbeddings: await this.hasEmbeddings(),
+      HasExistingEmbeddings: await this.hasEmbeddings(), // check if they have any currently embedded documents
+      HasCachedEmbeddings: hasVectorCachedFiles(), // check if they ever embedded any documents.
       EmbeddingBasePath: process.env.EMBEDDING_BASE_PATH,
       EmbeddingModelPref: process.env.EMBEDDING_MODEL_PREF,
       EmbeddingModelMaxChunkLength:

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -192,6 +192,19 @@ function normalizePath(filepath = "") {
   return result;
 }
 
+// Check if the vector-cache folder is empty or not
+// useful for it the user is changing embedders as this will
+// break the previous cache.
+function hasVectorCachedFiles() {
+  try {
+    return (
+      fs.readdirSync(vectorCachePath)?.filter((name) => name.endsWith(".json"))
+        .length !== 0
+    );
+  } catch {}
+  return false;
+}
+
 module.exports = {
   findDocumentInDocuments,
   cachedVectorInformation,
@@ -203,4 +216,5 @@ module.exports = {
   normalizePath,
   isWithin,
   documentsPath,
+  hasVectorCachedFiles,
 };


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1131


### What is in this change?

Warn the user when they are changing their embedding provider or model from a previous engine/model and they have currently embedded documents or even _cached_ embeddings as the incongruent dimensions between cache and new embeddings (query or embed) will cause failed embeddings or failed chats on cached embeddings used in workspaces.

### Additional Information

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
