### PR TITLE
#2317 Reduce workspace popup loading time by 98% when there are many files

### DIFF
--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -76,7 +76,8 @@ const Document = {
     clause = {},
     limit = null,
     orderBy = null,
-    include = null
+    include = null,
+    select = null
   ) {
     try {
       const results = await prisma.workspace_documents.findMany({
@@ -84,6 +85,7 @@ const Document = {
         ...(limit !== null ? { take: limit } : {}),
         ...(orderBy !== null ? { orderBy } : {}),
         ...(include !== null ? { include } : {}),
+        ...(select !== null ? { select: { ...select } } : {}),
       });
       return results;
     } catch (error) {

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -51,10 +51,7 @@ async function viewLocalFiles() {
         const filePath = path.join(folderPath, subfile);
         const rawData = fs.readFileSync(filePath, "utf8");
         const cachefilename = `${file}/${subfile}`;
-        filenames[cachefilename] = subfile;
-
         const { pageContent, ...metadata } = JSON.parse(rawData);
-
         const watchedInWorkspaces = liveSyncAvailable
           ? await Document.getOnlyWorkspaceIds({
               docpath: cachefilename,
@@ -73,6 +70,7 @@ async function viewLocalFiles() {
           // Is file watched in any workspace since sync updates all workspaces where file is referenced
           watched: watchedInWorkspaces.length !== 0,
         });
+        filenames[cachefilename] = subfile;
       }
 
       // Get documents pinned to at least one workspace.


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

connect #2317 

### What is in this change?

Reduces the loading time of the documents popup by fetching pinned documents once per folder.

Results on my local instance with ~14k files:
- loading time
  - before: 105 seconds
  - after: 2 seconds
- number of queries for pinned documents: 
  - before: ~14k
  - after: 8

#### Before

```
[0.05ms] Checked/created documentsPath
[1.28ms] Checked DocumentSyncQueue.enabled()
[2.29ms] Read subfolder: custom-documents
[122.83ms] Read subfolder: folder1
[205.92ms] Read subfolder: folder2
[301.90ms] Read subfolder: folder3
[336.27ms] Read subfolder: folder4
[35961.37ms] Read subfolder: folder5
[49814.86ms] Read subfolder: folder6
[51723.69ms] Read subfolder: folder7
[105922.62ms] Finished processing all folders and files

Function call timings summary:
  readFile: 1939.09ms
  parseJSON: 694.86ms
  getPinnedWorkspaces: 100892.30ms
  getWatchedWorkspaces: 6.67ms
  checkCachedVector: 1971.95ms
```

#### After

```
[0.05ms] Checked/created documentsPath
[11.17ms] Checked DocumentSyncQueue.enabled()
[12.08ms] Read subfolder: custom-documents
[54.88ms] Read subfolder: folder1
[65.54ms] Read subfolder: folder2
[74.09ms] Read subfolder: folder3
[90.14ms] Read subfolder: folder4
[648.97ms] Read subfolder: folder5
[781.37ms] Read subfolder: folder6
[817.45ms] Read subfolder: folder7
[1926.20ms] Finished processing all folders and files

Function call timings summary:
  readFile: 734.33ms
  parseJSON: 398.08ms
  getPinnedWorkspaces: 328.55ms
  getWatchedWorkspaces: 1.58ms
  checkCachedVector: 288.89ms
```

### Additional Information

An additional optional parameter `select` has been added to `Document.where`.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
