### PR TITLE
Omit invalid `response.text` values and `prompts`

### DIFF
--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -1,6 +1,5 @@
 const { v4: uuidv4 } = require("uuid");
 const moment = require("moment");
-const { assert } = require("joi");
 
 function clientAbortedHandler(resolve, fullText) {
   console.log(

--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 const moment = require("moment");
+const { assert } = require("joi");
 
 function clientAbortedHandler(resolve, fullText) {
   console.log(
@@ -63,9 +64,24 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
 
 function convertToChatHistory(history = []) {
   const formattedHistory = [];
-  history.forEach((history) => {
-    const { prompt, response, createdAt, feedbackScore = null, id } = history;
+  for (const record of history) {
+    const { prompt, response, createdAt, feedbackScore = null, id } = record;
     const data = JSON.parse(response);
+
+    // In the event that a bad response was stored - we should skip its entire record
+    // because it was likely an error and cannot be used in chats and will fail to render on UI.
+    if (typeof prompt !== "string") {
+      console.log(
+        `[convertToChatHistory] ChatHistory #${record.id} prompt property is not a string - skipping record.`
+      );
+      continue;
+    } else if (typeof data.text !== "string") {
+      console.log(
+        `[convertToChatHistory] ChatHistory #${record.id} response.text property is not a string - skipping record.`
+      );
+      continue;
+    }
+
     formattedHistory.push([
       {
         role: "user",
@@ -84,21 +100,36 @@ function convertToChatHistory(history = []) {
         feedbackScore,
       },
     ]);
-  });
+  }
 
   return formattedHistory.flat();
 }
 
 function convertToPromptHistory(history = []) {
   const formattedHistory = [];
-  history.forEach((history) => {
-    const { prompt, response } = history;
+  for (const record of history) {
+    const { prompt, response } = record;
     const data = JSON.parse(response);
+
+    // In the event that a bad response was stored - we should skip its entire record
+    // because it was likely an error and cannot be used in chats and will fail to render on UI.
+    if (typeof prompt !== "string") {
+      console.log(
+        `[convertToPromptHistory] ChatHistory #${record.id} prompt property is not a string - skipping record.`
+      );
+      continue;
+    } else if (typeof data.text !== "string") {
+      console.log(
+        `[convertToPromptHistory] ChatHistory #${record.id} response.text property is not a string - skipping record.`
+      );
+      continue;
+    }
+
     formattedHistory.push([
       { role: "user", content: prompt },
       { role: "assistant", content: data.text },
     ]);
-  });
+  }
   return formattedHistory.flat();
 }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2108


### What is in this change?
- Enforces validation on `response.text` and `prompt` for history creation to prevent collision with other prompt formatting tools we apply per-model.
<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
