### PR TITLE
Add API endpoint for updating pin status

### DIFF
--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -448,6 +448,73 @@ function apiWorkspaceEndpoints(app) {
   );
 
   app.post(
+    "/v1/workspace/:slug/update-pin",
+    [validApiKey],
+    async (request, response) => {
+      /*
+      #swagger.tags = ['Workspaces']
+      #swagger.description = 'Add or remove pin from a document in a workspace by its unique slug.'
+      #swagger.path = '/workspace/{slug}/update-pin'
+      #swagger.parameters['slug'] = {
+          in: 'path',
+          description: 'Unique slug of workspace to find',
+          required: true,
+          type: 'string'
+      }
+      #swagger.requestBody = {
+        description: 'JSON object with the document path and pin status to update.',
+        required: true,
+        type: 'object',
+        content: {
+          "application/json": {
+            example: {
+              docPath: "custom-documents/my-pdf.pdf-hash.json",
+              pinStatus: true
+            }
+          }
+        }
+      }
+      #swagger.responses[200] = {
+        description: 'OK',
+        content: {
+          "application/json": {
+            schema: {
+              type: 'object',
+              example: {
+                message: 'Pin status updated successfully'
+              }
+            }
+          }
+        }
+      }
+      #swagger.responses[404] = {
+        description: 'Document not found'
+      }
+      #swagger.responses[500] = {
+        description: 'Internal Server Error'
+      }
+      */
+      try {
+        const { slug = null } = request.params;
+        const { docPath, pinStatus = false } = reqBody(request);
+        const workspace = await Workspace.get({ slug });
+  
+        const document = await Document.get({
+          workspaceId: workspace.id,
+          docpath: docPath,
+        });
+        if (!document) return response.sendStatus(404).end();
+  
+        await Document.update(document.id, { pinned: pinStatus });
+        return response.status(200).json({ message: 'Pin status updated successfully' }).end();
+      } catch (error) {
+        console.error("Error processing the pin status update:", error);
+        return response.status(500).end();
+      }
+    }
+  );
+
+  app.post(
     "/v1/workspace/:slug/chat",
     [validApiKey],
     async (request, response) => {

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -1999,6 +1999,73 @@
           }
         }
       }
+    },"/v1/workspace/{slug}/update-pin": {
+      "post": {
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Add or remove pin from a document in a workspace by its unique slug.",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique slug of workspace to find"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "message": "Pin status updated successfully"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Document not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "description": "JSON object with the document path and pin status to update.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "docPath": {
+                    "type": "string",
+                    "example": "custom-documents/my-pdf.pdf-hash.json"
+                  },
+                  "pinStatus": {
+                    "type": "boolean",
+                    "example": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "/v1/workspace/{slug}/chat": {
       "post": {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #1051 

### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

<!-- Add any other context about the Pull Request here that was not captured above. -->

This pull request introduces a new API endpoint to update the pin status of a document within a workspace.
#### Key Changes:
1. **New Endpoint**:
   - **Path**: `/workspace/:slug/update-pin`
   - **Method**: `POST`
   - **Description**: Allows users to add or remove the pin status of a specified document in a workspace.

2. **Endpoint Details**:
   - **Parameters**:
     - `slug`: Unique identifier of the workspace (in path).
     - `Authorization`: Token (in header).
   - **Request Body**:
     ```json
     {
       "docPath": "custom-documents/my-pdf.pdf-hash.json",
       "pinStatus": true
     }
     ```
   - **Responses**:
     - `200 OK`: Pin status updated successfully.
     - `404 Not Found`: Document not found.
     - `500 Internal Server Error`: Internal server error.

3. **Documentation**:
   - Added the new endpoint to `openapi.json` for easy reference in Swagger UI at `http://localhost:3001/api-docs`.

   These changes enhance document management by allowing users to efficiently update pin statuses via the API.
---

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
