### PR TITLE
Allow 127.0.0.1 as valid URL for scraping

### DIFF
--- a/collector/extensions/index.js
+++ b/collector/extensions/index.js
@@ -118,7 +118,12 @@ function extensions(app) {
       try {
         const websiteDepth = require("../utils/extensions/WebsiteDepth");
         const { url, depth = 1, maxLinks = 20 } = reqBody(request);
-        if (!validURL(url)) return { success: false, reason: "Not a valid URL." };
+        if (!validURL(url)) {
+          return response.status(400).json({
+            success: false,
+            reason: "Not a valid URL."
+          });
+        }
 
         const scrapedData = await websiteDepth(url, depth, maxLinks);
         response.status(200).json({ success: true, data: scrapedData });

--- a/collector/utils/url/index.js
+++ b/collector/utils/url/index.js
@@ -23,6 +23,10 @@ function isInvalidIp({ hostname }) {
 
   // If fails to validate to number - abort and return as invalid.
   if (isNaN(Number(octetOne))) return true;
+
+  // Allow 127.0.0.1 (localhost) but block other private IP ranges
+  if (octetOne === "127" && hostname === "127.0.0.1") return false;
+
   return INVALID_OCTETS.includes(Number(octetOne));
 }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2459 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Modify validURL to allow the localhost IP `127.0.0.1`
- Now allows this to be valid for bulk link scraper and single link scraper
- Send 400 response on failed `validURL` check to fix frontend hanging on invalid URL

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
