### PR TITLE
PR#2355 Continued + expanded scope

### DIFF
--- a/server/models/documentSyncQueue.js
+++ b/server/models/documentSyncQueue.js
@@ -38,6 +38,13 @@ const DocumentSyncQueue = {
     return new Date(Number(new Date()) + queueRecord.staleAfterMs);
   },
 
+  /**
+   * Check if the document can be watched based on the metadata fields
+   * @param {object} metadata - metadata to check
+   * @param {string} metadata.title - title of the document
+   * @param {string} metadata.chunkSource - chunk source of the document
+   * @returns {boolean} - true if the document can be watched, false otherwise
+   */
   canWatch: function ({ title, chunkSource = null } = {}) {
     if (chunkSource.startsWith("link://") && title.endsWith(".html"))
       return true; // If is web-link material (prior to feature most chunkSources were links://)

--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -57,21 +57,6 @@ const Document = {
     }
   },
 
-  getOnlyWorkspaceIds: async function (clause = {}) {
-    try {
-      const workspaceIds = await prisma.workspace_documents.findMany({
-        where: clause,
-        select: {
-          workspaceId: true,
-        },
-      });
-      return workspaceIds.map((record) => record.workspaceId) || [];
-    } catch (error) {
-      console.error(error.message);
-      return [];
-    }
-  },
-
   where: async function (
     clause = {},
     limit = null,

--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -76,7 +76,8 @@ const Document = {
     clause = {},
     limit = null,
     orderBy = null,
-    include = null
+    include = null,
+    select = null
   ) {
     try {
       const results = await prisma.workspace_documents.findMany({
@@ -84,6 +85,7 @@ const Document = {
         ...(limit !== null ? { take: limit } : {}),
         ...(orderBy !== null ? { orderBy } : {}),
         ...(include !== null ? { include } : {}),
+        ...(select !== null ? { select: { ...select } } : {}),
       });
       return results;
     } catch (error) {

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -52,13 +52,6 @@ async function viewLocalFiles() {
         const rawData = fs.readFileSync(filePath, "utf8");
         const cachefilename = `${file}/${subfile}`;
         const { pageContent, ...metadata } = JSON.parse(rawData);
-        const watchedInWorkspaces = liveSyncAvailable
-          ? await Document.getOnlyWorkspaceIds({
-              docpath: cachefilename,
-              watched: true,
-            })
-          : [];
-
         subdocs.items.push({
           name: subfile,
           type: "file",
@@ -67,42 +60,22 @@ async function viewLocalFiles() {
           canWatch: liveSyncAvailable
             ? DocumentSyncQueue.canWatch(metadata)
             : false,
-          // Is file watched in any workspace since sync updates all workspaces where file is referenced
-          watched: watchedInWorkspaces.length !== 0,
+          // pinnedWorkspaces: [], // This is the list of workspaceIds that have pinned this document
+          // watched: false, // boolean to indicate if this document is watched in ANY workspace
         });
         filenames[cachefilename] = subfile;
       }
 
-      // Get documents pinned to at least one workspace.
-      const pinnedWorkspacesByDocument = (
-        await Document.where(
-          {
-            docpath: {
-              in: Object.keys(filenames),
-            },
-            pinned: true,
-          },
-          null,
-          null,
-          null,
-          {
-            workspaceId: true,
-            docpath: true,
-          }
-        )
-      ).reduce((result, { workspaceId, docpath }) => {
-        const filename = filenames[docpath];
-        if (!result[filename]) {
-          result[filename] = [];
-        }
-        if (!result[filename].includes(workspaceId)) {
-          result[filename].push(workspaceId);
-        }
-        return result;
-      }, {});
-
+      // Grab the pinned workspaces and watched documents for this folder's documents
+      // at the time of the query so we don't have to re-query the database for each file
+      const pinnedWorkspacesByDocument =
+        await getPinnedWorkspacesByDocument(filenames);
+      const watchedDocumentsFilenames =
+        await getWatchedDocumentFilenames(filenames);
       for (const item of subdocs.items) {
         item.pinnedWorkspaces = pinnedWorkspacesByDocument[item.name] || [];
+        item.watched =
+          watchedDocumentsFilenames.hasOwnProperty(item.name) || false;
       }
 
       directory.items.push(subdocs);
@@ -118,8 +91,13 @@ async function viewLocalFiles() {
   return directory;
 }
 
-// Searches the vector-cache folder for existing information so we dont have to re-embed a
-// document and can instead push directly to vector db.
+/**
+ * Searches the vector-cache folder for existing information so we dont have to re-embed a
+ * document and can instead push directly to vector db.
+ * @param {string} filename - the filename to check for cached vector information
+ * @param {boolean} checkOnly - if true, only check if the file exists, do not return the cached data
+ * @returns {Promise<{exists: boolean, chunks: any[]}>} - a promise that resolves to an object containing the existence of the file and its cached chunks
+ */
 async function cachedVectorInformation(filename = null, checkOnly = false) {
   if (!filename) return checkOnly ? false : { exists: false, chunks: [] };
 
@@ -246,6 +224,61 @@ function hasVectorCachedFiles() {
     );
   } catch {}
   return false;
+}
+
+/**
+ * @param {string[]} filenames - array of filenames to check for pinned workspaces
+ * @returns {Promise<Record<string, string[]>>} - a record of filenames and their corresponding workspaceIds
+ */
+async function getPinnedWorkspacesByDocument(filenames = []) {
+  return (
+    await Document.where(
+      {
+        docpath: {
+          in: Object.keys(filenames),
+        },
+        pinned: true,
+      },
+      null,
+      null,
+      null,
+      {
+        workspaceId: true,
+        docpath: true,
+      }
+    )
+  ).reduce((result, { workspaceId, docpath }) => {
+    const filename = filenames[docpath];
+    if (!result[filename]) result[filename] = [];
+    if (!result[filename].includes(workspaceId))
+      result[filename].push(workspaceId);
+    return result;
+  }, {});
+}
+
+/**
+ * Get a record of filenames and their corresponding workspaceIds that have watched a document
+ * that will be used to determine if a document should be displayed in the watched documents sidebar
+ * @param {string[]} filenames - array of filenames to check for watched workspaces
+ * @returns {Promise<Record<string, string[]>>} - a record of filenames and their corresponding workspaceIds
+ */
+async function getWatchedDocumentFilenames(filenames = []) {
+  return (
+    await Document.where(
+      {
+        docpath: { in: Object.keys(filenames) },
+        watched: true,
+      },
+      null,
+      null,
+      null,
+      { workspaceId: true, docpath: true }
+    )
+  ).reduce((result, { workspaceId, docpath }) => {
+    const filename = filenames[docpath];
+    result[filename] = workspaceId;
+    return result;
+  }, {});
 }
 
 module.exports = {

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -51,10 +51,7 @@ async function viewLocalFiles() {
         const filePath = path.join(folderPath, subfile);
         const rawData = fs.readFileSync(filePath, "utf8");
         const cachefilename = `${file}/${subfile}`;
-        filenames[cachefilename] = subfile;
-
         const { pageContent, ...metadata } = JSON.parse(rawData);
-
         const watchedInWorkspaces = liveSyncAvailable
           ? await Document.getOnlyWorkspaceIds({
               docpath: cachefilename,
@@ -73,6 +70,7 @@ async function viewLocalFiles() {
           // Is file watched in any workspace since sync updates all workspaces where file is referenced
           watched: watchedInWorkspaces.length !== 0,
         });
+        filenames[cachefilename] = subfile;
       }
 
       // Get documents pinned to at least one workspace.


### PR DESCRIPTION
 Original PR by @blazeyo 
 
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2317 
closes #2355
resolves #928 

### What is in this change?

Reduces the loading time of the documents popup by fetching pinned documents once per folder.

Results on my local instance with ~14k files:
- loading time
  - before: 105 seconds
  - after: 2 seconds
- number of queries for pinned documents: 
  - before: ~14k
  - after: 8

#### Before

```
[0.05ms] Checked/created documentsPath
[1.28ms] Checked DocumentSyncQueue.enabled()
[2.29ms] Read subfolder: custom-documents
[122.83ms] Read subfolder: folder1
[205.92ms] Read subfolder: folder2
[301.90ms] Read subfolder: folder3
[336.27ms] Read subfolder: folder4
[35961.37ms] Read subfolder: folder5
[49814.86ms] Read subfolder: folder6
[51723.69ms] Read subfolder: folder7
[105922.62ms] Finished processing all folders and files

Function call timings summary:
  readFile: 1939.09ms
  parseJSON: 694.86ms
  getPinnedWorkspaces: 100892.30ms
  getWatchedWorkspaces: 6.67ms
  checkCachedVector: 1971.95ms
```

#### After

```
[0.05ms] Checked/created documentsPath
[11.17ms] Checked DocumentSyncQueue.enabled()
[12.08ms] Read subfolder: custom-documents
[54.88ms] Read subfolder: folder1
[65.54ms] Read subfolder: folder2
[74.09ms] Read subfolder: folder3
[90.14ms] Read subfolder: folder4
[648.97ms] Read subfolder: folder5
[781.37ms] Read subfolder: folder6
[817.45ms] Read subfolder: folder7
[1926.20ms] Finished processing all folders and files

Function call timings summary:
  readFile: 734.33ms
  parseJSON: 398.08ms
  getPinnedWorkspaces: 328.55ms
  getWatchedWorkspaces: 1.58ms
  checkCachedVector: 288.89ms
```

### Additional Information

An additional optional parameter `select` has been added to `Document.where`.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
