### PR TITLE
Add handling of Personal Access Token in Confluence data connector

### DIFF
--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -18,15 +18,16 @@ async function loadConfluence(
     spaceKey = null,
     username = null,
     accessToken = null,
+    personalAccessToken = null,
     cloud = true,
   },
   response
 ) {
-  if (!baseUrl || !spaceKey || !username || !accessToken) {
+  if (!accessToken && !personalAccessToken || accessToken && !username || personalAccessToken && username) {
     return {
       success: false,
       reason:
-        "You need either a username and access token, or a personal access token (PAT), to use the Confluence connector.",
+        "You need either a username and access token, or only a personal access token (PAT), to use the Confluence connector.",
     };
   }
 
@@ -51,6 +52,7 @@ async function loadConfluence(
     spaceKey,
     username,
     accessToken,
+    personalAccessToken,
     cloud,
   });
 
@@ -98,7 +100,7 @@ async function loadConfluence(
       description: doc.metadata.title,
       docSource: `${origin} Confluence`,
       chunkSource: generateChunkSource(
-        { doc, baseUrl: origin, spaceKey, accessToken, username, cloud },
+        { doc, baseUrl: origin, spaceKey, accessToken, personalAccessToken, username, cloud },
         response.locals.encryptionWorker
       ),
       published: new Date().toLocaleString(),
@@ -137,14 +139,14 @@ async function fetchConfluencePage({
   spaceKey,
   username,
   accessToken,
+  personalAccessToken,
   cloud = true,
 }) {
-  if (!pageUrl || !baseUrl || !spaceKey || !username || !accessToken) {
+  if (!accessToken && !personalAccessToken || accessToken && !username || personalAccessToken && username) {
     return {
       success: false,
-      content: null,
       reason:
-        "You need either a username and access token, or a personal access token (PAT), to use the Confluence connector.",
+        "You need either a username and access token, or only a personal access token (PAT), to use the Confluence connector.",
     };
   }
 
@@ -170,6 +172,7 @@ async function fetchConfluencePage({
     spaceKey,
     username,
     accessToken,
+    personalAccessToken,
     cloud,
   });
 
@@ -234,9 +237,12 @@ function validBaseUrl(baseUrl) {
  * @returns {string}
  */
 function generateChunkSource(
-  { doc, baseUrl, spaceKey, accessToken, username, cloud },
+  { doc, baseUrl, spaceKey, accessToken, personalAccessToken, username, cloud },
   encryptionWorker
 ) {
+  if (personalAccessToken) {
+    accessToken = personalAccessToken;
+  }
   const payload = {
     baseUrl,
     spaceKey,

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Confluence/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Confluence/index.jsx
@@ -26,6 +26,7 @@ export default function ConfluenceOptions() {
         spaceKey: form.get("spaceKey"),
         username: form.get("username"),
         accessToken: form.get("accessToken"),
+	personalAccessToken: form.get("personalAccessToken"),
         cloud: form.get("isCloud") === "true",
       });
 
@@ -133,7 +134,7 @@ export default function ConfluenceOptions() {
                   name="username"
                   className="bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="jdoe@example.com"
-                  required={true}
+                  required={false}
                   autoComplete="off"
                   spellCheck={false}
                 />
@@ -157,7 +158,7 @@ export default function ConfluenceOptions() {
                       clickable={true}
                     >
                       <p className="text-sm">
-                        You need to provide an access token for authentication.
+                        You need to provide a username and access token or a personal access token for authentication.
                         You can generate an access token{" "}
                         <a
                           href="https://id.atlassian.com/manage-profile/security/api-tokens"
@@ -181,7 +182,45 @@ export default function ConfluenceOptions() {
                   name="accessToken"
                   className="bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="abcd1234"
-                  required={true}
+                  required={false}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </div>
+              <div className="flex flex-col pr-10">
+                <div className="flex flex-col gap-y-1 mb-4">
+                  <label className="text-white text-sm font-bold flex gap-x-2 items-center">
+                    <p className="font-bold text-white">
+                      Confluence Personal Access Token
+                    </p>
+                    <Warning
+                      size={14}
+                      className="ml-1 text-orange-500 cursor-pointer"
+                      data-tooltip-id="personal-access-token-tooltip"
+                      data-tooltip-place="right"
+                    />
+                    <Tooltip
+                      delayHide={300}
+                      id="personal-access-token-tooltip"
+                      className="max-w-xs z-99"
+                      clickable={true}
+                    >
+                      <p className="text-sm">
+                        You need to either provide a personal access token or a username and password for authentication.
+	                You can create a personal access token in your confluence user settings
+                      </p>
+                    </Tooltip>
+                  </label>
+                  <p className="text-xs font-normal text-theme-text-secondary">
+                    Personal access token for authentication.
+                  </p>
+                </div>
+                <input
+                  type="password"
+                  name="personalAccessToken"
+                  className="bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  placeholder="abcd1234"
+                  required={false}
                   autoComplete="off"
                   spellCheck={false}
                 />

--- a/frontend/src/models/dataConnector.js
+++ b/frontend/src/models/dataConnector.js
@@ -136,6 +136,7 @@ const DataConnector = {
       spaceKey,
       username,
       accessToken,
+      personalAccessToken,
       cloud,
     }) {
       return await fetch(`${API_BASE}/ext/confluence`, {
@@ -146,6 +147,7 @@ const DataConnector = {
           spaceKey,
           username,
           accessToken,
+	  personalAccessToken,
           cloud,
         }),
       })


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2704


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
- Add personalAccessToken handling to the Confluence Data Connector


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->
I basically just hacked it together, to see if I can make use of the connector and was lacking the PAT functionality. And only used docker-compose up --build to test it.
Tested with a Personal Access Token on a self hosted instance.
Not tested with Username/Password, as the instance does not allow this.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality (not tested possible side effects)
- [x] Docker build succeeds locally
