### PR TITLE
Fix markdown styling for rendered images

### DIFF
--- a/frontend/src/utils/chat/markdown.js
+++ b/frontend/src/utils/chat/markdown.js
@@ -44,7 +44,19 @@ const markdown = markdownIt({
       "</pre></div>"
     );
   },
-}).use(markdownItKatex);
+});
+
+// Custom renderer for responsive images rendered in markdown
+markdown.renderer.rules.image = function (tokens, idx) {
+  const token = tokens[idx];
+  const srcIndex = token.attrIndex("src");
+  const src = token.attrs[srcIndex][1];
+  const alt = token.content || "";
+
+  return `<div class="w-full max-w-[800px]"><img src="${src}" alt="${alt}" class="w-full h-auto" /></div>`;
+};
+
+markdown.use(markdownItKatex);
 
 export default function renderMarkdown(text = "") {
   return markdown.render(text);


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2122 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fix an issue where images in markdown were being rendered in their full size
- Fixed by creating a custom renderer function for `markdown-it` 
- Image now takes up the full container size and is responsive with a max width of 800px

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
