### PR TITLE
add `sessionToken` validation connection auth for AWSbedrock

### DIFF
--- a/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
@@ -1,7 +1,12 @@
 import { ArrowSquareOut, Info } from "@phosphor-icons/react";
 import { AWS_REGIONS } from "./regions";
+import { useState } from "react";
 
 export default function AwsBedrockLLMOptions({ settings }) {
+  const [useSessionToken, setUseSessionToken] = useState(
+    settings?.AwsBedrockLLMConnectionMethod === "sessionToken"
+  );
+
   return (
     <div className="w-full flex flex-col">
       {!settings?.credentialsOnly && (
@@ -23,6 +28,43 @@ export default function AwsBedrockLLMOptions({ settings }) {
           </div>
         </div>
       )}
+
+      <div className="flex flex-col gap-y-2">
+        <input
+          type="hidden"
+          name="AwsBedrockLLMConnectionMethod"
+          value={useSessionToken ? "sessionToken" : "iam"}
+        />
+        <div className="flex flex-col w-full">
+          <label className="text-white text-sm font-semibold block mb-3">
+            Use session token
+          </label>
+          <p className="text-white/50 text-sm">
+            Select the method to authenticate with AWS Bedrock.
+          </p>
+        </div>
+        <div className="flex items-center justify-start gap-x-4 bg-zinc-900 p-2.5 rounded-lg w-fit">
+          <span
+            className={`text-sm ${!useSessionToken ? "text-white" : "text-white/50"}`}
+          >
+            IAM
+          </span>
+          <label className="relative inline-flex items-center cursor-pointer">
+            <input
+              type="checkbox"
+              className="sr-only peer"
+              checked={useSessionToken}
+              onChange={(e) => setUseSessionToken(e.target.checked)}
+            />
+            <div className="w-11 h-6 bg-zinc-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary-button"></div>
+          </label>
+          <span
+            className={`text-sm ${useSessionToken ? "text-white" : "text-white/50"}`}
+          >
+            Session Token
+          </span>
+        </div>
+      </div>
 
       <div className="w-full flex items-center gap-[36px] my-1.5">
         <div className="flex flex-col w-60">
@@ -59,6 +101,25 @@ export default function AwsBedrockLLMOptions({ settings }) {
             spellCheck={false}
           />
         </div>
+        {useSessionToken && (
+          <div className="flex flex-col w-60">
+            <label className="text-white text-sm font-semibold block mb-3">
+              AWS Bedrock Session Token
+            </label>
+            <input
+              type="password"
+              name="AwsBedrockLLMSessionToken"
+              className="border-none bg-zinc-900 text-white placeholder:text-white/20 text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder="AWS Bedrock Session Token"
+              defaultValue={
+                settings?.AwsBedrockLLMSessionToken ? "*".repeat(20) : ""
+              }
+              required={true}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        )}
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
             AWS region

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -505,8 +505,11 @@ const SystemSettings = {
       GenericOpenAiKey: !!process.env.GENERIC_OPEN_AI_API_KEY,
       GenericOpenAiMaxTokens: process.env.GENERIC_OPEN_AI_MAX_TOKENS,
 
+      AwsBedrockLLMConnectionMethod:
+        process.env.AWS_BEDROCK_LLM_CONNECTION_METHOD || "iam",
       AwsBedrockLLMAccessKeyId: !!process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
       AwsBedrockLLMAccessKey: !!process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
+      AwsBedrockLLMSessionToken: !!process.env.AWS_BEDROCK_LLM_SESSION_TOKEN,
       AwsBedrockLLMRegion: process.env.AWS_BEDROCK_LLM_REGION,
       AwsBedrockLLMModel: process.env.AWS_BEDROCK_LLM_MODEL_PREFERENCE,
       AwsBedrockLLMTokenLimit: process.env.AWS_BEDROCK_LLM_MODEL_TOKEN_LIMIT,

--- a/server/utils/agents/aibitat/providers/bedrock.js
+++ b/server/utils/agents/aibitat/providers/bedrock.js
@@ -22,6 +22,11 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
       credentials: {
         accessKeyId: process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
+        // If we're using a session token, we need to pass it in as a credential
+        // otherwise we must omit it so it does not conflict if using IAM auth
+        ...(this.authMethod === "sessionToken"
+          ? { sessionToken: process.env.AWS_BEDROCK_LLM_SESSION_TOKEN }
+          : {}),
       },
       model,
     });
@@ -29,6 +34,17 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
     this._client = client;
     this.model = model;
     this.verbose = true;
+  }
+
+  /**
+   * Get the authentication method for the AWS Bedrock LLM.
+   * There are only two valid values for this setting - anything else will default to "iam".
+   * @returns {"iam"|"sessionToken"}
+   */
+  get authMethod() {
+    const method = process.env.AWS_BEDROCK_LLM_CONNECTION_METHOD || "iam";
+    if (!["iam", "sessionToken"].includes(method)) return "iam";
+    return method;
   }
 
   get client() {

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -213,6 +213,13 @@ const KEY_MAPPING = {
   },
 
   // AWS Bedrock LLM InferenceSettings
+  AwsBedrockLLMConnectionMethod: {
+    envKey: "AWS_BEDROCK_LLM_CONNECTION_METHOD",
+    checks: [
+      (input) =>
+        ["iam", "sessionToken"].includes(input) ? null : "Invalid value",
+    ],
+  },
   AwsBedrockLLMAccessKeyId: {
     envKey: "AWS_BEDROCK_LLM_ACCESS_KEY_ID",
     checks: [isNotEmpty],
@@ -220,6 +227,10 @@ const KEY_MAPPING = {
   AwsBedrockLLMAccessKey: {
     envKey: "AWS_BEDROCK_LLM_ACCESS_KEY",
     checks: [isNotEmpty],
+  },
+  AwsBedrockLLMSessionToken: {
+    envKey: "AWS_BEDROCK_LLM_SESSION_TOKEN",
+    checks: [],
   },
   AwsBedrockLLMRegion: {
     envKey: "AWS_BEDROCK_LLM_REGION",


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2299


### What is in this change?
AWS Bedrock validation via `sessionToken` vs `IAM`

`IAM` authentication will be enabled by default.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
