### PR TITLE
Patch handling of end chunk stream events for OpenAI endpoints

### DIFF
--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -38,8 +38,13 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
         });
       }
 
-      // LocalAi returns '' and others return null.
-      if (message.finish_reason !== "" && message.finish_reason !== null) {
+      // LocalAi returns '' and others return null on chunks - the last chunk is not "" or null.
+      // Either way, the key `finish_reason` must be present to determine ending chunk.
+      if (
+        message.hasOwnProperty("finish_reason") &&
+        message.finish_reason !== "" &&
+        message.finish_reason !== null
+      ) {
         writeResponseChunk(response, {
           uuid,
           sources,

--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -41,7 +41,7 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
       // LocalAi returns '' and others return null on chunks - the last chunk is not "" or null.
       // Either way, the key `finish_reason` must be present to determine ending chunk.
       if (
-        message.hasOwnProperty("finish_reason") &&
+        message?.hasOwnProperty("finish_reason") && // Got valid message and it is an object with finish_reason
         message.finish_reason !== "" &&
         message.finish_reason !== null
       ) {
@@ -55,6 +55,7 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
         });
         response.removeListener("close", handleAbort);
         resolve(fullText);
+        break; // Break streaming when a valid finish_reason is first encountered
       }
     }
   });


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1475
resolves #1508

Impacted LLMS to test:
- [x] Generic OpenAI
- [x] OpenAI
- [x] GroqAI
- [x] HuggingFace
- [x] LMStudio
- [x] LocalAI
- [x] Mistral
- [x] Perplexity
- [x] TextWebGenUI
- [x] TogetherAI
- [x] LiteLLM


### What is in this change?
Path OpenAI stream handler to explicitly check for `finish_reason` key in message chunks before comparison as if it is non-existent it is` != ''` and `!= null` and ends the stream with no data responses.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
