### PR TITLE
fix UserMenu rendered twice on Main page

### DIFF
--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -15,13 +15,9 @@ export default function Main() {
   }
 
   return (
-    <>
-      <UserMenu>
-        <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
-          {!isMobile && <Sidebar />}
-          <DefaultChatContainer />
-        </div>
-      </UserMenu>
-    </>
+    <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
+      {!isMobile && <Sidebar />}
+      <DefaultChatContainer />
+    </div>
   );
 }


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

### What is in this change?

The `<UserMenu>` component is rendered twice on the `<Main>` page:
1. Once in the `<Main>` page
2. Once in the `<PrivateRoute>` component

This PR removes the usage from the `<Main>` page.
I have build the Docker container and tested it locally, there is still a `<UserMenu>` in the top right corner of the `<Main>` page.

### Additional Information

### Developer Validations
- [X] I ran `yarn lint` from the root of the repo & committed changes
- [X] Relevant documentation has been updated
- [X] I have tested my code functionality
- [X] Docker build succeeds locally
