### PR TITLE
[FIX] Move to Workspace popup UI bug fix

### DIFF
--- a/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/MangeWorkspace/Documents/Directory/index.jsx
@@ -261,8 +261,8 @@ function Directory({
             )}
           </div>
           {amountSelected !== 0 && (
-            <div className="absolute bottom-[12px] left-0 right-0 flex justify-center">
-              <div className="mx-auto bg-white/40 rounded-lg py-1 px-2">
+            <div className="absolute bottom-[12px] left-0 right-0 flex justify-center pointer-events-none">
+              <div className="mx-auto bg-white/40 rounded-lg py-1 px-2 pointer-events-auto">
                 <div className="flex flex-row items-center gap-x-2">
                   <button
                     onClick={moveToWorkspace}


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1203 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fix "Move to Workspace" popup button transparent container bug
- Now allows user to click behind the transparent container and select files when the document picker is overflowing

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
