### PR TITLE
[FEAT] Add claude-3-7

### DIFF
--- a/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
@@ -41,7 +41,7 @@ export default function AnthropicAiOptions({ settings }) {
                 "claude-3-5-sonnet-latest",
                 "claude-3-5-sonnet-20241022",
                 "claude-3-5-sonnet-20240620",
-                "claude-3-7-sonnet-20250219"
+                "claude-3-7-sonnet-20250219",
               ].map((model) => {
                 return (
                   <option key={model} value={model}>

--- a/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
@@ -42,6 +42,7 @@ export default function AnthropicAiOptions({ settings }) {
                 "claude-3-5-sonnet-20241022",
                 "claude-3-5-sonnet-20240620",
                 "claude-3-7-sonnet-20250219",
+                "claude-3-7-sonnet-latest",
               ].map((model) => {
                 return (
                   <option key={model} value={model}>

--- a/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
@@ -41,6 +41,7 @@ export default function AnthropicAiOptions({ settings }) {
                 "claude-3-5-sonnet-latest",
                 "claude-3-5-sonnet-20241022",
                 "claude-3-5-sonnet-20240620",
+                "claude-3-7-sonnet-20250219"
               ].map((model) => {
                 return (
                   <option key={model} value={model}>

--- a/frontend/src/hooks/useGetProvidersModels.js
+++ b/frontend/src/hooks/useGetProvidersModels.js
@@ -38,6 +38,7 @@ const PROVIDER_DEFAULT_MODELS = {
     "claude-3-5-sonnet-20241022",
     "claude-3-5-sonnet-20240620",
     "claude-3-7-sonnet-20250219",
+    "claude-3-7-sonnet-latest",
   ],
   azure: [],
   lmstudio: [],

--- a/frontend/src/hooks/useGetProvidersModels.js
+++ b/frontend/src/hooks/useGetProvidersModels.js
@@ -37,6 +37,7 @@ const PROVIDER_DEFAULT_MODELS = {
     "claude-3-5-sonnet-latest",
     "claude-3-5-sonnet-20241022",
     "claude-3-5-sonnet-20240620",
+    "claude-3-7-sonnet-20250219",
   ],
   azure: [],
   lmstudio: [],

--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -196,8 +196,9 @@ class AnthropicLLM {
         const parseErrorMsg = (event) => {
           const error = event?.error?.error;
           if (!!error)
-            return `Anthropic Error:${error?.type || "unknown"} ${error?.message || "unknown error."
-              }`;
+            return `Anthropic Error:${error?.type || "unknown"} ${
+              error?.message || "unknown error."
+            }`;
           return event.message;
         };
 

--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -58,6 +58,7 @@ class AnthropicLLM {
       "claude-3-5-sonnet-latest",
       "claude-3-5-sonnet-20241022",
       "claude-3-5-sonnet-20240620",
+      "claude-3-7-sonnet-20250219",
     ];
     return validModels.includes(modelName);
   }
@@ -194,9 +195,8 @@ class AnthropicLLM {
         const parseErrorMsg = (event) => {
           const error = event?.error?.error;
           if (!!error)
-            return `Anthropic Error:${error?.type || "unknown"} ${
-              error?.message || "unknown error."
-            }`;
+            return `Anthropic Error:${error?.type || "unknown"} ${error?.message || "unknown error."
+              }`;
           return event.message;
         };
 

--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -59,6 +59,7 @@ class AnthropicLLM {
       "claude-3-5-sonnet-20241022",
       "claude-3-5-sonnet-20240620",
       "claude-3-7-sonnet-20250219",
+      "claude-3-7-sonnet-latest",
     ];
     return validModels.includes(modelName);
   }

--- a/server/utils/AiProviders/modelMap.js
+++ b/server/utils/AiProviders/modelMap.js
@@ -17,6 +17,7 @@ const MODEL_MAP = {
     "claude-3-5-sonnet-20241022": 200_000,
     "claude-3-5-sonnet-20240620": 200_000,
     "claude-3-7-sonnet-20250219": 200_000,
+    "claude-3-7-sonnet-latest": 200_000,
   },
   cohere: {
     "command-r": 128_000,

--- a/server/utils/AiProviders/modelMap.js
+++ b/server/utils/AiProviders/modelMap.js
@@ -16,6 +16,7 @@ const MODEL_MAP = {
     "claude-3-5-sonnet-latest": 200_000,
     "claude-3-5-sonnet-20241022": 200_000,
     "claude-3-5-sonnet-20240620": 200_000,
+    "claude-3-7-sonnet-20250219": 200_000,
   },
   cohere: {
     "command-r": 128_000,

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -758,6 +758,7 @@ function validAnthropicModel(input = "") {
     "claude-3-5-sonnet-20241022",
     "claude-3-5-sonnet-20240620",
     "claude-3-7-sonnet-20250219",
+    "claude-3-7-sonnet-latest",
   ];
   return validModels.includes(input)
     ? null

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -757,6 +757,7 @@ function validAnthropicModel(input = "") {
     "claude-3-5-sonnet-latest",
     "claude-3-5-sonnet-20241022",
     "claude-3-5-sonnet-20240620",
+    "claude-3-7-sonnet-20250219",
   ];
   return validModels.includes(input)
     ? null


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3342 

<img width="924" alt="image" src="https://github.com/user-attachments/assets/dfc1cc64-eaaa-44ae-9d1e-95ffc994ee1d" />


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
[Claude 3.7 Sonnet](https://docs.anthropic.com/en/api/messages) came out recently and can be used in the Messages API for Anthropic. 


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally

Docker build is successful but it needs an x-name: 
<img width="332" alt="image" src="https://github.com/user-attachments/assets/b412908c-a9c1-48fb-ac87-ad904687aaa6" />

instead of `name`

