### PR TITLE
match user prompts exactly not partially

### DIFF
--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -25,7 +25,10 @@ async function grepCommand(message, user = null) {
   // Allows multiple commands in one message
   let updatedMessage = message;
   for (const preset of userPresets) {
-    const regex = new RegExp(preset.command, "g");
+    const regex = new RegExp(
+      `(?:\\b\\s|^)(${preset.command})(?:\\b\\s|$)`,
+      "g"
+    );
     updatedMessage = updatedMessage.replace(regex, preset.prompt);
   }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #2244


### What is in this change?

This pull request introduces an update to the preset matching logic in Anything LLM. The changes ensure that the system accurately matches user-defined presets by applying stricter criteria. The new regex checks for either the start or end of a string, or a word boundary/whitespace, preventing incorrect matches of substrings. 

### Additional Information

Testing for the new regex implementation can be found here: [Regex Testing](https://regex101.com/r/lVusju/1). This update addresses the issue of incorrect matching between similar presets, enhancing the overall functionality and user experience.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
