### PR TITLE
fix: sanitize filename before writing

### DIFF
--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -3,11 +3,11 @@ const path = require("path");
 const { default: slugify } = require("slugify");
 const { v4 } = require("uuid");
 const UrlPattern = require("url-pattern");
-const { writeToServerDocuments } = require("../../files");
+const { writeToServerDocuments, sanitizeFileName } = require("../../files");
 const { tokenizeString } = require("../../tokenizer");
 const {
   ConfluencePagesLoader,
-} = require("langchain/document_loaders/web/confluence");
+} = require("@langchain/community/document_loaders/web/confluence");
 
 async function loadConfluence({ pageUrl, username, accessToken }) {
   if (!pageUrl || !username || !accessToken) {
@@ -89,11 +89,11 @@ async function loadConfluence({ pageUrl, username, accessToken }) {
     console.log(
       `[Confluence Loader]: Saving ${doc.metadata.title} to ${outFolder}`
     );
-    writeToServerDocuments(
-      data,
-      `${slugify(doc.metadata.title)}-${data.id}`,
-      outFolderPath
+
+    const fileName = sanitizeFileName(
+      `${slugify(doc.metadata.title)}-${data.id}`
     );
+    writeToServerDocuments(data, fileName, outFolderPath);
   });
 
   return {

--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -7,7 +7,7 @@ const { writeToServerDocuments, sanitizeFileName } = require("../../files");
 const { tokenizeString } = require("../../tokenizer");
 const {
   ConfluencePagesLoader,
-} = require("@langchain/community/document_loaders/web/confluence");
+} = require("langchain/document_loaders/web/confluence");
 
 async function loadConfluence({ pageUrl, username, accessToken }) {
   if (!pageUrl || !username || !accessToken) {

--- a/collector/utils/files/index.js
+++ b/collector/utils/files/index.js
@@ -129,6 +129,11 @@ function normalizePath(filepath = "") {
   return result;
 }
 
+function sanitizeFileName(fileName) {
+  if (!fileName) return fileName;
+  return fileName.replace(/[<>:"\/\\|?*]/g, "_");
+}
+
 module.exports = {
   trashFile,
   isTextType,
@@ -137,4 +142,5 @@ module.exports = {
   wipeCollectorStorage,
   normalizePath,
   isWithin,
+  sanitizeFileName,
 };

--- a/collector/utils/files/index.js
+++ b/collector/utils/files/index.js
@@ -131,7 +131,7 @@ function normalizePath(filepath = "") {
 
 function sanitizeFileName(fileName) {
   if (!fileName) return fileName;
-  return fileName.replace(/[<>:"\/\\|?*]/g, "_");
+  return fileName.replace(/[<>:"\/\\|?*]/g, "");
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes: https://github.com/Mintplex-Labs/anything-llm/issues/1737


 ### Pull Request Type

- [x] 🐛 fix

### Relevant Issues

resolves #1737

### What is in this change?

Added a `sanitizeFileName` function to remove special chars in filename. This is used in `confluence connector` to safely write to fs

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
