### PR TITLE
Encryption in JWT for single-user password mode

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ['pipertts-support'] # put your current branch to create a build. Core team only.
+    branches: ['encrypt-jwt-value'] # put your current branch to create a build. Core team only.
     paths-ignore:
       - '**.md'
       - 'cloud-deployments/*'

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -51,6 +51,7 @@ const {
   generateRecoveryCodes,
 } = require("../utils/PasswordRecovery");
 const { SlashCommandPresets } = require("../models/slashCommandsPresets");
+const { EncryptionManager } = require("../utils/EncryptionManager");
 
 function systemEndpoints(app) {
   if (!app) return;
@@ -236,7 +237,7 @@ function systemEndpoints(app) {
         });
         response.status(200).json({
           valid: true,
-          token: makeJWT({ p: password }, "30d"),
+          token: makeJWT({ p: new EncryptionManager().encrypt(password) }, "30d"),
           message: null,
         });
       }

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -237,7 +237,10 @@ function systemEndpoints(app) {
         });
         response.status(200).json({
           valid: true,
-          token: makeJWT({ p: new EncryptionManager().encrypt(password) }, "30d"),
+          token: makeJWT(
+            { p: new EncryptionManager().encrypt(password) },
+            "30d"
+          ),
           message: null,
         });
       }


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?
As a convenience, we have always just included the plaintext password in the JWT so we can quickly compare with requests on the backend. While this does work and is mostly safe, if for whatever reason, the JWT was taken from the user's browser, then it could be used to directly login to the instance without needing to do a JWT replay.

This is very unlikely and only applies to single-user instances that are using simple password protection.

Now, we encrypt and decrypt this `p` value in the JWT, as a consequence any currently logged-in sessions under these conditions will be logged out as their previous token will not pass validation. All that needs to be done is for the user to log back in to get a compliant token.
