### PR TITLE
Allow setting of safety thresholds for Gemini

### DIFF
--- a/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
@@ -19,25 +19,47 @@ export default function GeminiLLMOptions({ settings }) {
         </div>
 
         {!settings?.credentialsOnly && (
-          <div className="flex flex-col w-60">
-            <label className="text-white text-sm font-semibold block mb-4">
-              Chat Model Selection
-            </label>
-            <select
-              name="GeminiLLMModelPref"
-              defaultValue={settings?.GeminiLLMModelPref || "gemini-pro"}
-              required={true}
-              className="bg-zinc-900 border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
-            >
-              {["gemini-pro", "gemini-1.5-pro-latest"].map((model) => {
-                return (
-                  <option key={model} value={model}>
-                    {model}
-                  </option>
-                );
-              })}
-            </select>
-          </div>
+          <>
+            <div className="flex flex-col w-60">
+              <label className="text-white text-sm font-semibold block mb-4">
+                Chat Model Selection
+              </label>
+              <select
+                name="GeminiLLMModelPref"
+                defaultValue={settings?.GeminiLLMModelPref || "gemini-pro"}
+                required={true}
+                className="bg-zinc-900 border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+              >
+                {["gemini-pro", "gemini-1.5-pro-latest"].map((model) => {
+                  return (
+                    <option key={model} value={model}>
+                      {model}
+                    </option>
+                  );
+                })}
+              </select>
+            </div>
+            <div className="flex flex-col w-60">
+              <label className="text-white text-sm font-semibold block mb-4">
+                Safety Setting
+              </label>
+              <select
+                name="GeminiSafetySetting"
+                defaultValue={
+                  settings?.GeminiSafetySetting || "BLOCK_MEDIUM_AND_ABOVE"
+                }
+                required={true}
+                className="bg-zinc-900 border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+              >
+                <option value="BLOCK_NONE">None</option>
+                <option value="BLOCK_ONLY_HIGH">Block few</option>
+                <option value="BLOCK_MEDIUM_AND_ABOVE">
+                  Block some (default)
+                </option>
+                <option value="BLOCK_LOW_AND_ABOVE">Block most</option>
+              </select>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -354,6 +354,8 @@ const SystemSettings = {
       // Gemini Keys
       GeminiLLMApiKey: !!process.env.GEMINI_API_KEY,
       GeminiLLMModelPref: process.env.GEMINI_LLM_MODEL_PREF || "gemini-pro",
+      GeminiSafetySetting:
+        process.env.GEMINI_SAFETY_SETTING || "BLOCK_MEDIUM_AND_ABOVE",
 
       // LMStudio Keys
       LMStudioBasePath: process.env.LMSTUDIO_BASE_PATH,

--- a/server/utils/AiProviders/gemini/index.js
+++ b/server/utils/AiProviders/gemini/index.js
@@ -10,7 +10,10 @@ class GeminiLLM {
       throw new Error("No Gemini API key was set.");
 
     // Docs: https://ai.google.dev/tutorials/node_quickstart
-    const { GoogleGenerativeAI } = require("@google/generative-ai");
+    const {
+      GoogleGenerativeAI,
+      HarmCategory,
+    } = require("@google/generative-ai");
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
     this.model =
       modelPreference || process.env.GEMINI_LLM_MODEL_PREF || "gemini-pro";
@@ -29,6 +32,7 @@ class GeminiLLM {
 
     this.embedder = embedder ?? new NativeEmbedder();
     this.defaultTemp = 0.7; // not used for Gemini
+    this.safetyThreshold = this.#fetchSafetyThreshold();
   }
 
   #appendContext(contextTexts = []) {
@@ -41,6 +45,41 @@ class GeminiLLM {
         })
         .join("")
     );
+  }
+
+  // BLOCK_NONE can be a special candidate for some fields
+  // https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-attributes#how_to_remove_automated_response_blocking_for_select_safety_attributes
+  // so if you are wondering why BLOCK_NONE still failed, the link above will explain why.
+  #fetchSafetyThreshold() {
+    const threshold =
+      process.env.GEMINI_SAFETY_SETTING ?? "BLOCK_MEDIUM_AND_ABOVE";
+    const safetyThresholds = [
+      "BLOCK_NONE",
+      "BLOCK_ONLY_HIGH",
+      "BLOCK_MEDIUM_AND_ABOVE",
+      "BLOCK_LOW_AND_ABOVE",
+    ];
+    return safetyThresholds.includes(threshold)
+      ? threshold
+      : "BLOCK_MEDIUM_AND_ABOVE";
+  }
+
+  #safetySettings() {
+    return [
+      {
+        category: "HARM_CATEGORY_HATE_SPEECH",
+        threshold: this.safetyThreshold,
+      },
+      {
+        category: "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        threshold: this.safetyThreshold,
+      },
+      { category: "HARM_CATEGORY_HARASSMENT", threshold: this.safetyThreshold },
+      {
+        category: "HARM_CATEGORY_DANGEROUS_CONTENT",
+        threshold: this.safetyThreshold,
+      },
+    ];
   }
 
   streamingEnabled() {
@@ -143,6 +182,7 @@ class GeminiLLM {
     )?.content;
     const chatThread = this.gemini.startChat({
       history: this.formatMessages(messages),
+      safetySettings: this.#safetySettings(),
     });
     const result = await chatThread.sendMessage(prompt);
     const response = result.response;
@@ -164,6 +204,7 @@ class GeminiLLM {
     )?.content;
     const chatThread = this.gemini.startChat({
       history: this.formatMessages(messages),
+      safetySettings: this.#safetySettings(),
     });
     const responseStream = await chatThread.sendMessageStream(prompt);
     if (!responseStream.stream)

--- a/server/utils/AiProviders/gemini/index.js
+++ b/server/utils/AiProviders/gemini/index.js
@@ -10,10 +10,7 @@ class GeminiLLM {
       throw new Error("No Gemini API key was set.");
 
     // Docs: https://ai.google.dev/tutorials/node_quickstart
-    const {
-      GoogleGenerativeAI,
-      HarmCategory,
-    } = require("@google/generative-ai");
+    const { GoogleGenerativeAI } = require("@google/generative-ai");
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
     this.model =
       modelPreference || process.env.GEMINI_LLM_MODEL_PREF || "gemini-pro";

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -52,6 +52,10 @@ const KEY_MAPPING = {
     envKey: "GEMINI_LLM_MODEL_PREF",
     checks: [isNotEmpty, validGeminiModel],
   },
+  GeminiSafetySetting: {
+    envKey: "GEMINI_SAFETY_SETTING",
+    checks: [validGeminiSafetySetting],
+  },
 
   // LMStudio Settings
   LMStudioBasePath: {
@@ -526,6 +530,18 @@ function validGeminiModel(input = "") {
   return validModels.includes(input)
     ? null
     : `Invalid Model type. Must be one of ${validModels.join(", ")}.`;
+}
+
+function validGeminiSafetySetting(input = "") {
+  const validModes = [
+    "BLOCK_NONE",
+    "BLOCK_ONLY_HIGH",
+    "BLOCK_MEDIUM_AND_ABOVE",
+    "BLOCK_LOW_AND_ABOVE",
+  ];
+  return validModes.includes(input)
+    ? null
+    : `Invalid Safety setting. Must be one of ${validModes.join(", ")}.`;
 }
 
 function validAnthropicModel(input = "") {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1465
resolves #1348


### What is in this change?

Allow user to specify safety setting while interacting with the Gemini API.

**Note:** The `BLOCK_NONE` threshold can be restricted on some accounts 
https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-attributes#how_to_remove_automated_response_blocking_for_select_safety_attributes


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
