### PR TITLE
Allow custom headers in upload-link endpoint

### DIFF
--- a/collector/index.js
+++ b/collector/index.js
@@ -62,13 +62,13 @@ app.post(
   "/process-link",
   [verifyPayloadIntegrity],
   async function (request, response) {
-    const { link, headers = {} } = reqBody(request);
+    const { link, scraperHeaders = {} } = reqBody(request);
     try {
       const {
         success,
         reason,
         documents = [],
-      } = await processLink(link, headers);
+      } = await processLink(link, scraperHeaders);
       response.status(200).json({ url: link, success, reason, documents });
     } catch (e) {
       console.error(e);

--- a/collector/index.js
+++ b/collector/index.js
@@ -62,9 +62,13 @@ app.post(
   "/process-link",
   [verifyPayloadIntegrity],
   async function (request, response) {
-    const { link } = reqBody(request);
+    const { link, headers = {} } = reqBody(request);
     try {
-      const { success, reason, documents = [] } = await processLink(link);
+      const {
+        success,
+        reason,
+        documents = [],
+      } = await processLink(link, headers);
       response.status(200).json({ url: link, success, reason, documents });
     } catch (e) {
       console.error(e);

--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -96,7 +96,7 @@ async function getPageContent(link, captureAs = "text", headers = {}) {
 
     // Override scrape method if headers are available
     if (Object.keys(headers).length > 0) {
-      loader.scrape = async function() {
+      loader.scrape = async function () {
         const { launch } = await PuppeteerWebBaseLoader.imports();
         const browser = await launch({
           headless: "new",

--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -73,19 +73,24 @@ async function scrapeGenericUrl({
 /**
  * Validate the headers object
  * - Keys & Values must be strings and not empty
- * - Delete any keys from the object that are not strings or empty
+ * - Assemble a new object with only the valid keys and values
  * @param {{[key: string]: string}} headers - The headers object to validate
  * @returns {{[key: string]: string}} - The validated headers object
  */
 function validatedHeaders(headers = {}) {
-  if (Object.keys(headers).length === 0) return {};
-  let validHeaders = {};
-  for (const key of Object.keys(headers)) {
-    if (!key || typeof headers[key] !== "string") continue;
-    if (!headers[key] || typeof headers[key] !== "string") continue;
-    validHeaders[key] = headers[key];
+  try {
+    if (Object.keys(headers).length === 0) return {};
+    let validHeaders = {};
+    for (const key of Object.keys(headers)) {
+      if (!key?.trim()) continue;
+      if (typeof headers[key] !== "string" || !headers[key]?.trim()) continue;
+      validHeaders[key] = headers[key].trim();
+    }
+    return validHeaders;
+  } catch (error) {
+    console.error("Error validating headers", error);
+    return {};
   }
-  return validHeaders;
 }
 
 /**

--- a/collector/processLink/index.js
+++ b/collector/processLink/index.js
@@ -1,20 +1,21 @@
 const { validURL } = require("../utils/url");
 const { scrapeGenericUrl } = require("./convert/generic");
 
-async function processLink(link) {
+async function processLink(link, headers = {}) {
   if (!validURL(link)) return { success: false, reason: "Not a valid URL." };
-  return await scrapeGenericUrl(link);
+  return await scrapeGenericUrl(link, "text", true, headers);
 }
 
 /**
  * Get the text content of a link
  * @param {string} link - The link to get the text content of
  * @param {('html' | 'text' | 'json')} captureAs - The format to capture the page content as
+ * @param {Object} headers - Custom headers to use when making the request
  * @returns {Promise<{success: boolean, content: string}>} - Response from collector
  */
-async function getLinkText(link, captureAs = "text") {
+async function getLinkText(link, captureAs = "text", headers = {}) {
   if (!validURL(link)) return { success: false, reason: "Not a valid URL." };
-  return await scrapeGenericUrl(link, captureAs, false);
+  return await scrapeGenericUrl(link, captureAs, false, headers);
 }
 
 module.exports = {

--- a/collector/processLink/index.js
+++ b/collector/processLink/index.js
@@ -1,21 +1,37 @@
 const { validURL } = require("../utils/url");
 const { scrapeGenericUrl } = require("./convert/generic");
 
-async function processLink(link, headers = {}) {
+/**
+ * Process a link and return the text content. This util will save the link as a document
+ * so it can be used for embedding later.
+ * @param {string} link - The link to process
+ * @param {{[key: string]: string}} scraperHeaders - Custom headers to apply when scraping the link
+ * @returns {Promise<{success: boolean, content: string}>} - Response from collector
+ */
+async function processLink(link, scraperHeaders = {}) {
   if (!validURL(link)) return { success: false, reason: "Not a valid URL." };
-  return await scrapeGenericUrl(link, "text", true, headers);
+  return await scrapeGenericUrl({
+    link,
+    captureAs: "text",
+    processAsDocument: true,
+    scraperHeaders,
+  });
 }
 
 /**
- * Get the text content of a link
+ * Get the text content of a link - does not save the link as a document
+ * Mostly used in agentic flows/tools calls to get the text content of a link
  * @param {string} link - The link to get the text content of
  * @param {('html' | 'text' | 'json')} captureAs - The format to capture the page content as
- * @param {Object} headers - Custom headers to use when making the request
  * @returns {Promise<{success: boolean, content: string}>} - Response from collector
  */
-async function getLinkText(link, captureAs = "text", headers = {}) {
+async function getLinkText(link, captureAs = "text") {
   if (!validURL(link)) return { success: false, reason: "Not a valid URL." };
-  return await scrapeGenericUrl(link, captureAs, false, headers);
+  return await scrapeGenericUrl({
+    link,
+    captureAs,
+    processAsDocument: false,
+  });
 }
 
 module.exports = {

--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -323,9 +323,9 @@ function apiDocumentEndpoints(app) {
               example: {
                 "link": "https://anythingllm.com",
                 "addToWorkspaces": "workspace1,workspace2",
-                "headers": {
+                "scraperHeaders": {
                   "Authorization": "Bearer token123",
-                  "Custom-Header": "value"
+                  "My-Custom-Header": "value"
                 }
               }
             }
@@ -369,7 +369,11 @@ function apiDocumentEndpoints(app) {
     */
       try {
         const Collector = new CollectorApi();
-        const { link, addToWorkspaces = "", headers = {} } = reqBody(request);
+        const {
+          link,
+          addToWorkspaces = "",
+          scraperHeaders = {},
+        } = reqBody(request);
         const processingOnline = await Collector.online();
 
         if (!processingOnline) {
@@ -385,7 +389,7 @@ function apiDocumentEndpoints(app) {
 
         const { success, reason, documents } = await Collector.processLink(
           link,
-          headers
+          scraperHeaders
         );
         if (!success) {
           response

--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -322,7 +322,11 @@ function apiDocumentEndpoints(app) {
               type: 'object',
               example: {
                 "link": "https://anythingllm.com",
-                "addToWorkspaces": "workspace1,workspace2"
+                "addToWorkspaces": "workspace1,workspace2",
+                "headers": {
+                  "Authorization": "Bearer token123",
+                  "Custom-Header": "value"
+                }
               }
             }
           }
@@ -365,7 +369,7 @@ function apiDocumentEndpoints(app) {
     */
       try {
         const Collector = new CollectorApi();
-        const { link, addToWorkspaces = "" } = reqBody(request);
+        const { link, addToWorkspaces = "", headers = {} } = reqBody(request);
         const processingOnline = await Collector.online();
 
         if (!processingOnline) {
@@ -379,8 +383,10 @@ function apiDocumentEndpoints(app) {
           return;
         }
 
-        const { success, reason, documents } =
-          await Collector.processLink(link);
+        const { success, reason, documents } = await Collector.processLink(
+          link,
+          headers
+        );
         if (!success) {
           response
             .status(500)

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -1093,9 +1093,9 @@
                 "example": {
                   "link": "https://anythingllm.com",
                   "addToWorkspaces": "workspace1,workspace2",
-                  "headers": {
+                  "scraperHeaders": {
                     "Authorization": "Bearer token123",
-                    "Custom-Header": "value"
+                    "My-Custom-Header": "value"
                   }
                 }
               }

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -1092,7 +1092,11 @@
                 "type": "object",
                 "example": {
                   "link": "https://anythingllm.com",
-                  "addToWorkspaces": "workspace1,workspace2"
+                  "addToWorkspaces": "workspace1,workspace2",
+                  "headers": {
+                    "Authorization": "Bearer token123",
+                    "Custom-Header": "value"
+                  }
                 }
               }
             }

--- a/server/utils/collectorApi/index.js
+++ b/server/utils/collectorApi/index.js
@@ -101,12 +101,18 @@ class CollectorApi {
    * Process a link
    * - Will append the options to the request body
    * @param {string} link - The link to process
+   * @param {Object} headers - Custom headers to use when making the request
    * @returns {Promise<Object>} - The response from the collector API
    */
-  async processLink(link = "") {
+  async processLink(link = "", headers = {}) {
     if (!link) return false;
 
-    const data = JSON.stringify({ link, options: this.#attachOptions() });
+    const data = JSON.stringify({
+      link,
+      headers,
+      options: this.#attachOptions(),
+    });
+
     return await fetch(`${this.endpoint}/process-link`, {
       method: "POST",
       headers: {

--- a/server/utils/collectorApi/index.js
+++ b/server/utils/collectorApi/index.js
@@ -101,15 +101,15 @@ class CollectorApi {
    * Process a link
    * - Will append the options to the request body
    * @param {string} link - The link to process
-   * @param {Object} headers - Custom headers to use when making the request
+   * @param {{[key: string]: string}} scraperHeaders - Custom headers to apply to the web-scraping request URL
    * @returns {Promise<Object>} - The response from the collector API
    */
-  async processLink(link = "", headers = {}) {
+  async processLink(link = "", scraperHeaders = {}) {
     if (!link) return false;
 
     const data = JSON.stringify({
       link,
-      headers,
+      scraperHeaders,
       options: this.#attachOptions(),
     });
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3626 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Allows users calling on the `/v1/document/upload-link` endpoint to set (optional) custom headers that are passed to the puppeteer web scraper
- Ensured it does not break any existing functionality in developer API or main application

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
