### PR TITLE
[FIX] PDFLoader module bug fix

### DIFF
--- a/collector/processSingleFile/convert/asPDF/PDFLoader/index.js
+++ b/collector/processSingleFile/convert/asPDF/PDFLoader/index.js
@@ -1,5 +1,4 @@
 const fs = require("fs").promises;
-const pdf = require("pdf-parse");
 
 class PDFLoader {
   constructor(filePath, { splitPages = true } = {}) {
@@ -9,54 +8,90 @@ class PDFLoader {
 
   async load() {
     const buffer = await fs.readFile(this.filePath);
+    const { getDocument, version } = await this.getPdfJS();
 
-    const options = {
-      pagerender: this.splitPages ? this.renderPage : null,
-    };
+    const pdf = await getDocument({
+      data: new Uint8Array(buffer),
+      useWorkerFetch: false,
+      isEvalSupported: false,
+      useSystemFonts: true,
+    }).promise;
 
-    const { text, numpages, info, metadata, version } = await pdf(
-      buffer,
-      options
-    );
+    const meta = await pdf.getMetadata().catch(() => null);
+    const documents = [];
 
-    if (!this.splitPages) {
-      return [
-        {
-          pageContent: text.trim(),
-          metadata: {
-            source: this.filePath,
-            pdf: { version, info, metadata, totalPages: numpages },
+    for (let i = 1; i <= pdf.numPages; i += 1) {
+      const page = await pdf.getPage(i);
+      const content = await page.getTextContent();
+
+      if (content.items.length === 0) {
+        continue;
+      }
+
+      let lastY;
+      const textItems = [];
+      for (const item of content.items) {
+        if ("str" in item) {
+          if (lastY === item.transform[5] || !lastY) {
+            textItems.push(item.str);
+          } else {
+            textItems.push(`\n${item.str}`);
+          }
+          lastY = item.transform[5];
+        }
+      }
+
+      const text = textItems.join("");
+      documents.push({
+        pageContent: text.trim(),
+        metadata: {
+          source: this.filePath,
+          pdf: {
+            version,
+            info: meta?.info,
+            metadata: meta?.metadata,
+            totalPages: pdf.numPages,
+          },
+          loc: { pageNumber: i },
+        },
+      });
+    }
+
+    if (this.splitPages) {
+      return documents;
+    }
+
+    if (documents.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        pageContent: documents.map((doc) => doc.pageContent).join("\n\n"),
+        metadata: {
+          source: this.filePath,
+          pdf: {
+            version,
+            info: meta?.info,
+            metadata: meta?.metadata,
+            totalPages: pdf.numPages,
           },
         },
-      ];
-    }
-
-    return this.pages.map((pageContent, index) => ({
-      pageContent: pageContent.trim(),
-      metadata: {
-        source: this.filePath,
-        pdf: { version, info, metadata, totalPages: numpages },
-        loc: { pageNumber: index + 1 },
       },
-    }));
+    ];
   }
 
-  pages = [];
-
-  renderPage = async (pageData) => {
-    const textContent = await pageData.getTextContent();
-    let lastY,
-      text = "";
-    for (const item of textContent.items) {
-      if (lastY !== item.transform[5] && lastY !== undefined) {
-        text += "\n";
-      }
-      text += item.str;
-      lastY = item.transform[5];
+  async getPdfJS() {
+    try {
+      const pdfjs = await import("pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js");
+      return { getDocument: pdfjs.getDocument, version: pdfjs.version };
+    } catch (e) {
+      console.error(e);
+      throw new Error(
+        "Failed to load pdf-parse. Please install it with eg. `npm install pdf-parse`."
+      );
     }
-    this.pages.push(text);
-    return text;
-  };
+  }
 }
 
 module.exports = PDFLoader;


### PR DESCRIPTION

 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1878 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fixes a bug where some files that are uploaded to the collector would throw a `bad XRef entry` error and crash the collector
- Update the logic of the PDFLoader to use the same logic as the LangChain PDFLoader with the abstractions ripped out
- No longer use `pdf-parse` directly for parsing PDF files due to it not having as robust error handling as using `pdf.js` the same way the LangChain PDFLoader does it

**NOTE: The LangChain PDFLoader imports `pdf-parse` as an easy way to access `pdf.js` since `pdf-parse` has multiple versions of `pdf.js` bundled in the library**

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
