### PR TITLE
Add RAG agent plugin to API agent

### DIFF
--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -188,6 +188,7 @@ class EphemeralAgentHandler extends AgentHandler {
     );
 
     this.#funcsToLoad = [
+      AgentPlugins.memory.name,
       AgentPlugins.docSummarizer.name,
       AgentPlugins.webScraping.name,
       ...(await agentSkillsFromSystemSettings()),
@@ -209,6 +210,10 @@ class EphemeralAgentHandler extends AgentHandler {
       model: this.model ?? "gpt-4o",
       chats: await this.#chatHistory(20),
       handlerProps: {
+        invocation: {
+          workspace: this.#workspace,
+          workspace_id: this.#workspace.id,
+        },
         log: this.log,
       },
     });

--- a/server/utils/boot/MetaGenerator.js
+++ b/server/utils/boot/MetaGenerator.js
@@ -166,7 +166,7 @@ class MetaGenerator {
   }
 
   async #fetchConfg() {
-    this.#log(`fetching custome meta tag settings...`);
+    this.#log(`fetching custom meta tag settings...`);
     const { SystemSettings } = require("../../models/systemSettings");
     const customTitle = await SystemSettings.getValueOrFallback(
       { label: "meta_page_title" },


### PR DESCRIPTION
Adds the RAG plugin to agents which was omitted to do lack of `invocation` handlerProp, which is now handled.