### PR TITLE
Improve PromptInput component

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -24,8 +24,7 @@ const MAX_EDIT_STACK_SIZE = 100;
 export default function PromptInput({
   submit,
   onChange,
-  inputDisabled,
-  buttonDisabled,
+  isStreaming,
   sendCommand,
   attachments = [],
 }) {
@@ -62,9 +61,9 @@ export default function PromptInput({
   }, []);
 
   useEffect(() => {
-    if (!inputDisabled && textareaRef.current) textareaRef.current.focus();
+    if (!isStreaming && textareaRef.current) textareaRef.current.focus();
     resetTextAreaHeight();
-  }, [inputDisabled]);
+  }, [isStreaming]);
 
   /**
    * Save the current state before changes
@@ -115,6 +114,7 @@ export default function PromptInput({
     // Is simple enter key press w/o shift key
     if (event.keyCode === 13 && !event.shiftKey) {
       event.preventDefault();
+      if (isStreaming) return;
       return submit(event);
     }
 
@@ -264,7 +264,6 @@ export default function PromptInput({
                   handlePasteEvent(e);
                 }}
                 required={true}
-                disabled={inputDisabled}
                 onFocus={() => setFocused(true)}
                 onBlur={(e) => {
                   setFocused(false);
@@ -274,7 +273,7 @@ export default function PromptInput({
                 className={`border-none cursor-text max-h-[50vh] md:max-h-[350px] md:min-h-[40px] mx-2 md:mx-0 pt-[12px] w-full leading-5 md:text-md text-white bg-transparent placeholder:text-white/60 light:placeholder:text-theme-text-primary resize-none active:outline-none focus:outline-none flex-grow ${textSizeClass}`}
                 placeholder={"Send a message"}
               />
-              {buttonDisabled ? (
+              {isStreaming ? (
                 <StopGenerationButton />
               ) : (
                 <>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -48,11 +48,6 @@ export default function PromptInput({
     setPromptInput(e?.detail ?? "");
   }
 
-  function resetTextAreaHeight() {
-    if (!textareaRef.current) return;
-    textareaRef.current.style.height = "auto";
-  }
-
   useEffect(() => {
     if (!!window)
       window.addEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -282,8 +282,7 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
         <PromptInput
           submit={handleSubmit}
           onChange={handleMessageChange}
-          inputDisabled={loadingResponse}
-          buttonDisabled={loadingResponse}
+          isStreaming={loadingResponse}
           sendCommand={sendCommand}
           attachments={files}
         />


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3228 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Allow users to type in `PromptInput` text area field when chat is streaming back but does not allow them to submit messages
- Rename props for simplicity
- Remove duplicate `resetTextAreaHeight` function

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
