### PR TITLE
Patch `v1/document/upload` filename charset encoding

### DIFF
--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -1,6 +1,6 @@
 const { Telemetry } = require("../../../models/telemetry");
 const { validApiKey } = require("../../../utils/middleware/validApiKey");
-const { handleFileUpload } = require("../../../utils/files/multer");
+const { handleAPIFileUpload } = require("../../../utils/files/multer");
 const {
   viewLocalFiles,
   findDocumentInDocuments,
@@ -23,7 +23,7 @@ function apiDocumentEndpoints(app) {
 
   app.post(
     "/v1/document/upload",
-    [validApiKey, handleFileUpload],
+    [validApiKey, handleAPIFileUpload],
     async (request, response) => {
       /*
     #swagger.tags = ['Documents']

--- a/server/utils/files/multer.js
+++ b/server/utils/files/multer.js
@@ -3,7 +3,10 @@ const path = require("path");
 const fs = require("fs");
 const { v4 } = require("uuid");
 
-// Handle File uploads for auto-uploading.
+/**
+ * Handle File uploads for auto-uploading.
+ * Mostly used for internal GUI/API uploads.
+ */
 const fileUploadStorage = multer.diskStorage({
   destination: function (_, __, cb) {
     const uploadOutput =
@@ -16,6 +19,23 @@ const fileUploadStorage = multer.diskStorage({
     file.originalname = Buffer.from(file.originalname, "latin1").toString(
       "utf8"
     );
+    cb(null, file.originalname);
+  },
+});
+
+/**
+ * Handle API file upload as documents - this does not manipulate the filename
+ * at all for encoding/charset reasons.
+ */
+const fileAPIUploadStorage = multer.diskStorage({
+  destination: function (_, __, cb) {
+    const uploadOutput =
+      process.env.NODE_ENV === "development"
+        ? path.resolve(__dirname, `../../../collector/hotdir`)
+        : path.resolve(process.env.STORAGE_DIR, `../../collector/hotdir`);
+    cb(null, uploadOutput);
+  },
+  filename: function (_, file, cb) {
     cb(null, file.originalname);
   },
 });
@@ -38,7 +58,9 @@ const assetUploadStorage = multer.diskStorage({
   },
 });
 
-// Asset sub-storage manager for pfp icons.
+/**
+ * Handle PFP file upload as logos
+ */
 const pfpUploadStorage = multer.diskStorage({
   destination: function (_, __, cb) {
     const uploadOutput =
@@ -55,7 +77,12 @@ const pfpUploadStorage = multer.diskStorage({
   },
 });
 
-// Handle Generic file upload as documents
+/**
+ * Handle Generic file upload as documents from the GUI
+ * @param {Request} request
+ * @param {Response} response
+ * @param {NextFunction} next
+ */
 function handleFileUpload(request, response, next) {
   const upload = multer({ storage: fileUploadStorage }).single("file");
   upload(request, response, function (err) {
@@ -73,7 +100,33 @@ function handleFileUpload(request, response, next) {
   });
 }
 
-// Handle logo asset uploads
+/**
+ * Handle API file upload as documents - this does not manipulate the filename
+ * at all for encoding/charset reasons.
+ * @param {Request} request
+ * @param {Response} response
+ * @param {NextFunction} next
+ */
+function handleAPIFileUpload(request, response, next) {
+  const upload = multer({ storage: fileAPIUploadStorage }).single("file");
+  upload(request, response, function (err) {
+    if (err) {
+      response
+        .status(500)
+        .json({
+          success: false,
+          error: `Invalid file upload. ${err.message}`,
+        })
+        .end();
+      return;
+    }
+    next();
+  });
+}
+
+/**
+ * Handle logo asset uploads
+ */
 function handleAssetUpload(request, response, next) {
   const upload = multer({ storage: assetUploadStorage }).single("logo");
   upload(request, response, function (err) {
@@ -91,7 +144,9 @@ function handleAssetUpload(request, response, next) {
   });
 }
 
-// Handle PFP file upload as logos
+/**
+ * Handle PFP file upload as logos
+ */
 function handlePfpUpload(request, response, next) {
   const upload = multer({ storage: pfpUploadStorage }).single("file");
   upload(request, response, function (err) {
@@ -111,6 +166,7 @@ function handlePfpUpload(request, response, next) {
 
 module.exports = {
   handleFileUpload,
+  handleAPIFileUpload,
   handleAssetUpload,
   handlePfpUpload,
 };


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2474

### What is in this change?
- Adds API specific storage middleware for filename encoding without impacting the main UI file handler.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
