### PR TITLE
fix(Dockerfile): remove hardcoded exposed port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -169,9 +169,6 @@ USER anythingllm
 ENV NODE_ENV=production
 ENV ANYTHING_LLM_RUNTIME=docker
 
-# Expose the server port
-EXPOSE 3001
-
 # Setup the healthcheck
 HEALTHCHECK --interval=1m --timeout=10s --start-period=1m \
   CMD /bin/bash /usr/local/bin/docker-healthcheck.sh || exit 1


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Exposed hardcoded port are causing "overriding" problems in Docker compose labels. In our use case, we are using traefik labels but the exposed port keeps overriding.


### What is in this change?

Remove exposed port. It might also be improper since we can override th SERVER_PORT making the expose port not usable


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
