### PR TITLE
Prevent concurrent downloads on first-doc upload

### DIFF
--- a/server/utils/EmbeddingEngines/native/index.js
+++ b/server/utils/EmbeddingEngines/native/index.js
@@ -107,14 +107,21 @@ class NativeEmbedder {
       );
 
     let fetchResponse = await this.#fetchWithHost();
-    if (fetchResponse.pipeline !== null) return fetchResponse.pipeline;
+    if (fetchResponse.pipeline !== null) {
+      this.modelDownloaded = true;
+      return fetchResponse.pipeline;
+    }
 
     this.log(
       `Failed to download model from primary URL. Using fallback ${fetchResponse.retry}`
     );
     if (!!fetchResponse.retry)
       fetchResponse = await this.#fetchWithHost(fetchResponse.retry);
-    if (fetchResponse.pipeline !== null) return fetchResponse.pipeline;
+    if (fetchResponse.pipeline !== null) {
+      this.modelDownloaded = true;
+      return fetchResponse.pipeline;
+    }
+
     throw fetchResponse.error;
   }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1262 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
- User is on fresh installation of AnythingLLM with native embedder
- Uploads a document which results in more than 1 chunk
- Model will download from HuggingFace on chunk one
- On subsequent chunks the model attempts to download again and then tries to embed
- This pollutes the logs and results in unneeded cycles to attempt to download the pipeline even though it already exists.


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
