### PR TITLE
Fix incorrect Agent json function descriptions

### DIFF
--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -33,7 +33,19 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
 
       if (Array.isArray(def.examples)) {
         def.examples.forEach(({ prompt, call }) => {
-          shotExample += `Query: "${prompt}"\nJSON: ${call}\n`;
+          // Parse the original call JSON
+          let callObj = JSON.parse(call);
+
+          // Create a new object with the correct structure
+          let formattedCall = {
+            name: def.name,
+            arguments: callObj
+          };
+
+          // Stringify the new object with proper formatting
+          let formattedCallString = JSON.stringify(formattedCall, null, 2);
+
+          shotExample += `Query: "${prompt}"\nJSON: ${formattedCallString}\n`;
         });
       }
       output += `${shotExample}-----------\n`;


### PR DESCRIPTION
 ### Pull Request Type


- [ ] ✨ feat
- [ x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Resolves:

resolves #2432 


### What is in this change?

The example agent JSON query doesn't align with the description "All JSON responses should have two keys."  "name" "arguments"

Previous agent example:
```
Query: "Save that to memory please."
JSON: {
    "action": "store",
    "content": "<insert summary of conversation until now>"
}
```

This PR fixes that:

Corrected agent example:
```
Query: "Save that to memory please."
JSON: {
  "name": "rag-memory",
  "arguments": {
    "action": "store",
    "content": "<insert summary of conversation until now>"
  }
}
```

Larger, smarter models can understand the inaccuracy in the description and correct for it, but smaller models follow the examples which are incorrect.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
yarn lint doesn't work and looks for directories that don't exist.

- [ x] Relevant documentation has been updated
none needed

- [ x] I have tested my code functionality
ran it locally and looked at generations, also created a test script not included in this pr.

- [ x] Docker build succeeds locally
