### PR TITLE
Update the display to show 95% of the width on small screens, else 635px

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -112,7 +112,7 @@ export default function PromptInput({
         className="flex flex-col gap-y-1 rounded-t-lg md:w-3/4 w-full mx-auto max-w-xl items-center"
       >
         <div className="flex items-center rounded-lg md:mb-4">
-          <div className="w-[635px] bg-main-gradient shadow-2xl border border-white/50 rounded-2xl flex flex-col px-4 overflow-hidden">
+          <div className="w-[95vw] md:w-[635px] bg-main-gradient shadow-2xl border border-white/50 rounded-2xl flex flex-col px-4 overflow-hidden">
             <AttachmentManager attachments={attachments} />
             <div className="flex items-center w-full border-b-2 border-gray-500/50">
               <textarea


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2088

Here's a draft to help you fill out the sections:

### What is in this change?

This pull request introduces a minor CSS change to dynamically adjust the width of the interface based on the viewport size. Specifically, when the viewport width falls below 635 pixels, the interface will now take up 95% of the viewing window, ensuring that the full interface is visible and usable on smaller screens, such as mobile phones.

### Additional Information

This change is a temporary fix to address the immediate issue of the cutoff interface on mobile devices. While it does not provide a comprehensive mobile optimization solution, it improves the usability of the application on smaller screens. The fix is backwards compatible and does not introduce any breaking changes. 

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes _n/a_
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally _(not built, developed in GitHub codespaces)_
