### PR TITLE
fix: Patch agent flow to honor agent handler established provider

### DIFF
--- a/server/utils/agentFlows/executors/api-call.js
+++ b/server/utils/agentFlows/executors/api-call.js
@@ -8,8 +8,8 @@ const { safeJsonParse } = require("../../http");
  */
 async function executeApiCall(config, context) {
   const { url, method, headers = [], body, bodyType, formData } = config;
-  const { introspect } = context;
-
+  const { introspect, logger } = context;
+  logger(`\x1b[43m[AgentFlowToolExecutor]\x1b[0m - executing API Call block`);
   introspect(`Making ${method} request to external API...`);
 
   const requestConfig = {

--- a/server/utils/agentFlows/executors/llm-instruction.js
+++ b/server/utils/agentFlows/executors/llm-instruction.js
@@ -8,15 +8,21 @@ const AIbitat = require("../../agents/aibitat");
  */
 async function executeLLMInstruction(config, context) {
   const { instruction, inputVariable, resultVariable } = config;
-  const { introspect, variables, logger } = context;
-
+  const { introspect, variables, logger, aibitat } = context;
+  logger(
+    `\x1b[43m[AgentFlowToolExecutor]\x1b[0m - executing LLM Instruction block`
+  );
   introspect(`Processing data with LLM instruction...`);
+
   if (!variables[inputVariable]) {
     logger(`Input variable ${inputVariable} not found`);
     throw new Error(`Input variable ${inputVariable} not found`);
   }
 
   try {
+    logger(
+      `Sending request to LLM (${aibitat.defaultProvider.provider}::${aibitat.defaultProvider.model})`
+    );
     introspect(`Sending request to LLM...`);
 
     // Ensure the input is a string since we are sending it to the LLM direct as a message
@@ -24,7 +30,6 @@ async function executeLLMInstruction(config, context) {
     if (typeof input === "object") input = JSON.stringify(input);
     if (typeof input !== "string") input = String(input);
 
-    const aibitat = new AIbitat();
     const provider = aibitat.getProviderForConfig(aibitat.defaultProvider);
     const completion = await provider.complete([
       {

--- a/server/utils/agentFlows/index.js
+++ b/server/utils/agentFlows/index.js
@@ -141,25 +141,14 @@ class AgentFlows {
    * Execute a flow by UUID
    * @param {string} uuid - The UUID of the flow to execute
    * @param {Object} variables - Initial variables for the flow
-   * @param {Function} introspectFn - Function to introspect the flow
-   * @param {Function} loggerFn - Function to log the flow
+   * @param {Object} aibitat - The aibitat instance from the agent handler
    * @returns {Promise<Object>} Result of flow execution
    */
-  static async executeFlow(
-    uuid,
-    variables = {},
-    introspectFn = null,
-    loggerFn = null
-  ) {
+  static async executeFlow(uuid, variables = {}, aibitat = null) {
     const flow = AgentFlows.loadFlow(uuid);
     if (!flow) throw new Error(`Flow ${uuid} not found`);
     const flowExecutor = new FlowExecutor();
-    return await flowExecutor.executeFlow(
-      flow,
-      variables,
-      introspectFn,
-      loggerFn
-    );
+    return await flowExecutor.executeFlow(flow, variables, aibitat);
   }
 
   /**
@@ -210,12 +199,7 @@ class AgentFlows {
             },
             handler: async (args) => {
               aibitat.introspect(`Executing flow: ${flow.name}`);
-              const result = await AgentFlows.executeFlow(
-                uuid,
-                args,
-                aibitat.introspect,
-                aibitat.handlerProps.log
-              );
+              const result = await AgentFlows.executeFlow(uuid, args, aibitat);
               if (!result.success) {
                 aibitat.introspect(
                   `Flow failed: ${result.results[0]?.error || "Unknown error"}`

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -798,7 +798,7 @@ ${this.getHistory({ to: route.to })
 
       default:
         throw new Error(
-          `Unknown provider: ${config.provider}. Please use "openai"`
+          `Unknown provider: ${config.provider}. Please use a valid provider.`
         );
     }
   }

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -390,7 +390,7 @@ class AgentHandler {
       // Load flow plugin. This is marked by `@@flow_` in the array of functions to load.
       if (name.startsWith("@@flow_")) {
         const uuid = name.replace("@@flow_", "");
-        const plugin = AgentFlows.loadFlowPlugin(uuid);
+        const plugin = AgentFlows.loadFlowPlugin(uuid, this.aibitat);
         if (!plugin) {
           this.log(
             `Flow ${uuid} not found in flows directory. Skipping inclusion to agent cluster.`


### PR DESCRIPTION


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3248


### What is in this change?
- Fix bug where the agent flow execution, on calling of an AI model, would always fallback to the default `openai`. This should honor the users workspace LLM, then fallback to the system LLM. Only to prevent code exception should the `openai` fallback be triggered.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

- `aibitat` is now available in `context` for blocks, which gives access to the agent handler aibitat class.

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
