### PR TITLE
autodetect parseable text file contents

### DIFF
--- a/collector/utils/files/mime.js
+++ b/collector/utils/files/mime.js
@@ -1,7 +1,6 @@
 const MimeLib = require("mime");
-const path = require("path");
 class MimeDetector {
-  nonTextTypes = ["multipart", "image", "model", "audio", "video"];
+  nonTextTypes = ["multipart", "image", "model", "audio", "video", "font"];
   badMimes = [
     "application/octet-stream",
     "application/zip",
@@ -48,11 +47,6 @@ class MimeDetector {
     );
   }
 
-  // These are file types that are not detected by the mime library and need to be processed as text files.
-  // You should only add file types that are not detected by the mime library, are parsable as text, and are files
-  // with no extension. Otherwise, their extension should be added to the overrides array.
-  #specialTextFileTypes = ["dockerfile", "jenkinsfile", "dockerignore"];
-
   /**
    * Returns the MIME type of the file. If the file has no extension found, it will be processed as a text file.
    * @param {string} filepath
@@ -61,12 +55,6 @@ class MimeDetector {
   getType(filepath) {
     const parsedMime = this.lib.getType(filepath);
     if (!!parsedMime) return parsedMime;
-
-    // If the mime could not be parsed, it could be a special file type like Dockerfile or Jenkinsfile
-    // which we can reliably process as text files.
-    const baseName = path.basename(filepath)?.toLowerCase();
-    if (this.#specialTextFileTypes.includes(baseName)) return "text/plain";
-
     return null;
   }
 }


### PR DESCRIPTION
 s/o to @wprice-uh for initial work
 
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #2964
closes #2965 


### What is in this change?

When we encounter a filetype not explicitly known by the mime detector we do a limited peek into the first kb of the file. If the file is all control symbols or binary looking content, we assume it is not text. Otherwise we assume text.


<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

This will enable people to upload the millions of text type files are are parseable as text easily, but without an infinite list of growing known text filetypes in our `MimeType` class.

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
