### PR TITLE
[FEAT] Confluence Data Connector handles custom Confluence urls

### DIFF
--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -2,20 +2,30 @@ const fs = require("fs");
 const path = require("path");
 const { default: slugify } = require("slugify");
 const { v4 } = require("uuid");
+const UrlPattern = require("url-pattern");
 const { writeToServerDocuments } = require("../../files");
 const { tokenizeString } = require("../../tokenizer");
-const {
-  ConfluencePagesLoader,
-} = require("langchain/document_loaders/web/confluence");
+const { ConfluencePagesLoader } = require("langchain/document_loaders/web/confluence");
 
 function validSpaceUrl(spaceUrl = "") {
-  const UrlPattern = require("url-pattern");
-  const pattern = new UrlPattern(
-    "https\\://(:subdomain).atlassian.net/wiki/spaces/(:spaceKey)*"
-  );
-  const match = pattern.match(spaceUrl);
-  if (!match) return { valid: false, result: null };
-  return { valid: true, result: match };
+  // Atlassian default URL match
+  const atlassianPattern = new UrlPattern("https\\://(:subdomain).atlassian.net/wiki/spaces/(:spaceKey)/*");
+  const atlassianMatch = atlassianPattern.match(spaceUrl);
+  if (atlassianMatch) {
+    return { valid: true, result: atlassianMatch };
+  }
+
+  // Custom Confluence URL match
+  const customPattern = new UrlPattern("https\\://(:subdomain.):domain.:tld/wiki/spaces/(:spaceKey)/*");
+  const customMatch = customPattern.match(spaceUrl);
+  if (customMatch) {
+    customMatch.customDomain = (customMatch.subdomain ? `${customMatch.subdomain}.` : "") + //
+      (`${customMatch.domain}.${customMatch.tld}`);
+    return { valid: true, result: customMatch, custom: true };
+  }
+
+  // No match
+  return { valid: false, result: null };
 }
 
 async function loadConfluence({ pageUrl, username, accessToken }) {
@@ -31,15 +41,19 @@ async function loadConfluence({ pageUrl, username, accessToken }) {
   if (!validSpace.result) {
     return {
       success: false,
-      reason:
-        "Confluence space URL is not in the expected format of https://domain.atlassian.net/wiki/space/~SPACEID/*",
+      reason: "Confluence space URL is not in the expected format of https://domain.atlassian.net/wiki/space/~SPACEID/* or https://customDomain/wiki/space/~SPACEID/*",
     };
   }
 
-  const { subdomain, spaceKey } = validSpace.result;
-  console.log(`-- Working Confluence ${subdomain}.atlassian.net --`);
+  const { subdomain, customDomain, spaceKey } = validSpace.result;
+  let baseUrl = `https://${subdomain}.atlassian.net/wiki`;
+  if (customDomain) {
+    baseUrl = `https://${customDomain}/wiki`;
+  }
+
+  console.log(`-- Working Confluence ${baseUrl} --`);
   const loader = new ConfluencePagesLoader({
-    baseUrl: `https://${subdomain}.atlassian.net/wiki`,
+    baseUrl,
     spaceKey,
     username,
     accessToken,

--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -5,22 +5,29 @@ const { v4 } = require("uuid");
 const UrlPattern = require("url-pattern");
 const { writeToServerDocuments } = require("../../files");
 const { tokenizeString } = require("../../tokenizer");
-const { ConfluencePagesLoader } = require("langchain/document_loaders/web/confluence");
+const {
+  ConfluencePagesLoader,
+} = require("langchain/document_loaders/web/confluence");
 
 function validSpaceUrl(spaceUrl = "") {
   // Atlassian default URL match
-  const atlassianPattern = new UrlPattern("https\\://(:subdomain).atlassian.net/wiki/spaces/(:spaceKey)/*");
+  const atlassianPattern = new UrlPattern(
+    "https\\://(:subdomain).atlassian.net/wiki/spaces/(:spaceKey)/*"
+  );
   const atlassianMatch = atlassianPattern.match(spaceUrl);
   if (atlassianMatch) {
     return { valid: true, result: atlassianMatch };
   }
 
   // Custom Confluence URL match
-  const customPattern = new UrlPattern("https\\://(:subdomain.):domain.:tld/wiki/spaces/(:spaceKey)/*");
+  const customPattern = new UrlPattern(
+    "https\\://(:subdomain.):domain.:tld/wiki/spaces/(:spaceKey)/*"
+  );
   const customMatch = customPattern.match(spaceUrl);
   if (customMatch) {
-    customMatch.customDomain = (customMatch.subdomain ? `${customMatch.subdomain}.` : "") + //
-      (`${customMatch.domain}.${customMatch.tld}`);
+    customMatch.customDomain =
+      (customMatch.subdomain ? `${customMatch.subdomain}.` : "") + //
+      `${customMatch.domain}.${customMatch.tld}`;
     return { valid: true, result: customMatch, custom: true };
   }
 
@@ -41,7 +48,8 @@ async function loadConfluence({ pageUrl, username, accessToken }) {
   if (!validSpace.result) {
     return {
       success: false,
-      reason: "Confluence space URL is not in the expected format of https://domain.atlassian.net/wiki/space/~SPACEID/* or https://customDomain/wiki/space/~SPACEID/*",
+      reason:
+        "Confluence space URL is not in the expected format of https://domain.atlassian.net/wiki/space/~SPACEID/* or https://customDomain/wiki/space/~SPACEID/*",
     };
   }
 


### PR DESCRIPTION
### Pull Request Type
- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #1347

### What is in this change?

Confluence Data Connector used to only handle the hardcoded `{subdomain}.atlassian.net/wiki/spaces/(:spaceKey)/*`. Now it also handles custom confluence URLs like `(:subdomain.):domain.:tld/wiki/spaces/(:spaceKey)/*`.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
