### PR TITLE
Add dropdown for confluence connector deployment

### DIFF
--- a/collector/utils/extensions/Confluence/ConfluenceLoader/index.js
+++ b/collector/utils/extensions/Confluence/ConfluenceLoader/index.js
@@ -13,6 +13,7 @@ class ConfluencePagesLoader {
     limit = 25,
     expand = "body.storage,version",
     personalAccessToken,
+    cloud = true,
   }) {
     this.baseUrl = baseUrl;
     this.spaceKey = spaceKey;
@@ -21,6 +22,7 @@ class ConfluencePagesLoader {
     this.limit = limit;
     this.expand = expand;
     this.personalAccessToken = personalAccessToken;
+    this.cloud = cloud;
   }
 
   get authorizationHeader() {
@@ -74,7 +76,11 @@ class ConfluencePagesLoader {
 
   // https://developer.atlassian.com/cloud/confluence/rest/v2/intro/#auth
   async fetchAllPagesInSpace(start = 0, limit = this.limit) {
-    const url = `${this.baseUrl}/wiki/rest/api/content?spaceKey=${this.spaceKey}&limit=${limit}&start=${start}&expand=${this.expand}`;
+    const url = `${this.baseUrl}${
+      this.cloud ? "/wiki" : ""
+    }/rest/api/content?spaceKey=${
+      this.spaceKey
+    }&limit=${limit}&start=${start}&expand=${this.expand}`;
     const data = await this.fetchConfluenceData(url);
     if (data.size === 0) {
       return [];

--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -13,7 +13,13 @@ const { ConfluencePagesLoader } = require("./ConfluenceLoader");
  * @returns
  */
 async function loadConfluence(
-  { baseUrl = null, spaceKey = null, username = null, accessToken = null },
+  {
+    baseUrl = null,
+    spaceKey = null,
+    username = null,
+    accessToken = null,
+    cloud = true,
+  },
   response
 ) {
   if (!baseUrl || !spaceKey || !username || !accessToken) {
@@ -45,6 +51,7 @@ async function loadConfluence(
     spaceKey,
     username,
     accessToken,
+    cloud,
   });
 
   const { docs, error } = await loader
@@ -66,7 +73,7 @@ async function loadConfluence(
     };
   }
   const outFolder = slugify(
-    `confluence-${origin}-${v4().slice(0, 4)}`
+    `confluence-${hostname}-${v4().slice(0, 4)}`
   ).toLowerCase();
 
   const outFolderPath =
@@ -91,7 +98,7 @@ async function loadConfluence(
       description: doc.metadata.title,
       docSource: `${origin} Confluence`,
       chunkSource: generateChunkSource(
-        { doc, baseUrl: origin, spaceKey, accessToken, username },
+        { doc, baseUrl: origin, spaceKey, accessToken, username, cloud },
         response.locals.encryptionWorker
       ),
       published: new Date().toLocaleString(),
@@ -130,6 +137,7 @@ async function fetchConfluencePage({
   spaceKey,
   username,
   accessToken,
+  cloud = true,
 }) {
   if (!pageUrl || !baseUrl || !spaceKey || !username || !accessToken) {
     return {
@@ -162,6 +170,7 @@ async function fetchConfluencePage({
     spaceKey,
     username,
     accessToken,
+    cloud,
   });
 
   const { docs, error } = await loader
@@ -225,7 +234,7 @@ function validBaseUrl(baseUrl) {
  * @returns {string}
  */
 function generateChunkSource(
-  { doc, baseUrl, spaceKey, accessToken, username },
+  { doc, baseUrl, spaceKey, accessToken, username, cloud },
   encryptionWorker
 ) {
   const payload = {
@@ -233,6 +242,7 @@ function generateChunkSource(
     spaceKey,
     token: accessToken,
     username,
+    cloud,
   };
   return `confluence://${doc.metadata.url}?payload=${encryptionWorker.encrypt(
     JSON.stringify(payload)

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Confluence/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Confluence/index.jsx
@@ -26,6 +26,7 @@ export default function ConfluenceOptions() {
         spaceKey: form.get("spaceKey"),
         username: form.get("username"),
         accessToken: form.get("accessToken"),
+        cloud: form.get("isCloud") === "true",
       });
 
       if (!!error) {
@@ -54,6 +55,31 @@ export default function ConfluenceOptions() {
         <form className="w-full" onSubmit={handleSubmit}>
           <div className="w-full flex flex-col py-2">
             <div className="w-full flex flex-col gap-4">
+              <div className="flex flex-col pr-10">
+                <div className="flex flex-col gap-y-1 mb-4">
+                  <label className="text-white text-sm font-bold flex gap-x-2 items-center">
+                    <p className="font-bold text-white">
+                      Confluence deployment type
+                    </p>
+                  </label>
+                  <p className="text-xs font-normal text-white/50">
+                    Determine if your Confluence instance is hosted on Atlassian
+                    cloud or self-hosted.
+                  </p>
+                </div>
+                <select
+                  name="isCloud"
+                  className="bg-zinc-900 text-white placeholder:text-white/20 text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  required={true}
+                  autoComplete="off"
+                  spellCheck={false}
+                  defaultValue="true"
+                >
+                  <option value="true">Atlassian Cloud</option>
+                  <option value="false">Self-hosted</option>
+                </select>
+              </div>
+
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
                   <label className="text-white text-sm font-bold flex gap-x-2 items-center">

--- a/frontend/src/models/dataConnector.js
+++ b/frontend/src/models/dataConnector.js
@@ -119,7 +119,13 @@ const DataConnector = {
   },
 
   confluence: {
-    collect: async function ({ baseUrl, spaceKey, username, accessToken }) {
+    collect: async function ({
+      baseUrl,
+      spaceKey,
+      username,
+      accessToken,
+      cloud,
+    }) {
       return await fetch(`${API_BASE}/ext/confluence`, {
         method: "POST",
         headers: baseHeaders(),
@@ -128,6 +134,7 @@ const DataConnector = {
           spaceKey,
           username,
           accessToken,
+          cloud,
         }),
       })
         .then((res) => res.json())


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2375


### What is in this change?
Since Confluence has a miserably bad API and there is no definitive way to reliably parse a URL since there is no fixed way to deploy Confluence, we now need to have a very verbose Confluence connector that has all the properties available to interact via the API since we can not make any assumptions at all about users Confluence deployments since they are hosted an innumerable amount of ways.

This PR resolves the difference between the undocumented difference between cloud and self-hosted Confluence spaces in the API where `/wiki` is only in the REST API when on Atlassian Cloud, otherwise it is missing. There is not way to programmatically tell if a host is on cloud or not prior, so we default to assume it is.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
