### PR TITLE
Move CTA save buttons to top of workspace setting screens

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/index.jsx
@@ -9,6 +9,7 @@ import ChatTemperatureSettings from "./ChatTemperatureSettings";
 import ChatModeSelection from "./ChatModeSelection";
 import WorkspaceLLMSelection from "./WorkspaceLLMSelection";
 import ChatQueryRefusalResponse from "./ChatQueryRefusalResponse";
+import CTAButton from "@/components/lib/CTAButton";
 
 export default function ChatSettings({ workspace }) {
   const [settings, setSettings] = useState({});
@@ -45,13 +46,20 @@ export default function ChatSettings({ workspace }) {
 
   if (!workspace) return null;
   return (
-    <div id="workspace-chat-settings-container">
+    <div id="workspace-chat-settings-container" className="relative">
       <form
         ref={formEl}
         onSubmit={handleUpdate}
         id="chat-settings-form"
         className="w-1/2 flex flex-col gap-y-6"
       >
+        {hasChanges && (
+          <div className="absolute top-0 right-0">
+            <CTAButton type="submit">
+              {saving ? "Updating..." : "Update Workspace"}
+            </CTAButton>
+          </div>
+        )}
         <WorkspaceLLMSelection
           settings={settings}
           workspace={workspace}
@@ -78,15 +86,6 @@ export default function ChatSettings({ workspace }) {
           workspace={workspace}
           setHasChanges={setHasChanges}
         />
-        {hasChanges && (
-          <button
-            type="submit"
-            form="chat-settings-form"
-            className="w-fit transition-all duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
-          >
-            {saving ? "Updating..." : "Update workspace"}
-          </button>
-        )}
       </form>
     </div>
   );

--- a/frontend/src/pages/WorkspaceSettings/GeneralAppearance/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/GeneralAppearance/index.jsx
@@ -6,6 +6,7 @@ import WorkspaceName from "./WorkspaceName";
 import SuggestedChatMessages from "./SuggestedChatMessages";
 import DeleteWorkspace from "./DeleteWorkspace";
 import WorkspacePfp from "./WorkspacePfp";
+import CTAButton from "@/components/lib/CTAButton";
 
 export default function GeneralInfo({ slug }) {
   const [workspace, setWorkspace] = useState(null);
@@ -44,29 +45,28 @@ export default function GeneralInfo({ slug }) {
 
   if (!workspace || loading) return null;
   return (
-    <>
+    <div className="w-full relative">
       <form
         ref={formEl}
         onSubmit={handleUpdate}
         className="w-1/2 flex flex-col gap-y-6"
       >
+        {hasChanges && (
+          <div className="absolute top-0 right-0">
+            <CTAButton type="submit">
+              {saving ? "Updating..." : "Update Workspace"}
+            </CTAButton>
+          </div>
+        )}
         <WorkspaceName
           key={workspace.slug}
           workspace={workspace}
           setHasChanges={setHasChanges}
         />
-        {hasChanges && (
-          <button
-            type="submit"
-            className="transition-all w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
-          >
-            {saving ? "Updating..." : "Update workspace"}
-          </button>
-        )}
       </form>
       <SuggestedChatMessages slug={workspace.slug} />
       <WorkspacePfp workspace={workspace} slug={slug} />
       <DeleteWorkspace workspace={workspace} />
-    </>
+    </div>
   );
 }

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/index.jsx
@@ -8,6 +8,7 @@ import DocumentSimilarityThreshold from "./DocumentSimilarityThreshold";
 import ResetDatabase from "./ResetDatabase";
 import VectorCount from "./VectorCount";
 import VectorSearchMode from "./VectorSearchMode";
+import CTAButton from "@/components/lib/CTAButton";
 
 export default function VectorDatabase({ workspace }) {
   const [hasChanges, setHasChanges] = useState(false);
@@ -35,30 +36,34 @@ export default function VectorDatabase({ workspace }) {
 
   if (!workspace) return null;
   return (
-    <form
-      ref={formEl}
-      onSubmit={handleUpdate}
-      className="w-1/2 flex flex-col gap-y-6"
-    >
-      <div className="flex items-start gap-x-5">
-        <VectorDBIdentifier workspace={workspace} />
-        <VectorCount reload={true} workspace={workspace} />
-      </div>
-      <VectorSearchMode workspace={workspace} setHasChanges={setHasChanges} />
-      <MaxContextSnippets workspace={workspace} setHasChanges={setHasChanges} />
-      <DocumentSimilarityThreshold
-        workspace={workspace}
-        setHasChanges={setHasChanges}
-      />
-      <ResetDatabase workspace={workspace} />
-      {hasChanges && (
-        <button
-          type="submit"
-          className="w-fit transition-all duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
-        >
-          {saving ? "Updating..." : "Update workspace"}
-        </button>
-      )}
-    </form>
+    <div className="w-full relative">
+      <form
+        ref={formEl}
+        onSubmit={handleUpdate}
+        className="w-1/2 flex flex-col gap-y-6"
+      >
+        {hasChanges && (
+          <div className="absolute top-0 right-0">
+            <CTAButton type="submit">
+              {saving ? "Updating..." : "Update Workspace"}
+            </CTAButton>
+          </div>
+        )}
+        <div className="flex items-start gap-x-5">
+          <VectorDBIdentifier workspace={workspace} />
+          <VectorCount reload={true} workspace={workspace} />
+        </div>
+        <VectorSearchMode workspace={workspace} setHasChanges={setHasChanges} />
+        <MaxContextSnippets
+          workspace={workspace}
+          setHasChanges={setHasChanges}
+        />
+        <DocumentSimilarityThreshold
+          workspace={workspace}
+          setHasChanges={setHasChanges}
+        />
+        <ResetDatabase workspace={workspace} />
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3612 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Multiple users have reported it is not user friendly to scroll down to the bottom of each of the workspace settings pages in order to save
- Lots of users will do things such as modify prompt and forget to save because the button is not visible
- Move the button to the top right corner of the screen to help improve visibility and UX

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
