### PR TITLE
Feature/thread creation slug name

### DIFF
--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -31,12 +31,14 @@ function apiWorkspaceThreadEndpoints(app) {
           type: 'string'
       }
       #swagger.requestBody = {
-        description: 'Optional userId associated with the thread',
+        description: 'Optional userId associated with the thread, thread slug and thread name',
         required: false,
         content: {
           "application/json": {
             example: {
-              userId: 1
+              userId: 1,
+              name: 'Name',
+              slug: 'thread-slug'
             }
           }
         }
@@ -67,9 +69,9 @@ function apiWorkspaceThreadEndpoints(app) {
       }
       */
       try {
-        const { slug } = request.params;
-        let { userId = null } = reqBody(request);
-        const workspace = await Workspace.get({ slug });
+        const wslug = request.params.slug;
+        let { userId = null, name = null, slug = null } = reqBody(request);
+        const workspace = await Workspace.get({ wslug });
 
         if (!workspace) {
           response.sendStatus(400).end();
@@ -83,7 +85,8 @@ function apiWorkspaceThreadEndpoints(app) {
 
         const { thread, message } = await WorkspaceThread.new(
           workspace,
-          userId ? Number(userId) : null
+          userId ? Number(userId) : null,
+          { name, slug }
         );
 
         await Telemetry.sendTelemetry("workspace_thread_created", {

--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -71,7 +71,7 @@ function apiWorkspaceThreadEndpoints(app) {
       try {
         const wslug = request.params.slug;
         let { userId = null, name = null, slug = null } = reqBody(request);
-        const workspace = await Workspace.get({ wslug });
+        const workspace = await Workspace.get({ slug: wslug });
 
         if (!workspace) {
           response.sendStatus(400).end();

--- a/server/models/workspaceThread.js
+++ b/server/models/workspaceThread.js
@@ -5,12 +5,12 @@ const WorkspaceThread = {
   defaultName: "Thread",
   writable: ["name"],
 
-  new: async function (workspace, userId = null) {
+  new: async function (workspace, userId = null, data = {}) {
     try {
       const thread = await prisma.workspace_threads.create({
         data: {
-          name: this.defaultName,
-          slug: uuidv4(),
+          name: data.name || this.defaultName,
+          slug: data.slug || uuidv4(),
           user_id: userId ? Number(userId) : null,
           workspace_id: workspace.id,
         },


### PR DESCRIPTION
 ### Pull Request Type

- [x ] ✨ feat

### What is in this change?

Optional slug and name params for workspace thread creation to use with api.


### Additional Information

 Without slug param there is no way to identify thread by some 3rd party uuid4 with api. It's possible to store somewhere additional relation of "3rd party uuid4 - threadSlug", but with having ability of defining thread slug manually - this will be not required - thread slug will be equal to "3rd party uuid" so it will be easy to get required thread.

With thread name definition - it will be easy to use UI as "admin tool for viewing results of api based chats "

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally