### PR TITLE
Add full link to docSource metadata for URL scrapers

### DIFF
--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -36,7 +36,7 @@ async function scrapeGenericUrl(link, textOnly = false) {
     title: slugify(filename) + ".html",
     docAuthor: "no author found",
     description: "No description found.",
-    docSource: "URL link uploaded by the user.",
+    docSource: link,
     chunkSource: `link://${link}`,
     published: new Date().toLocaleString(),
     wordCount: content.split(" ").length,

--- a/collector/utils/extensions/WebsiteDepth/index.js
+++ b/collector/utils/extensions/WebsiteDepth/index.js
@@ -117,7 +117,7 @@ async function bulkScrapePages(links, outFolderPath) {
         title: slugify(filename) + ".html",
         docAuthor: "no author found",
         description: "No description found.",
-        docSource: "URL link uploaded by the user.",
+        docSource: link,
         chunkSource: `link://${link}`,
         published: new Date().toLocaleString(),
         wordCount: content.split(" ").length,


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2430 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Add full URL to `docSource` metadata field in both single link scraper and bulk link scraper
- This will allows the LLM to refer directly back to the URL instead of using the slugified title name by providing it context with the actual full URL

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
