### PR TITLE
Feature/thread creation slug name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
     "textgenwebui",
     "togetherai",
     "Unembed",
+    "uuidv",
     "vectordbs",
     "Weaviate",
     "Zilliz"

--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -31,12 +31,14 @@ function apiWorkspaceThreadEndpoints(app) {
           type: 'string'
       }
       #swagger.requestBody = {
-        description: 'Optional userId associated with the thread',
+        description: 'Optional userId associated with the thread, thread slug and thread name',
         required: false,
         content: {
           "application/json": {
             example: {
-              userId: 1
+              userId: 1,
+              name: 'Name',
+              slug: 'thread-slug'
             }
           }
         }
@@ -67,9 +69,9 @@ function apiWorkspaceThreadEndpoints(app) {
       }
       */
       try {
-        const { slug } = request.params;
-        let { userId = null } = reqBody(request);
-        const workspace = await Workspace.get({ slug });
+        const wslug = request.params.slug;
+        let { userId = null, name = null, slug = null } = reqBody(request);
+        const workspace = await Workspace.get({ wslug });
 
         if (!workspace) {
           response.sendStatus(400).end();
@@ -83,7 +85,8 @@ function apiWorkspaceThreadEndpoints(app) {
 
         const { thread, message } = await WorkspaceThread.new(
           workspace,
-          userId ? Number(userId) : null
+          userId ? Number(userId) : null,
+          { name, slug }
         );
 
         await Telemetry.sendTelemetry("workspace_thread_created", {

--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -71,7 +71,7 @@ function apiWorkspaceThreadEndpoints(app) {
       try {
         const wslug = request.params.slug;
         let { userId = null, name = null, slug = null } = reqBody(request);
-        const workspace = await Workspace.get({ wslug });
+        const workspace = await Workspace.get({ slug: wslug });
 
         if (!workspace) {
           response.sendStatus(400).end();

--- a/server/models/workspaceThread.js
+++ b/server/models/workspaceThread.js
@@ -1,16 +1,44 @@
 const prisma = require("../utils/prisma");
+const slugifyModule = require("slugify");
 const { v4: uuidv4 } = require("uuid");
 
 const WorkspaceThread = {
   defaultName: "Thread",
   writable: ["name"],
 
+  /**
+   * The default Slugify module requires some additional mapping to prevent downstream issues
+   * if the user is able to define a slug externally. We have to block non-escapable URL chars
+   * so that is the slug is rendered it doesn't break the URL or UI when visited.
+   * @param  {...any} args - slugify args for npm package.
+   * @returns {string}
+   */
+  slugify: function (...args) {
+    slugifyModule.extend({
+      "+": " plus ",
+      "!": " bang ",
+      "@": " at ",
+      "*": " splat ",
+      ".": " dot ",
+      ":": "",
+      "~": "",
+      "(": "",
+      ")": "",
+      "'": "",
+      '"': "",
+      "|": "",
+    });
+    return slugifyModule(...args);
+  },
+
   new: async function (workspace, userId = null, data = {}) {
     try {
       const thread = await prisma.workspace_threads.create({
         data: {
-          name: data.name || this.defaultName,
-          slug: data.slug || uuidv4(),
+          name: data.name ? String(data.name) : this.defaultName,
+          slug: data.slug
+            ? this.slugify(data.slug, { lowercase: true })
+            : uuidv4(),
           user_id: userId ? Number(userId) : null,
           workspace_id: workspace.id,
         },

--- a/server/models/workspaceThread.js
+++ b/server/models/workspaceThread.js
@@ -5,12 +5,12 @@ const WorkspaceThread = {
   defaultName: "Thread",
   writable: ["name"],
 
-  new: async function (workspace, userId = null) {
+  new: async function (workspace, userId = null, data = {}) {
     try {
       const thread = await prisma.workspace_threads.create({
         data: {
-          name: this.defaultName,
-          slug: uuidv4(),
+          name: data.name || this.defaultName,
+          slug: data.slug || uuidv4(),
           user_id: userId ? Number(userId) : null,
           workspace_id: workspace.id,
         },

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -2391,12 +2391,14 @@
           }
         },
         "requestBody": {
-          "description": "Optional userId associated with the thread",
+          "description": "Optional userId associated with the thread, thread slug and thread name",
           "required": false,
           "content": {
             "application/json": {
               "example": {
-                "userId": 1
+                "userId": 1,
+                "name": "Name",
+                "slug": "thread-slug"
               }
             }
           }


### PR DESCRIPTION
 ### Pull Request Type
 
 original PR by @abrakadobr

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

closes #2507


### What is in this change?
Optional slug and name params for workspace thread creation to use with API.
Adds validation to `.new` creation to ensure valid field upsert and sluggification of the `slug` input to prevent breaking the URL when viewed by the user.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

Without slug param there is no way to identify thread by some 3rd party uuid4 with api. It's possible to store somewhere additional relation of "3rd party uuid4 - threadSlug", but with having ability of defining thread slug manually - this will be not required - thread slug will be equal to "3rd party uuid" so it will be easy to get required thread.

With thread name definition - it will be easy to use UI as "admin tool for viewing results of api based chats "

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
