### PR TITLE
Fix multi-user setup bug for invalid username/password

### DIFF
--- a/frontend/src/pages/OnboardingFlow/Steps/UserSetup/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/UserSetup/index.jsx
@@ -288,6 +288,11 @@ const MyTeam = ({ setMultiUserLoginValid, myTeamSubmitRef, navigate }) => {
                   onChange={handleUsernameChange}
                 />
               </div>
+              <p className=" text-white text-opacity-80 text-xs font-base">
+                Username must be at least 6 characters long and only contain
+                lowercase letters, numbers, underscores, and hyphens with no
+                spaces.
+              </p>
               <div className="mt-4">
                 <label
                   htmlFor="name"
@@ -306,9 +311,8 @@ const MyTeam = ({ setMultiUserLoginValid, myTeamSubmitRef, navigate }) => {
                   onChange={handlePasswordChange}
                 />
               </div>
-              <p className="w-96 text-white text-opacity-80 text-xs font-base">
-                Username must be at least 6 characters long. Password must be at
-                least 8 characters long.
+              <p className=" text-white text-opacity-80 text-xs font-base">
+                Password must be at least 8 characters long.
               </p>
             </div>
           </div>

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -506,13 +506,15 @@ function systemEndpoints(app) {
           multiUserMode: true,
         });
         await EventLogs.logEvent("multi_user_mode_enabled", {}, user?.id);
-        response.status(200).json({ success: true, error: null });
+        response.status(200).json({ success: !!user, error });
       } catch (e) {
-        console.error(e.message, e);
-        response.status(500).json({
-          success: false,
-          error: "An unexpected error occurred.",
+        await User.delete({});
+        await SystemSettings._updateSettings({
+          multi_user_mode: false,
         });
+
+        console.error(e.message, e);
+        response.sendStatus(500).end();
       }
     }
   );

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -481,6 +481,15 @@ function systemEndpoints(app) {
           password,
           role: ROLES.admin,
         });
+
+        if (error || !user) {
+          response.status(400).json({
+            success: false,
+            error: error || "Failed to enable multi-user mode.",
+          });
+          return;
+        }
+
         await SystemSettings._updateSettings({
           multi_user_mode: true,
           limit_user_messages: false,
@@ -497,15 +506,13 @@ function systemEndpoints(app) {
           multiUserMode: true,
         });
         await EventLogs.logEvent("multi_user_mode_enabled", {}, user?.id);
-        response.status(200).json({ success: !!user, error });
+        response.status(200).json({ success: true, error: null });
       } catch (e) {
-        await User.delete({});
-        await SystemSettings._updateSettings({
-          multi_user_mode: false,
-        });
-
         console.error(e.message, e);
-        response.sendStatus(500).end();
+        response.status(500).json({
+          success: false,
+          error: "An unexpected error occurred.",
+        });
       }
     }
   );


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2129 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fixes a bug where during onboarding if a user is setting up multi-user mode and enters a username or password that does not meet validations for length or content it would lock the user out from the instance and require a full reset
- Patched by adding a check after `User.create()` is called to ensure the user was created successfully before enabling multi-user mode in `SystemSettings`

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
