### PR TITLE
Patch WSS upgrade for manual HTTPS certs

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -19,3 +19,6 @@ public/
 documents
 vector-cache
 yarn-error.log
+
+# Local SSL Certs for HTTPS
+sslcert

--- a/server/index.js
+++ b/server/index.js
@@ -38,7 +38,7 @@ app.use(
 
 if (!!process.env.ENABLE_HTTPS) {
   const server = bootSSL(app, process.env.SERVER_PORT || 3001)?.server;
-  require("express-ws")(app, server); // User same certificate + server for WSS connections
+  require("express-ws")(app, server); // Apply same certificate + server for WSS connections
 } else {
   require("express-ws")(app);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -36,7 +36,13 @@ app.use(
   })
 );
 
-require("express-ws")(app);
+if (!!process.env.ENABLE_HTTPS) {
+  const server = bootSSL(app, process.env.SERVER_PORT || 3001)?.server;
+  require("express-ws")(app, server); // User same certificate + server for WSS connections
+} else {
+  require("express-ws")(app);
+}
+
 app.use("/api", apiRouter);
 systemEndpoints(apiRouter);
 extensionEndpoints(apiRouter);
@@ -109,8 +115,4 @@ app.all("*", function (_, response) {
   response.sendStatus(404);
 });
 
-if (!!process.env.ENABLE_HTTPS) {
-  bootSSL(app, process.env.SERVER_PORT || 3001);
-} else {
-  bootHTTP(app, process.env.SERVER_PORT || 3001);
-}
+if (!process.env.ENABLE_HTTPS) bootHTTP(app, process.env.SERVER_PORT || 3001);

--- a/server/index.js
+++ b/server/index.js
@@ -37,10 +37,9 @@ app.use(
 );
 
 if (!!process.env.ENABLE_HTTPS) {
-  const server = bootSSL(app, process.env.SERVER_PORT || 3001)?.server;
-  require("express-ws")(app, server); // Apply same certificate + server for WSS connections
+  bootSSL(app, process.env.SERVER_PORT || 3001);
 } else {
-  require("express-ws")(app);
+  require("express-ws")(app); // load WebSockets in non-SSL mode.
 }
 
 app.use("/api", apiRouter);
@@ -115,4 +114,6 @@ app.all("*", function (_, response) {
   response.sendStatus(404);
 });
 
+// In non-https mode we need to boot at the end since the server has not yet
+// started and is `.listen`ing.
 if (!process.env.ENABLE_HTTPS) bootHTTP(app, process.env.SERVER_PORT || 3001);

--- a/server/utils/boot/index.js
+++ b/server/utils/boot/index.js
@@ -12,16 +12,17 @@ function bootSSL(app, port = 3001) {
     const privateKey = fs.readFileSync(process.env.HTTPS_KEY_PATH);
     const certificate = fs.readFileSync(process.env.HTTPS_CERT_PATH);
     const credentials = { key: privateKey, cert: certificate };
+    const server = https.createServer(credentials, app);
 
-    https
-      .createServer(credentials, app)
+    server
       .listen(port, async () => {
         await setupTelemetry();
         new CommunicationKey(true);
         console.log(`Primary server in HTTPS mode listening on port ${port}`);
       })
       .on("error", catchSigTerms);
-    return app;
+
+    return { app, server };
   } catch (e) {
     console.error(
       `\x1b[31m[SSL BOOT FAILED]\x1b[0m ${e.message} - falling back to HTTP boot.`,
@@ -46,7 +47,8 @@ function bootHTTP(app, port = 3001) {
       console.log(`Primary server in HTTP mode listening on port ${port}`);
     })
     .on("error", catchSigTerms);
-  return app;
+
+  return { app, server: null };
 }
 
 function catchSigTerms() {

--- a/server/utils/boot/index.js
+++ b/server/utils/boot/index.js
@@ -22,6 +22,7 @@ function bootSSL(app, port = 3001) {
       })
       .on("error", catchSigTerms);
 
+    require("express-ws")(app, server); // Apply same certificate + server for WSS connections
     return { app, server };
   } catch (e) {
     console.error(


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1417


### What is in this change?

Patch `@agents` directive not working when running AnythingLLM Docker in HTTPS mode. The certificate would not apply to the WebSocket connection and therefore upgrading from HTTPS<>WSS would fail as the socket was only WS.

This patch fixes that to where AnythingLLM does _not need to be run_ behind a proxy like Nginx in order to have the full system on SSL on the same cert.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
