### PR TITLE
Persist images attached in API requests to the UI for rendering

### DIFF
--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -115,6 +115,7 @@ async function chatSync({
           response: {
             text: textResponse,
             sources: [],
+            attachments,
             type: chatMode,
             thoughts,
           },
@@ -155,6 +156,7 @@ async function chatSync({
       response: {
         text: textResponse,
         sources: [],
+        attachments: attachments,
         type: chatMode,
         metrics: {},
       },
@@ -267,6 +269,7 @@ async function chatSync({
       response: {
         text: textResponse,
         sources: [],
+        attachments: attachments,
         type: chatMode,
         metrics: {},
       },
@@ -324,6 +327,7 @@ async function chatSync({
     response: {
       text: textResponse,
       sources,
+      attachments,
       type: chatMode,
       metrics: performanceMetrics,
     },
@@ -437,6 +441,7 @@ async function streamChat({
           response: {
             text: textResponse,
             sources: [],
+            attachments: attachments,
             type: chatMode,
             thoughts,
           },
@@ -486,8 +491,8 @@ async function streamChat({
       response: {
         text: textResponse,
         sources: [],
+        attachments: attachments,
         type: chatMode,
-        attachments: [],
         metrics: {},
       },
       threadId: thread?.id || null,
@@ -610,8 +615,8 @@ async function streamChat({
       response: {
         text: textResponse,
         sources: [],
+        attachments: attachments,
         type: chatMode,
-        attachments: [],
         metrics: {},
       },
       threadId: thread?.id || null,
@@ -671,7 +676,13 @@ async function streamChat({
     const { chat } = await WorkspaceChats.new({
       workspaceId: workspace.id,
       prompt: message,
-      response: { text: completeText, sources, type: chatMode, metrics },
+      response: {
+        text: completeText,
+        sources,
+        type: chatMode,
+        metrics,
+        attachments,
+      },
       threadId: thread?.id || null,
       apiSessionId: sessionId,
       user,


### PR DESCRIPTION


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3518


### What is in this change?
- When using `attachments` in the developer API & in a non-multi-user mode of AnythingLLM, the chat content will render in the UI, but images (attachments) did not - this renders them now as well.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
