### PR TITLE
Add AWS credential profile support for AWS Bedrock

### DIFF
--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -253,12 +253,7 @@ export const AVAILABLE_LLM_PROVIDERS = [
     logo: AWSBedrockLogo,
     options: (settings) => <AWSBedrockLLMOptions settings={settings} />,
     description: "Run powerful foundation models privately with AWS Bedrock.",
-    requiredConfig: [
-      "AwsBedrockLLMAccessKeyId",
-      "AwsBedrockLLMAccessKey",
-      "AwsBedrockLLMRegion",
-      "AwsBedrockLLMModel",
-    ],
+    requiredConfig: ["AwsBedrockLLMRegion", "AwsBedrockLLMModel"],
   },
   {
     name: "APIpie",

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -527,6 +527,7 @@ const SystemSettings = {
       AwsBedrockLLMAccessKeyId: !!process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
       AwsBedrockLLMAccessKey: !!process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
       AwsBedrockLLMSessionToken: !!process.env.AWS_BEDROCK_LLM_SESSION_TOKEN,
+      AwsBedrockLLMProfileName: process.env.AWS_BEDROCK_LLM_PROFILE_NAME,
       AwsBedrockLLMRegion: process.env.AWS_BEDROCK_LLM_REGION,
       AwsBedrockLLMModel: process.env.AWS_BEDROCK_LLM_MODEL_PREFERENCE,
       AwsBedrockLLMTokenLimit: process.env.AWS_BEDROCK_LLM_MODEL_TOKEN_LIMIT,

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -116,16 +116,28 @@ class Provider {
           ),
           ...config,
         });
