### PR TITLE
rename chatCircle to chatBubble in readme

### DIFF
--- a/embed/README.md
+++ b/embed/README.md
@@ -63,7 +63,7 @@ REQUIRED data attributes:
 
 **Style Overrides**
 
-- `data-chat-icon` — The chat bubble icon show when chat is closed. Options are `plus`, `chatCircle`, `support`, `search2`, `search`, `magic`.
+- `data-chat-icon` — The chat bubble icon show when chat is closed. Options are `plus`, `chatBubble`, `support`, `search2`, `search`, `magic`.
 
 - `data-button-color` — The chat bubble background color shown when chat is closed. Value must be hex color code.
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves https://github.com/Mintplex-Labs/anything-llm/issues/1970


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
The embeded chat integration readme lists the data-chat-icon option chatCircle but it should be chatBubble. This PR changes the name of that style in the README.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
