### PR TITLE
prevent accidental lockout from restricted chars in single pass mode

### DIFF
--- a/frontend/src/pages/GeneralSettings/Security/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Security/index.jsx
@@ -190,6 +190,7 @@ function MultiUserMode() {
   );
 }
 
+const PW_REGEX = new RegExp(/^[a-zA-Z0-9_\-!@$%^&*();]+$/);
 function PasswordProtection() {
   const [saving, setSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
@@ -200,10 +201,19 @@ function PasswordProtection() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (multiUserModeEnabled) return false;
+    const form = new FormData(e.target);
+
+    if (!PW_REGEX.test(form.get("password"))) {
+      showToast(
+        `Your password has restricted characters in it. Allowed symbols are _,-,!,@,$,%,^,&,*,(,),;`,
+        "error"
+      );
+      setSaving(false);
+      return;
+    }
 
     setSaving(true);
     setHasChanges(false);
-    const form = new FormData(e.target);
     const data = {
       usePassword,
       newPassword: form.get("password"),
@@ -323,9 +333,9 @@ function PasswordProtection() {
             </div>
             <div className="flex items-center justify-between space-x-14">
               <p className="text-white/80 text-xs rounded-lg w-96">
-                By default, you will be the only admin. As an admin you will
-                need to create accounts for all new users or admins. Do not lose
-                your password as only an Admin user can reset passwords.
+                By default, anyone with this password can log into the instance.
+                Do not lose this password as only the instance maintainer is
+                able to retrieve or reset the password once set.
               </p>
             </div>
           </div>

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -338,7 +338,7 @@ const KEY_MAPPING = {
   // System Settings
   AuthToken: {
     envKey: "AUTH_TOKEN",
-    checks: [requiresForceMode],
+    checks: [requiresForceMode, noRestrictedChars],
   },
   JWTSecret: {
     envKey: "JWT_SECRET",
@@ -571,6 +571,13 @@ async function validDockerizedUrl(input = "") {
 function validHuggingFaceEndpoint(input = "") {
   return input.slice(-6) !== ".cloud"
     ? `Your HF Endpoint should end in ".cloud"`
+    : null;
+}
+
+function noRestrictedChars(input = "") {
+  const regExp = new RegExp(/^[a-zA-Z0-9_\-!@$%^&*();]+$/);
+  return !regExp.test(input)
+    ? `Your password has restricted characters in it. It cannot contain backticks, quotes, or # signs.`
     : null;
 }
 

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -577,7 +577,7 @@ function validHuggingFaceEndpoint(input = "") {
 function noRestrictedChars(input = "") {
   const regExp = new RegExp(/^[a-zA-Z0-9_\-!@$%^&*();]+$/);
   return !regExp.test(input)
-    ? `Your password has restricted characters in it. It cannot contain backticks, quotes, or # signs.`
+    ? `Your password has restricted characters in it. Allowed symbols are _,-,!,@,$,%,^,&,*,(,),;`
     : null;
 }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1289


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

Prevent a password-protected instance from being self-owned by accidentally using `.env` file-protected chars in their password since they will be either removed or escaped and therefore the password will no longer match or will be broken on instance reboot as loading from the `.env` on boot will only boot what the system can read as opposed to what the user actually wanted the password to be.

Regex: `/^[a-zA-Z0-9_\-!@$%^&*();]+$/`

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
