### PR TITLE
Enable slash commands in dev API chat/stream-chat

### DIFF
--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -610,7 +610,8 @@ function apiWorkspaceEndpoints(app) {
                  mime: "image/png",
                  contentString: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                }
-             ]
+             ],
+             reset: false
            }
          }
        }
@@ -645,6 +646,7 @@ function apiWorkspaceEndpoints(app) {
           mode = "query",
           sessionId = null,
           attachments = [],
+          reset = false,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug: String(slug) });
 
@@ -660,7 +662,7 @@ function apiWorkspaceEndpoints(app) {
           return;
         }
 
-        if (!message?.length || !VALID_CHAT_MODE.includes(mode)) {
+        if ((!message?.length || !VALID_CHAT_MODE.includes(mode)) && !reset) {
           response.status(400).json({
             id: uuidv4(),
             type: "abort",
@@ -668,7 +670,7 @@ function apiWorkspaceEndpoints(app) {
             sources: [],
             close: true,
             error: !message?.length
-              ? "message parameter cannot be empty."
+              ? "Message is empty"
               : `${mode} is not a valid mode.`,
           });
           return;
@@ -682,6 +684,7 @@ function apiWorkspaceEndpoints(app) {
           thread: null,
           sessionId: !!sessionId ? String(sessionId) : null,
           attachments,
+          reset,
         });
 
         await Telemetry.sendTelemetry("sent_chat", {
@@ -732,7 +735,8 @@ function apiWorkspaceEndpoints(app) {
                  mime: "image/png",
                  contentString: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                }
-             ]
+             ],
+             reset: false
            }
          }
        }
@@ -788,6 +792,7 @@ function apiWorkspaceEndpoints(app) {
           mode = "query",
           sessionId = null,
           attachments = [],
+          reset = false,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug: String(slug) });
 
@@ -803,7 +808,7 @@ function apiWorkspaceEndpoints(app) {
           return;
         }
 
-        if (!message?.length || !VALID_CHAT_MODE.includes(mode)) {
+        if ((!message?.length || !VALID_CHAT_MODE.includes(mode)) && !reset) {
           response.status(400).json({
             id: uuidv4(),
             type: "abort",
@@ -832,6 +837,7 @@ function apiWorkspaceEndpoints(app) {
           thread: null,
           sessionId: !!sessionId ? String(sessionId) : null,
           attachments,
+          reset,
         });
         await Telemetry.sendTelemetry("sent_chat", {
           LLMSelection:

--- a/server/endpoints/api/workspaceThread/index.js
+++ b/server/endpoints/api/workspaceThread/index.js
@@ -351,7 +351,8 @@ function apiWorkspaceThreadEndpoints(app) {
                  mime: "image/png",
                  contentString: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                }
-              ]
+              ],
+              reset: false
             }
           }
         }
