### PR TITLE
fix: calculate estimated tokens for openai only

### DIFF
--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -41,7 +41,10 @@ async function scrapeGenericUrl(link, textOnly = false) {
     published: new Date().toLocaleString(),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asAudio.js
+++ b/collector/processSingleFile/convert/asAudio.js
@@ -56,7 +56,10 @@ async function asAudio({ fullFilePath = "", filename = "", options = {} }) {
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asDocx.js
+++ b/collector/processSingleFile/convert/asDocx.js
@@ -42,7 +42,10 @@ async function asDocX({ fullFilePath = "", filename = "" }) {
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asEPub.js
+++ b/collector/processSingleFile/convert/asEPub.js
@@ -40,7 +40,10 @@ async function asEPub({ fullFilePath = "", filename = "" }) {
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asMbox.js
+++ b/collector/processSingleFile/convert/asMbox.js
@@ -53,7 +53,10 @@ async function asMbox({ fullFilePath = "", filename = "" }) {
       published: createdDate(fullFilePath),
       wordCount: content.split(" ").length,
       pageContent: content,
-      token_count_estimate: tokenizeString(content).length,
+      token_count_estimate:
+        process.env.EMBEDDING_ENGINE === "openai"
+          ? tokenizeString(content).length
+          : undefined,
     };
 
     item++;

--- a/collector/processSingleFile/convert/asOfficeMime.js
+++ b/collector/processSingleFile/convert/asOfficeMime.js
@@ -38,7 +38,10 @@ async function asOfficeMime({ fullFilePath = "", filename = "" }) {
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asPDF/index.js
+++ b/collector/processSingleFile/convert/asPDF/index.js
@@ -49,7 +49,10 @@ async function asPdf({ fullFilePath = "", filename = "" }) {
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asTxt.js
+++ b/collector/processSingleFile/convert/asTxt.js
@@ -38,7 +38,10 @@ async function asTxt({ fullFilePath = "", filename = "" }) {
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   const document = writeToServerDocuments(

--- a/collector/processSingleFile/convert/asXlsx.js
+++ b/collector/processSingleFile/convert/asXlsx.js
@@ -67,7 +67,10 @@ async function asXlsx({ fullFilePath = "", filename = "" }) {
           published: createdDate(fullFilePath),
           wordCount: content.split(/\s+/).length,
           pageContent: content,
-          token_count_estimate: tokenizeString(content).length,
+          token_count_estimate:
+            process.env.EMBEDDING_ENGINE === "openai"
+              ? tokenizeString(content).length
+              : undefined,
         };
 
         const document = writeToServerDocuments(

--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -104,7 +104,10 @@ async function loadConfluence(
       published: new Date().toLocaleString(),
       wordCount: doc.pageContent.split(" ").length,
       pageContent: doc.pageContent,
-      token_count_estimate: tokenizeString(doc.pageContent).length,
+      token_count_estimate:
+        process.env.EMBEDDING_ENGINE === "openai"
+          ? tokenizeString(doc.pageContent).length
+          : undefined,
     };
 
     console.log(

--- a/collector/utils/extensions/RepoLoader/GithubRepo/index.js
+++ b/collector/utils/extensions/RepoLoader/GithubRepo/index.js
@@ -66,7 +66,10 @@ async function loadGithubRepo(args, response) {
       published: new Date().toLocaleString(),
       wordCount: doc.pageContent.split(" ").length,
       pageContent: doc.pageContent,
-      token_count_estimate: tokenizeString(doc.pageContent).length,
+      token_count_estimate:
+        process.env.EMBEDDING_ENGINE === "openai"
+          ? tokenizeString(doc.pageContent).length
+          : undefined,
     };
     console.log(
       `[Github Loader]: Saving ${doc.metadata.source} to ${outFolder}`

--- a/collector/utils/extensions/RepoLoader/GitlabRepo/index.js
+++ b/collector/utils/extensions/RepoLoader/GitlabRepo/index.js
@@ -82,7 +82,10 @@ async function loadGitlabRepo(args, response) {
     }
 
     data.wordCount = pageContent.split(" ").length;
-    data.token_count_estimate = tokenizeString(pageContent).length;
+    data.token_count_estimate =
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(pageContent).length
+        : undefined;
     data.pageContent = pageContent;
 
     console.log(

--- a/collector/utils/extensions/WebsiteDepth/index.js
+++ b/collector/utils/extensions/WebsiteDepth/index.js
@@ -122,7 +122,10 @@ async function bulkScrapePages(links, outFolderPath) {
         published: new Date().toLocaleString(),
         wordCount: content.split(" ").length,
         pageContent: content,
-        token_count_estimate: tokenizeString(content).length,
+        token_count_estimate:
+          process.env.EMBEDDING_ENGINE === "openai"
+            ? tokenizeString(content).length
+            : undefined,
       };
 
       writeToServerDocuments(data, data.title, outFolderPath);

--- a/collector/utils/extensions/YoutubeTranscript/index.js
+++ b/collector/utils/extensions/YoutubeTranscript/index.js
@@ -115,7 +115,10 @@ async function loadYouTubeTranscript({ url }) {
     published: new Date().toLocaleString(),
     wordCount: content.split(" ").length,
     pageContent: content,
-    token_count_estimate: tokenizeString(content).length,
+    token_count_estimate:
+      process.env.EMBEDDING_ENGINE === "openai"
+        ? tokenizeString(content).length
+        : undefined,
   };
 
   console.log(`[YouTube Loader]: Saving ${metadata.title} to ${outFolder}`);

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/index.jsx
@@ -136,7 +136,7 @@ export default function DocumentSettings({ workspace, systemSettings }) {
 
     let totalTokenCount = 0;
     newMovedItems.forEach((item) => {
-      const { cached, token_count_estimate } = item;
+      const { cached, token_count_estimate = 0 } = item;
       if (!cached) {
         totalTokenCount += token_count_estimate;
       }

--- a/server/utils/DocumentManager/index.js
+++ b/server/utils/DocumentManager/index.js
@@ -41,8 +41,9 @@ class DocumentManager {
         );
 
         if (
-          !data.hasOwnProperty("pageContent") ||
-          !data.hasOwnProperty("token_count_estimate")
+          process.env.EMBEDDING_ENGINE === "openai" &&
+          (!data.hasOwnProperty("pageContent") ||
+            !data.hasOwnProperty("token_count_estimate"))
         ) {
           this.log(
             `Skipping document - Could not find page content or token_count_estimate in pinned source.`

--- a/server/utils/TextSplitter/index.js
+++ b/server/utils/TextSplitter/index.js
@@ -10,7 +10,7 @@
  * @property {string} published - ISO 8601 date string
  * @property {number} wordCount - Number of words in the document
  * @property {string} pageContent - The raw text content of the document
- * @property {number} token_count_estimate - Number of tokens in the document
+ * @property {number} [token_count_estimate] - Number of tokens in the document
  */
 
 function isNullOrNaN(value) {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3069


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

The function `tokenizeString` is very CPU-intensive. Its only use I found is here to estimate embedding costs for OpenAI:
https://github.com/Mintplex-Labs/anything-llm/blob/e1af72daa73a12ee96035548f81fd364d5da3c4c/frontend/src/components/Modals/ManageWorkspace/Documents/index.jsx#L145-L146
When run against a local LLM provider, this function isn’t necessary, thus saving significant time and energy.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
