### PR TITLE
Populate .env file using variable inside userdata script

### DIFF
--- a/cloud-deployments/digitalocean/terraform/user_data.tp1
+++ b/cloud-deployments/digitalocean/terraform/user_data.tp1
@@ -9,8 +9,10 @@ sudo systemctl enable docker
 sudo systemctl start docker  
   
 mkdir -p /home/anythingllm
-touch /home/anythingllm/.env
-  
+cat <<EOF >/home/anythingllm/.env
+${env_content}
+EOF
+
 sudo docker pull mintplexlabs/anythingllm
 sudo docker run -d -p 3001:3001 --cap-add SYS_ADMIN -v /home/anythingllm:/app/server/storage -v /home/anythingllm/.env:/app/server/.env -e STORAGE_DIR="/app/server/storage" mintplexlabs/anythingllm
 echo "Container ID: $(sudo docker ps --latest --quiet)"  


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1976 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

Variable for env file `env_content` is available https://github.com/Mintplex-Labs/anything-llm/blob/master/cloud-deployments/digitalocean/terraform/main.tf#L25 but not used inside the userdata script so added it. Now `.env` file will be populated inside the server.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
