### PR TITLE
Fix tooltip showing on both sides of file picker

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
@@ -46,7 +46,7 @@ export default function WorkspaceFileRow({
       }`}
     >
       <div
-        data-tooltip-id={`directory-item-${item.url}`}
+        data-tooltip-id={`ws-directory-item-${item.url}`}
         className="col-span-10 w-fit flex gap-x-[4px] items-center relative"
       >
         <File
@@ -77,7 +77,7 @@ export default function WorkspaceFileRow({
         )}
       </div>
       <Tooltip
-        id={`directory-item-${item.url}`}
+        id={`ws-directory-item-${item.url}`}
         place="bottom"
         delayShow={800}
         className="tooltip invert z-99"


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2123


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fix bug where hovering on a file after being embedded into a workspace will make a tooltip appear on both the workspace table and My Documents table
- Patched by giving tooltips different IDs in workspace table

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
