### PR TITLE
Disable Agent retry to prevent looping on crash

### DIFF
--- a/server/utils/agents/aibitat/plugins/cli.js
+++ b/server/utils/agents/aibitat/plugins/cli.js
@@ -19,14 +19,9 @@ const cli = {
         let printing = [];
 
         aibitat.onError(async (error) => {
-          console.error(chalk.red(`   error: ${error?.message}`));
-          if (error instanceof RetryError) {
-            console.error(chalk.red(`   retrying in 60 seconds...`));
-            setTimeout(() => {
-              aibitat.retry();
-            }, 60000);
-            return;
-          }
+          let errorMessage =
+            error?.message || "An error occurred while running the agent.";
+          console.error(chalk.red(`   error: ${errorMessage}`), error);
         });
 
         aibitat.onStart(() => {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3463


### What is in this change?

- Prevent infinite retry on any LLM provider crash/abort due to rate-limiting or otherwise. This will prevent closes connections from being able to retry if they failed.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information
- Surfaces error to UI or as a result via API

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
