### PR TITLE
Mobile render fix

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -98,7 +98,7 @@ const HistoricalMessage = ({
               saveChanges={saveEditedMessage}
             />
           ) : (
-            <div>
+            <div className={'overflow-x-scroll break-words'}>
               <span
                 className={`flex flex-col gap-y-1`}
                 dangerouslySetInnerHTML={{


### PR DESCRIPTION
Allows for the reflowing of text and not breaking the parent box due of display flex container. Does not change any pre-existing classes only specifies further that it should stay inside.


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### What is in this change?

CSS on single div


### Additional Information

I'm serving locally via Docker so that I can look on mobile and then I saw this problem.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ x ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [ x ] I have tested my code functionality
- [ x ] Docker build succeeds locally
