### PR TITLE
Add 3GB file size limit to body parser middlewares

### DIFF
--- a/collector/index.js
+++ b/collector/index.js
@@ -16,12 +16,14 @@ const extensions = require("./extensions");
 const { processRawText } = require("./processRawText");
 const { verifyPayloadIntegrity } = require("./middleware/verifyIntegrity");
 const app = express();
+const FILE_LIMIT = "3GB";
 
 app.use(cors({ origin: true }));
 app.use(
-  bodyParser.text(),
-  bodyParser.json(),
+  bodyParser.text({ limit: FILE_LIMIT }),
+  bodyParser.json({ limit: FILE_LIMIT }),
   bodyParser.urlencoded({
+    limit: FILE_LIMIT,
     extended: true,
   })
 );


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2389 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

Sets the bodyParser limits in the collector.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