-      case "bedrock":
+      case "bedrock": {
+        const awsAuthMethod =
+          process.env.AWS_BEDROCK_LLM_CONNECTION_METHOD || "iam";
         return new ChatBedrockConverse({
           model: process.env.AWS_BEDROCK_LLM_MODEL_PREFERENCE,
           region: process.env.AWS_BEDROCK_LLM_REGION,
-          credentials: {
-            accessKeyId: process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
-            secretAccessKey: process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
-          },
+          ...(awsAuthMethod === "profile"
+            ? {
+                profile: process.env.AWS_BEDROCK_LLM_PROFILE_NAME,
+              }
+            : {
+                credentials: {
+                  accessKeyId: process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
+                  secretAccessKey: process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
+                  ...(awsAuthMethod === "sessionToken" && {
+                    sessionToken: process.env.AWS_BEDROCK_LLM_SESSION_TOKEN,
+                  }),
+                },
+              }),
           ...config,
         });
+      }
       case "fireworksai":
         return new ChatOpenAI({
           apiKey: process.env.FIREWORKS_AI_LLM_API_KEY,

--- a/server/utils/agents/aibitat/providers/bedrock.js
+++ b/server/utils/agents/aibitat/providers/bedrock.js
@@ -19,15 +19,19 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
     const model = process.env.AWS_BEDROCK_LLM_MODEL_PREFERENCE ?? null;
     const client = new ChatBedrockConverse({
       region: process.env.AWS_BEDROCK_LLM_REGION,
-      credentials: {
-        accessKeyId: process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
-        // If we're using a session token, we need to pass it in as a credential
-        // otherwise we must omit it so it does not conflict if using IAM auth
-        ...(this.authMethod === "sessionToken"
-          ? { sessionToken: process.env.AWS_BEDROCK_LLM_SESSION_TOKEN }
-          : {}),
-      },
+      ...(this.authMethod === "profile"
+        ? {
+            profile: process.env.AWS_BEDROCK_LLM_PROFILE_NAME,
+          }
+        : {
+            credentials: {
+              accessKeyId: process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID,
+              secretAccessKey: process.env.AWS_BEDROCK_LLM_ACCESS_KEY,
+              ...(this.authMethod === "sessionToken" && {
+                sessionToken: process.env.AWS_BEDROCK_LLM_SESSION_TOKEN,
+              }),
+            },
+          }),
       model,
     });
 
@@ -38,12 +42,12 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
 
   /**
    * Get the authentication method for the AWS Bedrock LLM.
-   * There are only two valid values for this setting - anything else will default to "iam".
-   * @returns {"iam"|"sessionToken"}
+   * There are only three valid values for this setting - anything else will default to "iam".
+   * @returns {"iam"|"sessionToken"|"profile"}
    */
   get authMethod() {
     const method = process.env.AWS_BEDROCK_LLM_CONNECTION_METHOD || "iam";
-    if (!["iam", "sessionToken"].includes(method)) return "iam";
+    if (!["iam", "sessionToken", "profile"].includes(method)) return "iam";
     return method;
   }
 

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -140,14 +140,26 @@ class AgentHandler {
           );
         break;
       case "bedrock":
-        if (
-          !process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID ||
-          !process.env.AWS_BEDROCK_LLM_ACCESS_KEY ||
-          !process.env.AWS_BEDROCK_LLM_REGION
-        )
-          throw new Error(
-            "AWS Bedrock Access Keys and region must be provided to use agents."
-          );
+        if (process.env.AWS_BEDROCK_LLM_CONNECTION_METHOD === "profile") {
+          if (
+            !process.env.AWS_BEDROCK_LLM_PROFILE_NAME ||
+            !process.env.AWS_BEDROCK_LLM_REGION
+          ) {
+            throw new Error(
+              "AWS Bedrock requires a profile name and region to use agents for the profile authentication method."
+            );
+          }
+        } else {
+          if (
+            !process.env.AWS_BEDROCK_LLM_ACCESS_KEY_ID ||
+            !process.env.AWS_BEDROCK_LLM_ACCESS_KEY ||
+            !process.env.AWS_BEDROCK_LLM_REGION
+          ) {
+            throw new Error(
+              "AWS Bedrock requires valid access keys and a region to use agents for the iam authentication method."
+            );
+          }
+        }
         break;
       case "fireworksai":
         if (!process.env.FIREWORKS_AI_LLM_API_KEY)

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -219,7 +219,9 @@ const KEY_MAPPING = {
     envKey: "AWS_BEDROCK_LLM_CONNECTION_METHOD",
     checks: [
       (input) =>
-        ["iam", "sessionToken"].includes(input) ? null : "Invalid value",
+        ["iam", "sessionToken", "profile"].includes(input)
+          ? null
+          : "Invalid value",
     ],
   },
   AwsBedrockLLMAccessKeyId: {
@@ -233,6 +235,10 @@ const KEY_MAPPING = {
   AwsBedrockLLMSessionToken: {
     envKey: "AWS_BEDROCK_LLM_SESSION_TOKEN",
     checks: [],
+  },
+  AwsBedrockLLMProfileName: {
+    envKey: "AWS_BEDROCK_LLM_PROFILE_NAME",
+    checks: [isNotEmpty],
   },
   AwsBedrockLLMRegion: {
     envKey: "AWS_BEDROCK_LLM_REGION",


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Resolves #2864 

### What is in this change?

Support using AWS Credentials profile to avoid passing the static AWS Access Key and Secret Key manually.
It will also allow the easy integration with using IAM Role when the server is running on AWS EC2.

### Additional Information

- Lanchain Reference code: https://v03.api.js.langchain.com/classes/_langchain_aws.ChatBedrockConverse.html
- https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated → I'll work on this in separate PR since it can be larger change.
- [x] I have tested my code functionality
- [x] Docker build succeeds locally - Ran with each option (IAM, Session, and Profile)

**Test Details**

1. Prepare AWS credentials by running `aws configure`
2. Add the following configuration to the devcontainer.json. 

```json
{
  "mounts": [
    "source=${env:HOME}${env:USERPROFILE}/.aws,target=/root/.aws,type=bind"
  ],
  "remoteUser": "root",
}
```

3. Run the server and check the Bedrock invocation with each option.

With the change, 
- IAM Selected
<img width="745" alt="iam-credentials" src="https://github.com/user-attachments/assets/24164a74-cdc2-4310-b7b4-da8f47e8ad18" />

- Profile Selected
<img width="499" alt="profile-credentials" src="https://github.com/user-attachments/assets/bdfe9e0d-b033-4083-aad8-8380d497761b" />
