### PR TITLE
Patch missing folder autogenerate for plugins

### DIFF
--- a/server/utils/agents/imported.js
+++ b/server/utils/agents/imported.js
@@ -46,12 +46,22 @@ class ImportedPlugin {
   }
 
   /**
+   * Checks if the plugin folder exists and if it does not, creates the folder.
+   */
+  static checkPluginFolderExists() {
+    const dir = path.resolve(pluginsPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    return;
+  }
+
+  /**
    * Loads plugins from `plugins` folder in storage that are custom loaded and defined.
    * only loads plugins that are active: true.
    * @returns {Promise<string[]>} - array of plugin names to be loaded later.
    */
   static async activeImportedPlugins() {
     const plugins = [];
+    this.checkPluginFolderExists();
     const folders = fs.readdirSync(path.resolve(pluginsPath));
     for (const folder of folders) {
       const configLocation = path.resolve(
@@ -72,6 +82,7 @@ class ImportedPlugin {
    */
   static listImportedPlugins() {
     const plugins = [];
+    this.checkPluginFolderExists();
     if (!fs.existsSync(pluginsPath)) return plugins;
 
     const folders = fs.readdirSync(path.resolve(pluginsPath));


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2271


### What is in this change?
If a user invoked agents but the plugin folder is missing - it will kill the agent until the folder exists.
This patch resolves the bug by creating the folder if it does not yet exist in storage directory.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
