### PR TITLE
[FIX] Fix manual input model pref for agents

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
@@ -1,7 +1,9 @@
 import useGetProviderModels, {
   DISABLED_PROVIDERS,
 } from "@/hooks/useGetProvidersModels";
+import paths from "@/utils/paths";
 import { useTranslation } from "react-i18next";
+import { Link, useParams } from "react-router-dom";
 
 // These models do NOT support function calling
 function supportedModel(provider, model = "") {
@@ -18,11 +20,32 @@ export default function AgentModelSelection({
   workspace,
   setHasChanges,
 }) {
+  const { slug } = useParams();
   const { defaultModels, customModels, loading } =
     useGetProviderModels(provider);
 
   const { t } = useTranslation();
-  if (DISABLED_PROVIDERS.includes(provider)) return null;
+  if (DISABLED_PROVIDERS.includes(provider)) {
+    return (
+      <div className="w-full h-10 justify-center items-center flex">
+        <p className="text-sm font-base text-white text-opacity-60 text-center">
+          Multi-model support is not supported for this provider yet.
+          <br />
+          Agent's will use{" "}
+          <Link
+            to={paths.workspace.settings.chatSettings(slug)}
+            className="underline"
+          >
+            the model set for the workspace
+          </Link>{" "}
+          or{" "}
+          <Link to={paths.settings.llmPreference()} className="underline">
+            the model set for the system.
+          </Link>
+        </p>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
@@ -2,6 +2,7 @@ import useGetProviderModels, {
   DISABLED_PROVIDERS,
 } from "@/hooks/useGetProvidersModels";
 import { useTranslation } from "react-i18next";
+
 export default function ChatModelSelection({
   provider,
   workspace,

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
@@ -3,8 +3,10 @@ import AnythingLLMIcon from "@/media/logo/anything-llm-icon.png";
 import WorkspaceLLMItem from "./WorkspaceLLMItem";
 import { AVAILABLE_LLM_PROVIDERS } from "@/pages/GeneralSettings/LLMPreference";
 import { CaretUpDown, MagnifyingGlass, X } from "@phosphor-icons/react";
-import ChatModelSelection from "../ChatModelSelection";
+import ChatModelSelection from "./ChatModelSelection";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import paths from "@/utils/paths";
 
 // Some providers can only be associated with a single model.
 // In that case there is no selection to be made so we can just move on.
@@ -148,7 +150,22 @@ export default function WorkspaceLLMSelection({
           </button>
         )}
       </div>
-      {!NO_MODEL_SELECTION.includes(selectedLLM) && (
+      {NO_MODEL_SELECTION.includes(selectedLLM) ? (
+        <>
+          {selectedLLM !== "default" && (
+            <div className="w-full h-10 justify-center items-center flex mt-4">
+              <p className="text-sm font-base text-white text-opacity-60 text-center">
+                Multi-model support is not supported for this provider yet.
+                <br />
+                This workspace will use{" "}
+                <Link to={paths.settings.llmPreference()} className="underline">
+                  the model set for the system.
+                </Link>
+              </p>
+            </div>
+          )}
+        </>
+      ) : (
         <div className="mt-4 flex flex-col gap-y-1">
           <ChatModelSelection
             provider={selectedLLM}

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -172,7 +172,7 @@ class AgentHandler {
       case "mistral":
         return "mistral-medium";
       case "generic-openai":
-        return "gpt-3.5-turbo";
+        return null;
       case "perplexity":
         return "sonar-small-online";
       case "textgenwebui":
@@ -184,9 +184,29 @@ class AgentHandler {
 
   #providerSetupAndCheck() {
     this.provider = this.invocation.workspace.agentProvider || "openai";
-    this.model =
-      this.invocation.workspace.agentModel || this.#providerDefault();
-    this.log(`Start ${this.#invocationUUID}::${this.provider}:${this.model}`);
+
+    // Providers that will not update the agentModel because they will manually enter
+    // the model name in the setup modal
+    const providersWithoutAgentModel = ["azure", "generic-openai"];
+
+    if (providersWithoutAgentModel.includes(this.provider)) {
+      switch (this.provider) {
+        case "azure":
+          this.model = process.env.OPEN_MODEL_PREF || this.#providerDefault();
+          break;
+        case "generic-openai":
+          this.model =
+            process.env.GENERIC_OPEN_AI_MODEL_PREF || this.#providerDefault();
+          break;
+      }
+    } else {
+      this.model =
+        this.invocation.workspace.agentModel || this.#providerDefault();
+    }
+
+    this.log(
+      `Start ${this.#invocationUUID}::${this.provider}${this.model ? `:${this.model}` : ""}`
+    );
     this.#checkSetup();
   }
 

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -212,9 +212,7 @@ class AgentHandler {
   #providerSetupAndCheck() {
     this.provider = this.invocation.workspace.agentProvider || "openai";
     this.model = this.#fetchModel();
-    this.log(
-      `Start ${this.#invocationUUID}::${this.provider}${this.model ? `:${this.model}` : ""}`
-    );
+    this.log(`Start ${this.#invocationUUID}::${this.provider}:${this.model}`);
     this.#checkSetup();
   }
 

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -10,6 +10,12 @@ const { USER_AGENT, WORKSPACE_AGENT } = require("./defaults");
 class AgentHandler {
   #invocationUUID;
   #funcsToLoad = [];
+  #noProviderModelDefault = {
+    azure: "OPEN_MODEL_PREF",
+    lmstudio: "LMSTUDIO_MODEL_PREF",
+    textgenwebui: null, // does not even use `model` in API req
+    "generic-openai": "GENERIC_OPEN_AI_MODEL_PREF",
+  };
   invocation = null;
   aibitat = null;
   channel = null;
@@ -182,28 +188,30 @@ class AgentHandler {
     }
   }
 
+  /**
+   * Finds or assumes the model preference value to use for API calls.
+   * If multi-model loading is supported, we use their agent model selection of the workspace
+   * If not supported, we attempt to fallback to the system provider value for the LLM preference
+   * and if that fails - we assume a reasonable base model to exist.
+   * @returns {string} the model preference value to use in API calls
+   */
+  #fetchModel() {
+    if (!Object.keys(this.#noProviderModelDefault).includes(this.provider))
+      return this.invocation.workspace.agentModel || this.#providerDefault();
+
+    // Provider has no reliable default (cant load many models) - so we need to look at system
+    // for the model param.
+    const sysModelKey = this.#noProviderModelDefault[this.provider];
+    if (!!sysModelKey)
+      return process.env[sysModelKey] ?? this.#providerDefault();
+
+    // If all else fails - look at the provider default list
+    return this.#providerDefault();
+  }
+
   #providerSetupAndCheck() {
     this.provider = this.invocation.workspace.agentProvider || "openai";
-
-    // Providers that will not update the agentModel because they will manually enter
-    // the model name in the setup modal
-    const providersWithoutAgentModel = ["azure", "generic-openai"];
-
-    if (providersWithoutAgentModel.includes(this.provider)) {
-      switch (this.provider) {
-        case "azure":
-          this.model = process.env.OPEN_MODEL_PREF || this.#providerDefault();
-          break;
-        case "generic-openai":
-          this.model =
-            process.env.GENERIC_OPEN_AI_MODEL_PREF || this.#providerDefault();
-          break;
-      }
-    } else {
-      this.model =
-        this.invocation.workspace.agentModel || this.#providerDefault();
-    }
-
+    this.model = this.#fetchModel();
     this.log(
       `Start ${this.#invocationUUID}::${this.provider}${this.model ? `:${this.model}` : ""}`
     );


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1840 

### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- On some LLM providers, the user needs to manually enter the model pref name and when doing this in the agent settings, it does not update the agentModel column in the workspace table so we need to grab the correct model from the environment and inject it into the agent on provider setup
- This fixes a bug where a user is using the Generic OpenAI LLM provider model and it never updates to the correct model (would always default back to gpt-3.5-turbo)

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
