### PR TITLE
Update OpenAI TTS config to allow a custom BaseURL allowing for any TTS engine with a compatible API

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -214,6 +214,7 @@ GID='1000'
 # TTS_PROVIDER="openai"
 # TTS_OPEN_AI_KEY=sk-example
 # TTS_OPEN_AI_VOICE_MODEL=nova
+# TTS_OPEN_AI_ENDPOINT="https://api.openai.com/v1" #optional for openAI compatible endpoints
 
 # TTS_PROVIDER="elevenlabs"
 # TTS_ELEVEN_LABS_KEY=

--- a/frontend/src/components/TextToSpeech/OpenAiOptions/index.jsx
+++ b/frontend/src/components/TextToSpeech/OpenAiOptions/index.jsx
@@ -1,3 +1,6 @@
+import React, { useState } from "react";
+import { CaretDown, CaretUp } from "@phosphor-icons/react";
+
 function toProperCase(string) {
   return string.replace(/\w\S*/g, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
@@ -7,7 +10,14 @@ function toProperCase(string) {
 export default function OpenAiTextToSpeechOptions({ settings }) {
   const apiKey = settings?.TTSOpenAIKey;
 
+  const apiEndpoint = settings?.TTSOpenAIEndpoint;
+
+  //only show the control by default if a custom url is entered
+  const [showAdvancedControls, setShowAdvancedControls] = useState(!!apiEndpoint)
+  
+
   return (
+    <div className="w-full flex flex-col gap-y-7">
     <div className="flex gap-x-4">
       <div className="flex flex-col w-60">
         <label className="text-white text-sm font-semibold block mb-3">
@@ -45,5 +55,52 @@ export default function OpenAiTextToSpeechOptions({ settings }) {
         </select>
       </div>
     </div>
+
+      <div className="flex justify-start mt-4">
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            setShowAdvancedControls(!showAdvancedControls);
+          }}
+          className="text-white hover:text-white/70 flex items-center text-sm"
+        >
+          {showAdvancedControls ? "Hide" : "Show"} Manual Endpoint Input
+          {showAdvancedControls ? (
+            <CaretUp size={14} className="ml-1" />
+          ) : (
+            <CaretDown size={14} className="ml-1" />
+          )}
+        </button>
+      </div>
+
+      <div hidden={!showAdvancedControls}>
+        <div className="w-full flex items-start gap-4">
+          <div className="flex flex-col w-60">
+            <div className="flex justify-between items-center mb-2">
+              <label className="text-white text-sm font-semibold">
+                OpenAI Base URL
+              </label>
+            </div>
+            {/* { showAdvancedControls && !!apiEndpoint && */}
+              <input
+                type="url"
+                name="TTSOpenAIEndpoint"
+                className="bg-zinc-900 text-white placeholder:text-white/20 text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                placeholder="http://localhost:7851/v1"
+                defaultValue={apiEndpoint}
+                required={false}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            {/* } */}
+            <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+              Only necessary if using an alternative OpenAI Speech API Compatible Endpoint
+            </p>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    
   );
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,7 +8,7 @@ import { visualizer } from "rollup-plugin-visualizer"
 dns.setDefaultResultOrder("verbatim")
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   assetsInclude: [
     './public/piper/ort-wasm-simd-threaded.wasm',
     './public/piper/piper_phonemize.wasm',
@@ -56,6 +56,7 @@ export default defineConfig({
     ]
   },
   build: {
+    sourcemap: mode === 'development', // Enable source maps in development mode
     rollupOptions: {
       output: {
         // These settings ensure the primary JS and CSS file references are always index.{js,css}
@@ -84,4 +85,4 @@ export default defineConfig({
       plugins: []
     }
   }
-})
+}))

--- a/server/.env.example
+++ b/server/.env.example
@@ -204,6 +204,7 @@ TTS_PROVIDER="native"
 # TTS_PROVIDER="openai"
 # TTS_OPEN_AI_KEY=sk-example
 # TTS_OPEN_AI_VOICE_MODEL=nova
+# TTS_OPEN_AI_ENDPOINT="https://api.openai.com/v1" #optional for openAI compatible endpoints
 
 # TTS_PROVIDER="elevenlabs"
 # TTS_ELEVEN_LABS_KEY=

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -225,6 +225,7 @@ const SystemSettings = {
       TextToSpeechProvider: process.env.TTS_PROVIDER || "native",
       TTSOpenAIKey: !!process.env.TTS_OPEN_AI_KEY,
       TTSOpenAIVoiceModel: process.env.TTS_OPEN_AI_VOICE_MODEL,
+      TTSOpenAIEndpoint: process.env.TTS_OPEN_AI_ENDPOINT || null,
       // Eleven Labs TTS
       TTSElevenLabsKey: !!process.env.TTS_ELEVEN_LABS_KEY,
       TTSElevenLabsVoiceModel: process.env.TTS_ELEVEN_LABS_VOICE_MODEL,

--- a/server/utils/TextToSpeech/openAi/index.js
+++ b/server/utils/TextToSpeech/openAi/index.js
@@ -4,6 +4,7 @@ class OpenAiTTS {
       throw new Error("No OpenAI API key was set.");
     const { OpenAI: OpenAIApi } = require("openai");
     this.openai = new OpenAIApi({
+      baseURL: process.env.TTS_OPEN_AI_ENDPOINT || `https://api.openai.com/v1`,
       apiKey: process.env.TTS_OPEN_AI_KEY,
     });
     this.voice = process.env.TTS_OPEN_AI_VOICE_MODEL ?? "alloy";

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -489,6 +489,10 @@ const KEY_MAPPING = {
     envKey: "TTS_OPEN_AI_VOICE_MODEL",
     checks: [],
   },
+  TTSOpenAIEndpoint: {
+    envKey: "TTS_OPEN_AI_ENDPOINT",
+    checks: [validOptionalLLMExternalBasePath],
+  },
 
   // TTS ElevenLabs
   TTSElevenLabsKey: {
@@ -560,6 +564,13 @@ function validLLMExternalBasePath(input = "") {
   } catch {
     return "Not a valid URL";
   }
+}
+
+function validOptionalLLMExternalBasePath(input = "") {
+  if (!input) {
+    return null
+  }
+  return validLLMExternalBasePath(input)
 }
 
 function validOllamaLLMBasePath(input = "") {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

resolves #xxx

### What is in this change?

This adds an input field for a custom BaseURL for the OpenAI TTS endpoint when selecting OpenAI as a TTS provider.

Since OpenAI has become an industry standard many tools have taken to mirroring their API for ease of integration.

With this change it allows for a much richer choice of options to use as a TTS provider.

I tested it using [AllTalk_TTS's OpenAI speech endpoint](https://github.com/erew123/alltalk_tts/wiki/API-%E2%80%90-OpenAI-V1-Speech-Compatible-Endpoint) and it works wonderfully.


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes

- [ x] Relevant documentation has been updated
     couldn't find any relevant docs, but it is notated in the env comments
     
- [ x] I have tested my code functionality

- [ x] Docker build succeeds locally
    In order to debug this, I needed to get the frontend/server/collector all working since the docker takes a VERY long time on the production-build  3/3 chown step.  There has got to be a way to speed that up.  Also, when running the servers independently, it doesn't save the config in any .env file so with every restart I had to set it up again, don't know what I missed there.  I was also running it under WSL ubuntu, so that was it's own pita, my dev machine is a MBP, but only my PC can run the models :/
