### PR TITLE
Fix upload in dev API garbled Chinese chars 

### DIFF
--- a/server/utils/files/multer.js
+++ b/server/utils/files/multer.js
@@ -13,9 +13,10 @@ const fileUploadStorage = multer.diskStorage({
     cb(null, uploadOutput);
   },
   filename: function (_, file, cb) {
-    file.originalname = Buffer.from(file.originalname, "latin1").toString(
-      "utf8"
-    );
+    // Decode the filename from URI encoding (Chinese characters, etc.)
+    const decodedFilename = decodeURIComponent(file.originalname);
+    // Convert from UTF-8 to the correct encoding if needed
+    file.originalname = Buffer.from(decodedFilename, 'utf8').toString('utf8');
     cb(null, file.originalname);
   },
 });

--- a/server/utils/files/multer.js
+++ b/server/utils/files/multer.js
@@ -16,7 +16,7 @@ const fileUploadStorage = multer.diskStorage({
     // Decode the filename from URI encoding (Chinese characters, etc.)
     const decodedFilename = decodeURIComponent(file.originalname);
     // Convert from UTF-8 to the correct encoding if needed
-    file.originalname = Buffer.from(decodedFilename, 'utf8').toString('utf8');
+    file.originalname = Buffer.from(decodedFilename, "utf8").toString("utf8");
     cb(null, file.originalname);
   },
 });


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2474 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fix a bug where if a file with Chinese character is uploaded via the developer API (`/v1/document/upload` route) it would save the file with garbled characters instead of the correct Chinese characters
- Fixed by doing a `decodeURIComponent` in the multer middleware before converting to utf8

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
