### PR TITLE
[FEAT] Add Llama 3.2 models to Fireworks AI's LLM selection dropdown

### DIFF
--- a/server/utils/AiProviders/fireworksAi/models.js
+++ b/server/utils/AiProviders/fireworksAi/models.js
@@ -1,4 +1,16 @@
 const MODELS = {
+  "accounts/fireworks/models/llama-v3p2-3b-instruct": {
+    id: "accounts/fireworks/models/llama-v3p2-3b-instruct",
+    organization: "Meta",
+    name: "Llama 3.2 3B Instruct",
+    maxLength: 131072,
+  },
+  "accounts/fireworks/models/llama-v3p2-1b-instruct": {
+    id: "accounts/fireworks/models/llama-v3p2-1b-instruct",
+    organization: "Meta",
+    name: "Llama 3.2 1B Instruct",
+    maxLength: 131072,
+  },
   "accounts/fireworks/models/llama-v3p1-405b-instruct": {
     id: "accounts/fireworks/models/llama-v3p1-405b-instruct",
     organization: "Meta",

--- a/server/utils/AiProviders/fireworksAi/scripts/chat_models.txt
+++ b/server/utils/AiProviders/fireworksAi/scripts/chat_models.txt
@@ -1,5 +1,7 @@
 | Organization | Model Name | Model String for API | Context length |
 |--------------|------------|----------------------|----------------|
+| Meta | Llama 3.2 3B Instruct | accounts/fireworks/models/llama-v3p2-3b-instruct | 131072 |
+| Meta | Llama 3.2 1B Instruct | accounts/fireworks/models/llama-v3p2-1b-instruct | 131072 |
 | Meta | Llama 3.1 405B Instruct | accounts/fireworks/models/llama-v3p1-405b-instruct | 131072 |
 | Meta | Llama 3.1 70B Instruct | accounts/fireworks/models/llama-v3p1-70b-instruct | 131072 |
 | Meta | Llama 3.1 8B Instruct | accounts/fireworks/models/llama-v3p1-8b-instruct | 131072 |

--- a/server/utils/AiProviders/fireworksAi/scripts/parse.mjs
+++ b/server/utils/AiProviders/fireworksAi/scripts/parse.mjs
@@ -9,8 +9,8 @@
 
 // Update the date below if you run this again because Fireworks AI added new models.
 
-// Last Collected: Sep 15, 2024
-// NOTE: Only managed to collect 18 out of ~100 models!
+// Last Collected: Sep 27, 2024
+// NOTE: Only managed to collect 20 out of ~100 models!
 // https://fireworks.ai/models lists almost 100 chat language models.
 // If you want to add models, please manually add them to chat_models.txt...
 // ... I tried to write a script to grab them all but gave up after a few hours...


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #2383

### What is in this change?

Llama 3.2 1B and Llama 3.2 3B instruct models now available for selection when using Firworks AI LLM provider.

- Updated `chat_models.txt` to include llama 3.2 text models
- Ran `node parse.mjs` to extract JSON of models to  chat_models.json (untracked by git)
- Copied JSON output to `models.js`
- Updated comment in `parse.mjs` to show date last updated.

### Additional Information

Llama 3.2 support announced by Fireworks AI Sept. 25th: https://fireworks.ai/blog/llama32-with-fireworks.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
