### PR TITLE
Fix typo leading to agent history in threads not being unique in same workspace

### DIFF
--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -35,7 +35,7 @@ class AgentHandler {
           {
             workspaceId: this.invocation.workspace_id,
             user_id: this.invocation.user_id || null,
-            thread_id: this.invocation.user_id || null,
+            thread_id: this.invocation.thread_id || null,
             include: true,
           },
           limit,


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1349


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
Typo in invocation thread filter not using `thread_id` leading to chats within the same workspace but different threads all being used. So thread 1 chats would be included in thread 2, confusing the agent with history.


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
