### PR TITLE
feat: add support for voyage-3-large and voyage-code-3 embedding models

### DIFF
--- a/frontend/src/components/EmbeddingSelection/VoyageAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/VoyageAiOptions/index.jsx
@@ -38,6 +38,8 @@ export default function VoyageAiOptions({ settings }) {
                 "voyage-2",
                 "voyage-3",
                 "voyage-3-lite",
+                "voyage-3-large",
+                "voyage-code-3",
               ].map((model) => {
                 return (
                   <option key={model} value={model}>

--- a/server/.env.example
+++ b/server/.env.example
@@ -149,7 +149,7 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 
 # EMBEDDING_ENGINE='voyageai'
 # VOYAGEAI_API_KEY=
-# EMBEDDING_MODEL_PREF='voyage-large-2-instruct'
+# EMBEDDING_MODEL_PREF='voyage-3-lite' # Options: voyage-3-large, voyage-code-3, voyage-3, voyage-3-lite, voyage-large-2-instruct, etc.
 
 # EMBEDDING_ENGINE='litellm'
 # EMBEDDING_MODEL_PREF='text-embedding-ada-002'

--- a/server/.env.example
+++ b/server/.env.example
@@ -149,7 +149,7 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 
 # EMBEDDING_ENGINE='voyageai'
 # VOYAGEAI_API_KEY=
-# EMBEDDING_MODEL_PREF='voyage-3-lite' # Options: voyage-3-large, voyage-code-3, voyage-3, voyage-3-lite, voyage-large-2-instruct, etc.
+# EMBEDDING_MODEL_PREF='voyage-large-2-instruct'
 
 # EMBEDDING_ENGINE='litellm'
 # EMBEDDING_MODEL_PREF='text-embedding-ada-002'

--- a/server/utils/EmbeddingEngines/voyageAi/index.js
+++ b/server/utils/EmbeddingEngines/voyageAi/index.js
@@ -24,6 +24,8 @@ class VoyageAiEmbedder {
       case "voyage-multilingual-2":
       case "voyage-3":
       case "voyage-3-lite":
+      case "voyage-3-large":
+      case "voyage-code-3":
         return 32_000;
       case "voyage-large-2-instruct":
       case "voyage-law-2":


### PR DESCRIPTION
- Add voyage-3-large and voyage-code-3 to VoyageAiOptions dropdown
- Update getMaxEmbeddingLength to support 32k context for new models
- Update .env.example with new model options


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### What is in this change?

Added the new VoyageAI models voyage-3-large and voyage-code-3 https://docs.voyageai.com/docs/embeddings

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
