### PR TITLE
Show scrollbar on rendered tables in chat

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -96,7 +96,7 @@ const HistoricalMessage = ({
               saveChanges={saveEditedMessage}
             />
           ) : (
-            <div className="overflow-x-scroll break-words no-scroll">
+            <div className="overflow-x-scroll break-words show-scrollbar">
               <span
                 className="flex flex-col gap-y-1"
                 dangerouslySetInnerHTML={{

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -62,7 +62,7 @@ const PromptReply = ({
         <div className="flex gap-x-5">
           <WorkspaceProfileImage workspace={workspace} />
           <span
-            className={`overflow-x-scroll break-words no-scroll`}
+            className="overflow-x-scroll break-words show-scrollbar"
             dangerouslySetInnerHTML={{ __html: renderMarkdown(reply) }}
           />
         </div>


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fixes a bug where users cannot see the horizontal scrollbar on messages that contain markdown tables that are rendered and overflow past the max width of the messages
- When a table overflows, a horizontal scrollbar is now visible allowing the user to scroll left and right even without a trackpad

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