@@ -386,6 +387,7 @@ function apiWorkspaceThreadEndpoints(app) {
           mode = "query",
           userId,
           attachments = [],
+          reset = false,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug });
         const thread = await WorkspaceThread.get({
@@ -405,7 +407,7 @@ function apiWorkspaceThreadEndpoints(app) {
           return;
         }
 
-        if (!message?.length || !VALID_CHAT_MODE.includes(mode)) {
+        if ((!message?.length || !VALID_CHAT_MODE.includes(mode)) && !reset) {
           response.status(400).json({
             id: uuidv4(),
             type: "abort",
@@ -413,7 +415,7 @@ function apiWorkspaceThreadEndpoints(app) {
             sources: [],
             close: true,
             error: !message?.length
-              ? "message parameter cannot be empty."
+              ? "Message is empty"
               : `${mode} is not a valid mode.`,
           });
           return;
@@ -427,6 +429,7 @@ function apiWorkspaceThreadEndpoints(app) {
           user,
           thread,
           attachments,
+          reset,
         });
         await Telemetry.sendTelemetry("sent_chat", {
           LLMSelection: process.env.LLM_PROVIDER || "openai",
@@ -489,7 +492,8 @@ function apiWorkspaceThreadEndpoints(app) {
                  mime: "image/png",
                  contentString: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                }
-              ]
+              ],
+              reset: false
             }
           }
         }
@@ -545,6 +549,7 @@ function apiWorkspaceThreadEndpoints(app) {
           mode = "query",
           userId,
           attachments = [],
+          reset = false,
         } = reqBody(request);
         const workspace = await Workspace.get({ slug });
         const thread = await WorkspaceThread.get({
@@ -564,7 +569,7 @@ function apiWorkspaceThreadEndpoints(app) {
           return;
         }
 
-        if (!message?.length || !VALID_CHAT_MODE.includes(mode)) {
+        if ((!message?.length || !VALID_CHAT_MODE.includes(mode)) && !reset) {
           response.status(400).json({
             id: uuidv4(),
             type: "abort",
@@ -594,6 +599,7 @@ function apiWorkspaceThreadEndpoints(app) {
           user,
           thread,
           attachments,
+          reset,
         });
         await Telemetry.sendTelemetry("sent_chat", {
           LLMSelection: process.env.LLM_PROVIDER || "openai",

--- a/server/models/workspaceChats.js
+++ b/server/models/workspaceChats.js
@@ -104,6 +104,9 @@ const WorkspaceChats = {
     }
   },
 
+  /**
+   * @deprecated Use markThreadHistoryInvalidV2 instead.
+   */
   markHistoryInvalid: async function (workspaceId = null, user = null) {
     if (!workspaceId) return;
     try {
@@ -123,6 +126,9 @@ const WorkspaceChats = {
     }
   },
 
+  /**
+   * @deprecated Use markThreadHistoryInvalidV2 instead.
+   */
   markThreadHistoryInvalid: async function (
     workspaceId = null,
     user = null,
@@ -136,6 +142,28 @@ const WorkspaceChats = {
           thread_id: threadId,
           user_id: user?.id,
         },
+        data: {
+          include: false,
+        },
+      });
+      return;
+    } catch (error) {
+      console.error(error.message);
+    }
+  },
+
+  /**
+   * @description This function is used to mark a thread's history as invalid.
+   * and works with an arbitrary where clause.
+   * @param {Object} whereClause - The where clause to update the chats.
+   * @param {Object} data - The data to update the chats with.
+   * @returns {Promise<void>}
+   */
+  markThreadHistoryInvalidV2: async function (whereClause = {}) {
+    if (!whereClause) return;
+    try {
+      await prisma.workspace_chats.updateMany({
+        where: whereClause,
         data: {
           include: false,
         },

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -2280,7 +2280,8 @@
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -2382,7 +2383,8 @@
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -3143,7 +3145,8 @@
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -3255,7 +3258,8 @@
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -3,7 +3,13 @@ const { DocumentManager } = require("../DocumentManager");
 const { WorkspaceChats } = require("../../models/workspaceChats");
 const { getVectorDbClass, getLLMProvider } = require("../helpers");
 const { writeResponseChunk } = require("../helpers/chat/responses");
-const { chatPrompt, sourceIdentifier, recentChatHistory, grepAllUserCommands, VALID_COMMANDS } = require("./index");
+const {
+  chatPrompt,
+  sourceIdentifier,
+  recentChatHistory,
+  grepAllUserCommands,
+  VALID_COMMANDS,
+} = require("./index");
 const {
   EphemeralAgentHandler,
   EphemeralEventListener,

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -514,8 +514,6 @@ async function streamChat({
     apiSessionId: sessionId,
   });
 
-  console.log({ chatHistory });
-
   // Look for pinned documents and see if the user decided to use this feature. We will also do a vector search
   // as pinning is a supplemental tool but it should be used with caution since it can easily blow up a context window.
   // However we limit the maximum of appended context to 80% of its overall size, mostly because if it expands beyond this

--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -36,8 +36,7 @@ async function grepCommand(message, user = null) {
 }
 
 /**
- * @description This function will return the first command found in the message
- * and replace all preset commands with their corresponding prompts.
+ * @description This function will do recursive replacement of all slash commands with their corresponding prompts.
  * @notice This function is used for API calls and is not user-scoped. THIS FUNCTION DOES NOT SUPPORT PRESET COMMANDS.
  * @returns {Promise<string>}
  */

--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -35,17 +35,13 @@ async function grepCommand(message, user = null) {
   return updatedMessage;
 }
 
-async function grepAllUserCommands(message) {
-  const availableCommands = Object.keys(VALID_COMMANDS);
-
-  // Check if the message starts with any built-in command
-  for (let i = 0; i < availableCommands.length; i++) {
-    const cmd = availableCommands[i];
-    const re = new RegExp(`^(${cmd})`, "i");
-    if (re.test(message)) {
-      return cmd;
-    }
-  }
+/**
+ * @description This function will return the first command found in the message
+ * and replace all preset commands with their corresponding prompts.
+ * @notice This function is used for API calls and is not user-scoped. THIS FUNCTION DOES NOT SUPPORT PRESET COMMANDS.
+ * @returns {Promise<string>}
+ */
+async function grepAllSlashCommands(message) {
   const allPresets = await SlashCommandPresets.where({});
 
   // Replace all preset commands with their corresponding prompts
@@ -107,6 +103,6 @@ module.exports = {
   recentChatHistory,
   chatPrompt,
   grepCommand,
-  grepAllUserCommands,
+  grepAllSlashCommands,
   VALID_COMMANDS,
 };

--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -35,6 +35,33 @@ async function grepCommand(message, user = null) {
   return updatedMessage;
 }
 
+async function grepAllUserCommands(message) {
+  const availableCommands = Object.keys(VALID_COMMANDS);
+
+  // Check if the message starts with any built-in command
+  for (let i = 0; i < availableCommands.length; i++) {
+    const cmd = availableCommands[i];
+    const re = new RegExp(`^(${cmd})`, "i");
+    if (re.test(message)) {
+      return cmd;
+    }
+  }
+  const allPresets = await SlashCommandPresets.where({});
+
+  // Replace all preset commands with their corresponding prompts
+  // Allows multiple commands in one message
+  let updatedMessage = message;
+  for (const preset of allPresets) {
+    const regex = new RegExp(
+      `(?:\\b\\s|^)(${preset.command})(?:\\b\\s|$)`,
+      "g"
+    );
+    updatedMessage = updatedMessage.replace(regex, preset.prompt);
+  }
+
+  return updatedMessage;
+}
+
 async function recentChatHistory({
   user = null,
   workspace,
@@ -80,5 +107,6 @@ module.exports = {
   recentChatHistory,
   chatPrompt,
   grepCommand,
+  grepAllUserCommands,
   VALID_COMMANDS,
 };


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3513 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Allows recursive expansion of any slash commands in the developer API endpoints (chat/stream-chat). Default commands like `/reset` are not supported.

- Added `reset` param to API chat/stream endpoints for workspace/thread that can reset chat history of a specific request. This parameter will return early if the `message` property is empty and `reset` is true.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
