### PR TITLE
patch: Auto thread renaming

### DIFF
--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
@@ -5,6 +5,7 @@ import { Plus, CircleNotch, Trash } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import ThreadItem from "./ThreadItem";
 import { useParams } from "react-router-dom";
+export const THREAD_RENAME_EVENT = "renameThread";
 
 export default function ThreadContainer({ workspace }) {
   const { threadSlug = null } = useParams();
@@ -25,10 +26,10 @@ export default function ThreadContainer({ workspace }) {
       );
     };
 
-    window.addEventListener("renameThread", chatHandler);
+    window.addEventListener(THREAD_RENAME_EVENT, chatHandler);
 
     return () => {
-      window.removeEventListener("renameThread", chatHandler);
+      window.removeEventListener(THREAD_RENAME_EVENT, chatHandler);
     };
   }, []);
 

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -12,7 +12,6 @@ import handleSocketResponse, {
   AGENT_SESSION_END,
   AGENT_SESSION_START,
 } from "@/utils/chat/agent";
-import truncate from "truncate";
 
 export default function ChatContainer({ workspace, knownHistory = [] }) {
   const { threadSlug = null } = useParams();
@@ -39,19 +38,6 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
   const handleSubmit = async (event) => {
     event.preventDefault();
     if (!message || message === "") return false;
-
-    // If first message and it is a thread
-    // and message is not blank/whitespace,
-    // then send event to rename the thread
-    if (threadSlug && chatHistory.length === 0 && message.trim().length > 0) {
-      const truncatedName = truncate(message, 22);
-      window.dispatchEvent(
-        new CustomEvent("renameThread", {
-          detail: { threadSlug, newName: truncatedName },
-        })
-      );
-    }
-
     const prevChatHistory = [
       ...chatHistory,
       { content: message, role: "user" },

--- a/frontend/src/utils/chat/index.js
+++ b/frontend/src/utils/chat/index.js
@@ -1,3 +1,4 @@
+import { THREAD_RENAME_EVENT } from "@/components/Sidebar/ActiveWorkspaces/ThreadContainer";
 export const ABORT_STREAM_EVENT = "abort-chat-stream";
 
 // For handling of chat responses in the frontend by their various types.
@@ -135,6 +136,21 @@ export default function handleChat(
   if (action === "reset_chat") {
     // Chat was reset, keep reset message and clear everything else.
     setChatHistory([_chatHistory.pop()]);
+  }
+
+  // If thread was updated automatically based on chat prompt
+  // then we can handle the updating of the thread here.
+  if (action === "rename_thread") {
+    if (!!chatResult?.thread?.slug && chatResult.thread.name) {
+      window.dispatchEvent(
+        new CustomEvent(THREAD_RENAME_EVENT, {
+          detail: {
+            threadSlug: chatResult.thread.slug,
+            newName: chatResult.thread.name,
+          },
+        })
+      );
+    }
   }
 }
 

--- a/server/endpoints/chat.js
+++ b/server/endpoints/chat.js
@@ -199,11 +199,21 @@ function chatEndpoints(app) {
           thread
         );
 
+        // If thread was renamed emit event to frontend via special `action` response.
         await WorkspaceThread.autoRenameThread({
           thread,
           workspace,
           user,
           newName: truncate(message, 22),
+          onRename: (thread) => {
+            writeResponseChunk(response, {
+              action: "rename_thread",
+              thread: {
+                slug: thread.slug,
+                name: thread.name,
+              },
+            });
+          },
         });
 
         await Telemetry.sendTelemetry("sent_chat", {


### PR DESCRIPTION
- Do not rename threads if already named
- Move update to `chatHandler` action emitter
- Remove logic from frontend to rename the thread based in chat container.