### PR TITLE
2049 remove break that prevents fetching files from gitlab repo

### DIFF
--- a/collector/utils/extensions/RepoLoader/GitlabRepo/RepoLoader/index.js
+++ b/collector/utils/extensions/RepoLoader/GitlabRepo/RepoLoader/index.js
@@ -223,10 +223,6 @@ class GitLabRepoLoader {
         const objects = Array.isArray(data)
           ? data.filter((item) => item.type === "blob")
           : []; // only get files, not paths or submodules
-        if (objects.length === 0) {
-          fetching = false;
-          break;
-        }
 
         // Apply ignore path rules to found objects. If any rules match it is an invalid file path.
         console.log(


### PR DESCRIPTION
Remove unnecessary break that prevents checking next pages for blob objects.


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2049


### What is in this change?

Remove unnecessary if block with break that prevents checking next pages for blob objects in a large GitLab repository tree.

### Additional Information


### Developer Validations

- [X] I ran `yarn lint` from the root of the repo & committed changes
- [X] Relevant documentation has been updated
- [X] I have tested my code functionality
- [ ] Docker build succeeds locally
