### PR TITLE
Add ability to use Esc keypress to close modal for document selection

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/index.jsx
@@ -32,6 +32,20 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
     fetchWorkspace();
   }, [providedSlug, slug]);
 
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        hideModal();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [hideModal]);
+
   if (!workspace) return null;
 
   if (isMobile) {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #2220


### What is in this change?

This pull request adds the ability to close the modal dialogue for selecting documents in workspaces using the Escape key on the keyboard. Specifically, the changes include:

- Adding an event listener to the modal dialogue to listen for the Escape key press event.
- Closing the modal dialogue when the Escape key is pressed.

This change provides an additional option for users to dismiss the modal, improving the overall user experience and efficiency.

### Additional Information

This change addresses a feature request to improve the workflow for users who work with multiple workspaces and need to quickly switch between them. By allowing the Escape key to close the modal, users can reduce mouse movement and streamline their workflow. This change does not introduce any breaking changes or affect existing functionality.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
