### PR TITLE
Fix scraping failed bug in link/bulk link scrapers

### DIFF
--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -61,7 +61,7 @@ async function getPageContent(link) {
         ignoreHTTPSErrors: true,
       },
       gotoOptions: {
-        waitUntil: "networkidle0",
+        waitUntil: "networkidle2",
       },
       async evaluate(page, browser) {
         const result = await page.evaluate(() => document.body.innerText);

--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -61,7 +61,7 @@ async function getPageContent(link) {
         ignoreHTTPSErrors: true,
       },
       gotoOptions: {
-        waitUntil: "domcontentloaded",
+        waitUntil: "networkidle0",
       },
       async evaluate(page, browser) {
         const result = await page.evaluate(() => document.body.innerText);

--- a/collector/utils/extensions/WebsiteDepth/index.js
+++ b/collector/utils/extensions/WebsiteDepth/index.js
@@ -145,9 +145,9 @@ async function websiteScraper(startUrl, depth = 1, maxLinks = 20) {
   const outFolderPath =
     process.env.NODE_ENV === "development"
       ? path.resolve(
-        __dirname,
-        `../../../../server/storage/documents/${outFolder}`
-      )
+          __dirname,
+          `../../../../server/storage/documents/${outFolder}`
+        )
       : path.resolve(process.env.STORAGE_DIR, `documents/${outFolder}`);
 
   console.log("Discovering links...");

--- a/collector/utils/extensions/WebsiteDepth/index.js
+++ b/collector/utils/extensions/WebsiteDepth/index.js
@@ -48,7 +48,7 @@ async function getPageLinks(url, baseUrl) {
   try {
     const loader = new PuppeteerWebBaseLoader(url, {
       launchOptions: { headless: "new" },
-      gotoOptions: { waitUntil: "domcontentloaded" },
+      gotoOptions: { waitUntil: "networkidle0" },
     });
     const docs = await loader.load();
     const html = docs[0].pageContent;
@@ -92,7 +92,7 @@ async function bulkScrapePages(links, outFolderPath) {
     try {
       const loader = new PuppeteerWebBaseLoader(link, {
         launchOptions: { headless: "new" },
-        gotoOptions: { waitUntil: "domcontentloaded" },
+        gotoOptions: { waitUntil: "networkidle0" },
         async evaluate(page, browser) {
           const result = await page.evaluate(() => document.body.innerText);
           await browser.close();

--- a/collector/utils/extensions/WebsiteDepth/index.js
+++ b/collector/utils/extensions/WebsiteDepth/index.js
@@ -48,7 +48,7 @@ async function getPageLinks(url, baseUrl) {
   try {
     const loader = new PuppeteerWebBaseLoader(url, {
       launchOptions: { headless: "new" },
-      gotoOptions: { waitUntil: "networkidle0" },
+      gotoOptions: { waitUntil: "networkidle2" },
     });
     const docs = await loader.load();
     const html = docs[0].pageContent;
@@ -92,7 +92,7 @@ async function bulkScrapePages(links, outFolderPath) {
     try {
       const loader = new PuppeteerWebBaseLoader(link, {
         launchOptions: { headless: "new" },
-        gotoOptions: { waitUntil: "networkidle0" },
+        gotoOptions: { waitUntil: "networkidle2" },
         async evaluate(page, browser) {
           const result = await page.evaluate(() => document.body.innerText);
           await browser.close();
@@ -145,9 +145,9 @@ async function websiteScraper(startUrl, depth = 1, maxLinks = 20) {
   const outFolderPath =
     process.env.NODE_ENV === "development"
       ? path.resolve(
-          __dirname,
-          `../../../../server/storage/documents/${outFolder}`
-        )
+        __dirname,
+        `../../../../server/storage/documents/${outFolder}`
+      )
       : path.resolve(process.env.STORAGE_DIR, `documents/${outFolder}`);
 
   console.log("Discovering links...");


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2758 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Replace `domcontentloaded` Puppeteer option with `networkidle0` which waits for all network connections to close before attempting scraping
- `domcontentloaded` only waits for initial HTML document to load before continuing 
- Referenced [these langchain docs](https://v03.api.js.langchain.com/types/_langchain_community.document_loaders_web_puppeteer.PuppeteerGotoOptions.html) and [Puppeteer docs](https://pptr.dev/api/puppeteer.puppeteerlifecycleevent) to use `networkidle0` life cycle event

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
