### PR TITLE
1693 get workspace users api

### DIFF
--- a/server/endpoints/api/admin/index.js
+++ b/server/endpoints/api/admin/index.js
@@ -426,7 +426,60 @@ function apiAdminEndpoints(app) {
       }
     }
   );
+  app.get(
+    "/v1/admin/workspaces/:workspaceId/users", 
+    [validApiKey], 
+    async (request, response) => {
+    /*
+      #swagger.tags = ['Admin']
+      #swagger.path = '/v1/admin/workspaces/{workspaceId}/users'
+      #swagger.parameters['workspaceId'] = {
+        in: 'path',
+        description: 'id of the workspace.',
+        required: true,
+        type: 'string'
+      }
+      #swagger.description = 'Retrieve a list of users with permissions to access the specified workspace.'
+      #swagger.responses[200] = {
+        content: {
+          "application/json": {
+            schema: {
+              type: 'object',
+              example: {
+                users: [
+                  {"userId": 1, "role": "admin"},
+                  {"userId": 2, "role": "member"}
+                ]
+              }
+            }
+          }
+        }
+      }
+      #swagger.responses[403] = {
+        schema: {
+          "$ref": "#/definitions/InvalidAPIKey"
+        }
+      }
+       #swagger.responses[401] = {
+        description: "Instance is not in Multi-User mode. Method denied",
+      }
+      */
+      
+      try {
+        if (!multiUserMode(response)) {
+          response.sendStatus(401).end();
+          return;
+        }
 
+        const workspaceId = request.params.workspaceId;
+        const users = await Workspace.workspaceUsers(workspaceId);
+        
+        response.status(200).json({ users });
+      } catch (e) {
+        console.error(e);
+        response.sendStatus(500).end();
+      }
+  });
   app.post(
     "/v1/admin/workspaces/:workspaceId/update-users",
     [validApiKey],
@@ -494,7 +547,6 @@ function apiAdminEndpoints(app) {
       }
     }
   );
-
   app.post(
     "/v1/admin/workspace-chats",
     [validApiKey],

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -502,6 +502,59 @@
         }
       }
     },
+    "/v1/admin/workspaces/:workspaceId/users": {
+      "get": {
+        "tags": ["Admin"],
+        "description": "Retrieve a list of users for the given workspace.",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the workspace whose users are to be retrieved."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK, successful operation. Returns a list of user IDs for the given workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {"type": "string"}
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized, not authorized to access resources in multi-user mode.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/workspaces/{workspaceId}/update-users": {
       "post": {
         "tags": [


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #1693  

### What is in this change?

Adds API endpoint and swagger docs to allow reading workspace membership by returning user ids who have access

It makes use of he existing workspaceUsers function:

https://github.com/Mintplex-Labs/anything-llm/blob/172543e1cdf5e8b4ae6603f61ddd98f0b59c8aba/server/models/workspace.js#L222

Adding the endpoint: 
`${API_BASE}/admin/workspaces/${workspaceId}/users`,

### Additional Information

Although this adds only one function - **Please review carefully** - I would not say it is fully tested.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
