### PR TITLE
bugfix: API new user return 400 if user creation failed

### DIFF
--- a/server/endpoints/api/admin/index.js
+++ b/server/endpoints/api/admin/index.js
@@ -134,7 +134,7 @@ function apiAdminEndpoints(app) {
       const newUserParams = reqBody(request);
       const { user: newUser, error } = await User.create(newUserParams);
       
-      if (newUser === null) {
+      if (!newUser) {
         // e.g., password is too short
         response.status(400).json({ user: newUser, error });
       } else {

--- a/server/endpoints/api/admin/index.js
+++ b/server/endpoints/api/admin/index.js
@@ -133,13 +133,7 @@ function apiAdminEndpoints(app) {
 
       const newUserParams = reqBody(request);
       const { user: newUser, error } = await User.create(newUserParams);
-      
-      if (!newUser) {
-        // e.g., password is too short
-        response.status(400).json({ user: newUser, error });
-      } else {
-        response.status(200).json({ user: newUser, error });
-      }
+      response.status(newUser ? 200 : 400).json({ user: newUser, error });
     } catch (e) {
       console.error(e);
       response.sendStatus(500).end();

--- a/server/endpoints/api/admin/index.js
+++ b/server/endpoints/api/admin/index.js
@@ -133,7 +133,13 @@ function apiAdminEndpoints(app) {
 
       const newUserParams = reqBody(request);
       const { user: newUser, error } = await User.create(newUserParams);
-      response.status(200).json({ user: newUser, error });
+      
+      if (newUser === null) {
+        // e.g., password is too short
+        response.status(400).json({ user: newUser, error });
+      } else {
+        response.status(200).json({ user: newUser, error });
+      }
     } catch (e) {
       console.error(e);
       response.sendStatus(500).end();


### PR DESCRIPTION
The client might not check the error field unless they realize it's a 4xx error instead of 200 success.


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
