### PR TITLE
Improve RAG responses via source backfilling

### DIFF
--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -151,16 +151,27 @@ async function chatWithWorkspace(
     };
   }
 
-  contextTexts = [...contextTexts, ...vectorSearchResults.contextTexts];
+  const { fillSourceWindow } = require("../helpers/chat");
+  const filledSources = fillSourceWindow({
+    nDocs: workspace?.topN || 4,
+    searchResults: vectorSearchResults.sources,
+    history: rawHistory,
+    filterIdentifiers: pinnedDocIdentifiers,
+  });
+
+  // Why does contextTexts get all the info, but sources only get current search?
+  // This is to give the ability of the LLM to "comprehend" a contextual response without
+  // populating the Citations under a response with documents the user "thinks" are irrelevant
+  // due to how we manage backfilling of the context to keep chats with the LLM more correct in responses.
+  // If a past citation was used to answer the question - that is visible in the history so it logically makes sense
+  // and does not appear to the user that a new response used information that is otherwise irrelevant for a given prompt.
+  // TLDR; reduces GitHub issues for "LLM citing document that has no answer in it" while keep answers highly accurate.
+  contextTexts = [...contextTexts, ...filledSources.contextTexts];
   sources = [...sources, ...vectorSearchResults.sources];
 
-  // If in query mode and no sources are found from the vector search and no pinned documents, do not
+  // If in query mode and no context chunks are found from search, backfill, or pins -  do not
   // let the LLM try to hallucinate a response or use general knowledge and exit early
-  if (
-    chatMode === "query" &&
-    vectorSearchResults.sources.length === 0 &&
-    pinnedDocIdentifiers.length === 0
-  ) {
+  if (chatMode === "query" && contextTexts.length === 0) {
     return {
       id: uuid,
       type: "textResponse",

--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -224,9 +224,7 @@ async function recentChatHistory({
   workspace,
   thread = null,
   messageLimit = 20,
-  chatMode = null,
 }) {
-  if (chatMode === "query") return { rawHistory: [], chatHistory: [] };
   const rawHistory = (
     await WorkspaceChats.where(
       {


### PR DESCRIPTION
 resolves #1240
 
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

> [!WARNING]
> This PR enables `query` to work with chat history now but **only** in the app. Behavior in the embed is the same.

In an effort to improve RAG results without adding unwarranted or "conditional" middleware like ReRankers, there is a lot of room for improvement of the traditional RAG pipeline AnythingLLM uses. This PR includes the ability to **backfill** sources during a chat session.

## What is backfilling?

Currently, AnythingLLM will append `Context` snippets to the `system` prompt on each chat. These contexts come from the attached VectorStores `.similaritySearch` method. While this works for direct questions this does not scale well as chat's become higher context or more vague. This leads to a bad RAG experience in a traditional chat, but is far worse in `query` where a follow-up query, that is contextually relevant, is deemed irrelevant.

## Example

**prompt 1**: "What is anythingllm?" 
-  possibly get 4 good sources and get a good LLM response as it is operating with high context.

**prompt 2**: "Tell me some features" 
  - This question is appropriate, topical, and a decent inquiry but standalone is quite vague when viewed outside of the context of the chat.
  - Possible get 0 - 1 maybe relevant sources
  - We now must rely on the _maybe_ existent snippet for source and hope the previous LLM response has something worth looking at

_introduced in this pr_

**prompt 1**: "What is anythingllm?" 
-  possibly get 4 good sources and get a good LLM response as it is operating with high context.

**prompt 2**: "Tell me some features" 
  - Possible get 0 - 1 maybe relevant sources
  - We now can backfill the context window in this order of priority
     - Pinned documents
     - This queries search results
     - Work backwards in chat history citations to backfill the source window to the workspace's assigned snippet window value.
 
 
 With this, we can now ensure that follow-up questions will be more relevant and contextually pertinent as a conversation continues. 
 
 **"What if the contextual topic changes"?**
 - This is handled as we prioritize sources from search results  first, then backfill in by more recent chats with historical references
 - If you have a relevant contextual change in the chat, those sources will take precedence over the historical ones and will become the new historical reference