### PR TITLE
Skip too large files to read

### DIFF
--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -45,10 +45,15 @@ async function viewLocalFiles() {
       };
       const subfiles = fs.readdirSync(folderPath);
       const filenames = {};
+      const maxSize = 0x1fffffe8;
 
       for (const subfile of subfiles) {
         if (path.extname(subfile) !== ".json") continue;
         const filePath = path.join(folderPath, subfile);
+        
+        const stats = fs.statSync(filePath);
+        if (stats.size > maxSize) continue; // skip too large files to read
+
         const rawData = fs.readFileSync(filePath, "utf8");
         const cachefilename = `${file}/${subfile}`;
         const { pageContent, ...metadata } = JSON.parse(rawData);


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [X] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

It's not possible to view documents if there is a file bigger than 512 MB in documents.

### What is in this change?

Skipping the reading the file when the size is bigger than 512 MB.


### Additional Information

By preemptively filtering out oversized files, we improve reliability and maintain system efficiency.
Oversized files can happen due to big PDFs with images.

### Developer Validations


- [X] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [X] I have tested my code functionality
- [ ] Docker build succeeds locally
