### PR TITLE
Gemini Pro 1.5, API support for 2M context and new experimental model

### DIFF
--- a/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
@@ -35,6 +35,7 @@ export default function GeminiLLMOptions({ settings }) {
                   "gemini-1.0-pro",
                   "gemini-1.5-pro-latest",
                   "gemini-1.5-flash-latest",
+                  "gemini-1.5-pro-exp-0801",
                 ].map((model) => {
                   return (
                     <option key={model} value={model}>

--- a/frontend/src/hooks/useGetProvidersModels.js
+++ b/frontend/src/hooks/useGetProvidersModels.js
@@ -16,6 +16,7 @@ const PROVIDER_DEFAULT_MODELS = {
     "gemini-1.0-pro",
     "gemini-1.5-pro-latest",
     "gemini-1.5-flash-latest",
+    "gemini-1.5-pro-exp-0801",
   ],
   anthropic: [
     "claude-instant-1.2",

--- a/server/utils/AiProviders/gemini/index.js
+++ b/server/utils/AiProviders/gemini/index.js
@@ -96,7 +96,9 @@ class GeminiLLM {
       case "gemini-1.5-flash-latest":
         return 1_048_576;
       case "gemini-1.5-pro-latest":
-        return 1_048_576;
+        return 2_097_152;
+      case "gemini-1.5-pro-exp-0801":
+        return 2_097_152;
       default:
         return 30_720; // assume a gemini-pro model
     }
@@ -108,6 +110,7 @@ class GeminiLLM {
       "gemini-1.0-pro",
       "gemini-1.5-pro-latest",
       "gemini-1.5-flash-latest",
+      "gemini-1.5-pro-exp-0801",
     ];
     return validModels.includes(modelName);
   }

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -585,6 +585,7 @@ function validGeminiModel(input = "") {
     "gemini-1.0-pro",
     "gemini-1.5-pro-latest",
     "gemini-1.5-flash-latest",
+    "gemini-1.5-pro-exp-0801",
   ];
   return validModels.includes(input)
     ? null


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [X] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs


### What is in this change?

Increases the 1M Pro 1.5 token window to now supported 2M, and adds support for new experimental model

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
