### PR TITLE
fix: Update submodule URLs to HTTPS for improved accessibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "browser-extension"]
 	path = browser-extension
-	url = git@github.com:Mintplex-Labs/anythingllm-extension.git
+	url = https://github.com/Mintplex-Labs/anythingllm-extension.git
 [submodule "embed"]
 	path = embed
-	url = git@github.com:Mintplex-Labs/anythingllm-embed.git
+	url = https://github.com/Mintplex-Labs/anythingllm-embed.git
 	branch = main

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@75lb/deep-merge@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@75lb/deep-merge/-/deep-merge-1.1.2.tgz#6aa53d9730e64a159075da65d3bd057abfe1dde0"
+  integrity sha512-08K9ou5VNbheZFxM5tDWoqjA3ImC50DiuuJ2tj1yEPRfkp8lLLg6XAaJ4On+a0yAXor/8ay5gHnAIshRM44Kpw==
+  dependencies:
+    lodash "^4.17.21"
+    typical "^7.1.1"
+
 "@anthropic-ai/sdk@^0.20.1":
   version "0.20.9"
   resolved "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.20.9.tgz"
@@ -2143,6 +2151,11 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
 array-back@^6.2.2:
   version "6.2.2"
   resolved "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz"
@@ -2699,6 +2712,16 @@ command-exists@^1.2.9:
   resolved "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
+command-line-args@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
 command-line-args@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-6.0.1.tgz#cbd1efb4f72b285dbd54bde9a8585c2d9694b070"
@@ -2708,6 +2731,16 @@ command-line-args@^6.0.1:
     find-replace "^5.0.2"
     lodash.camelcase "^4.3.0"
     typical "^7.2.0"
+
+command-line-usage@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-7.0.3.tgz#6bce992354f6af10ecea2b631bfdf0c8b3bfaea3"
+  integrity sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==
+  dependencies:
+    array-back "^6.2.2"
+    chalk-template "^0.4.0"
+    table-layout "^4.1.0"
+    typical "^7.1.1"
 
 command-line-usage@^7.0.1:
   version "7.0.1"
@@ -3592,6 +3625,13 @@ finalhandler@1.2.0:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
 
 find-replace@^5.0.2:
   version "5.0.2"
@@ -6172,6 +6212,11 @@ stoppable@^1.1.0:
   resolved "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz"
   integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
+stream-read-all@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stream-read-all/-/stream-read-all-3.0.1.tgz#60762ae45e61d93ba0978cda7f3913790052ad96"
+  integrity sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==
+
 streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
@@ -6336,6 +6381,19 @@ synckit@^0.8.6:
   dependencies:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
+
+table-layout@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-3.0.2.tgz#69c2be44388a5139b48c59cf21e73b488021769a"
+  integrity sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==
+  dependencies:
+    "@75lb/deep-merge" "^1.1.1"
+    array-back "^6.2.2"
+    command-line-args "^5.2.1"
+    command-line-usage "^7.0.0"
+    stream-read-all "^3.0.1"
+    typical "^7.1.1"
+    wordwrapjs "^5.1.0"
 
 table-layout@^4.1.0:
   version "4.1.1"
@@ -6566,6 +6624,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
 
 typical@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
## Problem
When trying to clone and initialize the repository with submodules, users who don't have SSH keys configured face initialization failures because the browser-extension submodule uses an SSH URL. This creates an unnecessary barrier to entry for new contributors and users who want to work with the full codebase including the browser extension.

## Changes Made
1. Modified `.gitmodules` to use HTTPS instead of SSH for submodule URLs
   - Changed `git@github.com:Mintplex-Labs/anythingllm-extension.git` to `https://github.com/Mintplex-Labs/anythingllm-extension.git`
   - This allows cloning without requiring SSH key setup

2. Updated dependencies in `server/yarn.lock`
   - Ensures consistent dependency versions across environments

3. Fixed submodule initialization process
   - Both browser-extension and embed submodules can now be initialized with a simple `git submodule update --init --recursive`
   - No additional authentication setup required

## Benefits
- **Easier Onboarding**: New users can clone and start working with the codebase immediately
- **Reduced Setup Time**: No need to generate and configure SSH keys just to clone the repository
- **Consistent Access**: HTTPS URLs work consistently across different environments and CI/CD systems
- **Better Documentation**: Clear submodule URLs make it obvious how to access the repositories

## Testing Done
- Successfully tested submodule initialization from a fresh clone
- Verified both browser-extension and embed submodules initialize correctly
- Confirmed all submodule content is properly accessible

## Related Issues
This addresses a common issue where users might see errors like:
```
fatal: Could not read from remote repository.
Please make sure you have the correct access rights and the repository exists.
```
when trying to initialize submodules without SSH keys configured.