### PR TITLE
[FIX] Hide TTS and more actions on chat reset message

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/ActionMenu/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/ActionMenu/index.jsx
@@ -33,7 +33,7 @@ function ActionMenu({ chatId, forkThread, isEditing, role }) {
     };
   }, []);
 
-  if (isEditing || role === "user") return null;
+  if (!chatId || isEditing || role === "user") return null;
 
   return (
     <div className="mt-2 -ml-0.5 relative" ref={menuRef}>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/index.jsx
@@ -16,7 +16,7 @@ export default function TTSMessage({ slug, chatId, message }) {
     getSettings();
   }, []);
 
-  if (loading) return null;
+  if (!chatId || loading) return null;
   if (provider !== "native")
     return <AsyncTTSMessage slug={slug} chatId={chatId} />;
   return <NativeTTSMessage message={message} />;


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1849 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- When using the `/reset` command, hide the TTS and more actions options
- Fixes a bug where a user tries to fork off of this message and would create a null workspace

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
