### PR TITLE
Fix Cannot read properties of undefined (reading 'length')

### DIFF
--- a/collector/processSingleFile/convert/asPDF.js
+++ b/collector/processSingleFile/convert/asPDF.js
@@ -22,7 +22,7 @@ async function asPDF({ fullFilePath = "", filename = "" }) {
         doc.metadata?.loc?.pageNumber || "unknown"
       } --`
     );
-    if (!doc.pageContent.length) continue;
+    if (!doc.pageContent || !doc.pageContent.length) continue;
     pageContent.push(doc.pageContent);
   }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

Fix TypeError: Cannot read properties of undefined (reading 'length').
Disregard the action of pushing the page content if the value of doc.pageContent is 'undefined'.

### Additional Information

The original error message is as below 
```
node:internal/modules/cjs/loader:1137
    at async /app/collector/index.js:41:11
    at async processSingleFile  (/app/collector/processSingleFile/index.js:69:10)
    at asPDF (/app/collector/processSingleFile/convert/asPDF.js:25:26)
TypeError: Cannot read properties of undefined (reading 'length')
```

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ x] I have tested my code functionality
- [ x] Docker build succeeds locally
