### PR TITLE
Add Custom SSO Button to Login Page via Branding Settings

### DIFF
--- a/frontend/src/components/Modals/Password/MultiUserAuth.jsx
+++ b/frontend/src/components/Modals/Password/MultiUserAuth.jsx
@@ -8,6 +8,7 @@ import { useModal } from "@/hooks/useModal";
 import RecoveryCodeModal from "@/components/Modals/DisplayRecoveryCodeModal";
 import { useTranslation } from "react-i18next";
 import { t } from "i18next";
+import SSOButton from "./SSOAuth";
 
 const RecoveryForm = ({ onSubmit, setShowRecoveryForm }) => {
   const [username, setUsername] = useState("");
@@ -323,16 +324,21 @@ export default function MultiUserAuth() {
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
             </div>
           </div>
-          <div className="flex items-center md:p-12 px-10 mt-12 md:mt-0 space-x-2 border-gray-600 w-full flex-col gap-y-8">
+          <div className="flex flex-col items-center md:p-12 px-6 md:px-0 mt-12 md:mt-0 w-full gap-y-4">
             <button
               disabled={loading}
               type="submit"
-              className="md:text-primary-button md:bg-transparent text-dark-text text-sm font-bold focus:ring-4 focus:outline-none rounded-md border-[1.5px] border-primary-button md:h-[34px] h-[48px] md:hover:text-white md:hover:bg-primary-button bg-primary-button focus:z-10 w-full"
+              className="appearance-none leading-normal md:text-primary-button md:bg-transparent text-dark-text text-sm font-bold focus:ring-4 focus:outline-none rounded-md border-[1.5px] border-primary-button md:h-[34px] h-[48px] md:hover:text-white md:hover:bg-primary-button bg-primary-button focus:z-10 w-full md:w-[300px]"
             >
               {loading
                 ? t("login.multi-user.validating")
                 : t("login.multi-user.login")}
             </button>
+
+            <div className="w-full flex justify-center">
+              <SSOButton />
+            </div>
+
             <button
               type="button"
               className="text-white text-sm flex gap-x-1 hover:text-primary-button hover:underline"

--- a/frontend/src/components/Modals/Password/SSOAuth.jsx
+++ b/frontend/src/components/Modals/Password/SSOAuth.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+import System from "../../../models/system";
+
+export default function SSOButton() {
+  const [ssoUrl, setSsoUrl] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchSSO() {
+      const { url, error } = await System.fetchssoButton();
+      if (!error && typeof url === "string") {
+        setSsoUrl(url);
+      }
+      setLoading(false);
+    }
+    fetchSSO();
+  }, []);
+
+  if (loading || ssoUrl === "") return null;
+
+  const handleSSORedirect = () => {
+    window.location.href = ssoUrl;
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleSSORedirect}
+      className="appearance-none leading-normal md:text-primary-button md:bg-transparent text-dark-text text-sm font-bold focus:ring-4 focus:outline-none rounded-md border-[1.5px] border-primary-button md:h-[34px] h-[48px] md:hover:text-white md:hover:bg-primary-button bg-primary-button focus:z-10 w-full md:w-[300px]"
+    >
+      Sign in with SSO
+    </button>
+  );
+}

--- a/frontend/src/locales/ar/common.js
+++ b/frontend/src/locales/ar/common.js
@@ -694,6 +694,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/da/common.js
+++ b/frontend/src/locales/da/common.js
@@ -733,6 +733,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/de/common.js
+++ b/frontend/src/locales/de/common.js
@@ -731,6 +731,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -487,6 +487,11 @@ const TRANSLATIONS = {
         description:
           "Set the support email address that should be accessible by users when they need help.",
       },
+      "sso-button": {
+        title: "Single Sign On (SSO) URL",
+        description:
+          "Set the SSO URL that should redirect users on the login page.",
+      },
       "app-name": {
         title: "Name",
         description:

--- a/frontend/src/locales/es/common.js
+++ b/frontend/src/locales/es/common.js
@@ -693,6 +693,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/fa/common.js
+++ b/frontend/src/locales/fa/common.js
@@ -686,6 +686,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/fr/common.js
+++ b/frontend/src/locales/fr/common.js
@@ -694,6 +694,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/he/common.js
+++ b/frontend/src/locales/he/common.js
@@ -679,6 +679,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/it/common.js
+++ b/frontend/src/locales/it/common.js
@@ -692,6 +692,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/ja/common.js
+++ b/frontend/src/locales/ja/common.js
@@ -725,6 +725,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/ko/common.js
+++ b/frontend/src/locales/ko/common.js
@@ -679,6 +679,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/nl/common.js
+++ b/frontend/src/locales/nl/common.js
@@ -689,6 +689,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/pt_BR/common.js
+++ b/frontend/src/locales/pt_BR/common.js
@@ -690,6 +690,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/ru/common.js
+++ b/frontend/src/locales/ru/common.js
@@ -734,6 +734,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/tr/common.js
+++ b/frontend/src/locales/tr/common.js
@@ -689,6 +689,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/vn/common.js
+++ b/frontend/src/locales/vn/common.js
@@ -688,6 +688,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/zh/common.js
+++ b/frontend/src/locales/zh/common.js
@@ -667,6 +667,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/locales/zh_TW/common.js
+++ b/frontend/src/locales/zh_TW/common.js
@@ -670,6 +670,10 @@ const TRANSLATIONS = {
         title: null,
         description: null,
       },
+      "sso-button": {
+        title: null,
+        description: null,
+      },
       "app-name": {
         title: null,
         description: null,

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -321,14 +321,11 @@ const System = {
     if (!!url && Date.now() - lastFetched < 3_600_000)
       return { url: url, error: null };
 
-    const { ssoButton, error } = await fetch(
-      `${API_BASE}/system/sso-button`,
-      {
-        method: "GET",
-        cache: "no-cache",
-        headers: baseHeaders(),
-      }
-    )
+    const { ssoButton, error } = await fetch(`${API_BASE}/system/sso-button`, {
+      method: "GET",
+      cache: "no-cache",
+      headers: baseHeaders(),
+    })
       .then((res) => res.json())
       .catch((e) => {
         console.log(e);

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -10,6 +10,7 @@ const System = {
     footerIcons: "anythingllm_footer_links",
     supportEmail: "anythingllm_support_email",
     customAppName: "anythingllm_custom_app_name",
+    SSOButton: "anythingllm_sso_url",
     canViewChatHistory: "anythingllm_can_view_chat_history",
   },
   ping: async function () {
@@ -309,6 +310,37 @@ const System = {
       JSON.stringify({ email: supportEmail, lastFetched: Date.now() })
     );
     return { email: supportEmail, error: null };
+  },
+
+  fetchssoButton: async function () {
+    const cache = window.localStorage.getItem(this.cacheKeys.ssoButton);
+    const { url, lastFetched } = cache
+      ? safeJsonParse(cache, { url: "", lastFetched: 0 })
+      : { url: "", lastFetched: 0 };
+
+    if (!!url && Date.now() - lastFetched < 3_600_000)
+      return { url: url, error: null };
+
+    const { ssoButton, error } = await fetch(
+      `${API_BASE}/system/sso-button`,
+      {
+        method: "GET",
+        cache: "no-cache",
+        headers: baseHeaders(),
+      }
+    )
+      .then((res) => res.json())
+      .catch((e) => {
+        console.log(e);
+        return { url: "", error: e.message };
+      });
+
+    if (!ssoButton || !!error) return { url: "", error: null };
+    window.localStorage.setItem(
+      this.cacheKeys.ssoButton,
+      JSON.stringify({ url: ssoButton, lastFetched: Date.now() })
+    );
+    return { url: ssoButton, error: null };
   },
 
   fetchCustomAppName: async function () {

--- a/frontend/src/pages/GeneralSettings/Settings/Branding/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/Branding/index.jsx
@@ -7,6 +7,7 @@ import CustomMessages from "../components/CustomMessages";
 import { useTranslation } from "react-i18next";
 import CustomAppName from "../components/CustomAppName";
 import CustomSiteSettings from "../components/CustomSiteSettings";
+import SSOButton from "../components/SSOButton";
 
 export default function BrandingSettings() {
   const { t } = useTranslation();
@@ -34,6 +35,7 @@ export default function BrandingSettings() {
           <CustomMessages />
           <FooterCustomization />
           <SupportEmail />
+          <SSOButton />
           <CustomSiteSettings />
         </div>
       </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/SSOButton/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/SSOButton/index.jsx
@@ -55,10 +55,7 @@ export default function SSOButton() {
 
   if (!canCustomize || loading) return null;
   return (
-    <form
-      className="flex flex-col gap-y-0.5 mt-4"
-      onSubmit={updatessoButton}
-    >
+    <form className="flex flex-col gap-y-0.5 mt-4" onSubmit={updatessoButton}>
       <h2 className="text-sm leading-6 font-semibold text-white">
         {t("customization.items.sso-button.title")}
       </h2>

--- a/frontend/src/pages/GeneralSettings/Settings/components/SSOButton/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/SSOButton/index.jsx
@@ -1,0 +1,99 @@
+import useUser from "@/hooks/useUser";
+import Admin from "@/models/admin";
+import System from "@/models/system";
+import showToast from "@/utils/toast";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export default function SSOButton() {
+  const [canCustomize, setCanCustomize] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [ssoButton, setssoButton] = useState("");
+  const [ssobool, setSSObool] = useState("");
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const fetchssoButton = async () => {
+      const ssoButton = await System.fetchssoButton();
+      setssoButton(ssoButton.url || "");
+      setSSObool(ssoButton.url || "");
+      setCanCustomize(true);
+      setLoading(false);
+    };
+    fetchssoButton();
+  }, []);
+
+  const updatessoButton = async (e, newValue = null) => {
+    e.preventDefault();
+    let sso_url = newValue;
+    if (newValue === null) {
+      const form = new FormData(e.target);
+      sso_url = form.get("ssoButton");
+    }
+
+    const { success, error } = await Admin.updateSystemPreferences({
+      sso_url,
+    });
+
+    if (!success) {
+      showToast(`Failed to update sso url: ${error}`, "error");
+      return;
+    } else {
+      showToast("Successfully updated sso url.", "success");
+      window.localStorage.removeItem(System.cacheKeys.ssoButton);
+      setssoButton(sso_url);
+      setSSObool(sso_url);
+      setHasChanges(false);
+    }
+  };
+
+  const handleChange = (e) => {
+    setssoButton(e.target.value);
+    setHasChanges(true);
+  };
+
+  if (!canCustomize || loading) return null;
+  return (
+    <form
+      className="flex flex-col gap-y-0.5 mt-4"
+      onSubmit={updatessoButton}
+    >
+      <h2 className="text-sm leading-6 font-semibold text-white">
+        {t("customization.items.sso-button.title")}
+      </h2>
+      <p className="text-xs text-white/60">
+        {t("customization.items.sso-button.description")}
+      </p>
+      <div className="flex items-center gap-x-4">
+        <input
+          name="ssoButton"
+          type="text"
+          className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+          placeholder="https://anythingllm.com/ssologin"
+          required={true}
+          autoComplete="off"
+          onChange={handleChange}
+          value={ssoButton}
+        />
+        {ssobool !== "" && (
+          <button
+            type="button"
+            onClick={(e) => updatessoButton(e, "")}
+            className="text-white text-base font-medium hover:text-opacity-60"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      {hasChanges && (
+        <button
+          type="submit"
+          className="transition-all mt-2 w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
+        >
+          Save
+        </button>
+      )}
+    </form>
+  );
+}

--- a/server/endpoints/admin.js
+++ b/server/endpoints/admin.js
@@ -383,6 +383,9 @@ function adminEndpoints(app) {
             case "custom_app_name":
               requestedSettings[label] = setting?.value || null;
               break;
+            case "sso_url":
+              requestedSettings[label] = setting?.value || null;
+              break;
             case "feature_flags":
               requestedSettings[label] =
                 (await SystemSettings.getFeatureFlags()) || {};
@@ -452,6 +455,9 @@ function adminEndpoints(app) {
           imported_agent_skills: ImportedPlugin.listImportedPlugins(),
           custom_app_name:
             (await SystemSettings.get({ label: "custom_app_name" }))?.value ||
+            null,
+          sso_url:
+            (await SystemSettings.get({ label: "sso_url" }))?.value ||
             null,
           feature_flags: (await SystemSettings.getFeatureFlags()) || {},
           meta_page_title: await SystemSettings.getValueOrFallback(

--- a/server/endpoints/admin.js
+++ b/server/endpoints/admin.js
@@ -457,8 +457,7 @@ function adminEndpoints(app) {
             (await SystemSettings.get({ label: "custom_app_name" }))?.value ||
             null,
           sso_url:
-            (await SystemSettings.get({ label: "sso_url" }))?.value ||
-            null,
+            (await SystemSettings.get({ label: "sso_url" }))?.value || null,
           feature_flags: (await SystemSettings.getFeatureFlags()) || {},
           meta_page_title: await SystemSettings.getValueOrFallback(
             { label: "meta_page_title" },

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -655,6 +655,21 @@ function systemEndpoints(app) {
     }
   });
 
+  app.get("/system/sso-button", async (_, response) => {
+    try {
+      const ssoButton =
+        (
+          await SystemSettings.get({
+            label: "sso_url",
+          })
+        )?.value ?? null;
+      response.status(200).json({ ssoButton: ssoButton });
+    } catch (error) {
+      console.error("Error fetching custom app name:", error);
+      response.status(500).json({ message: "Internal server error" });
+    }
+  });
+
   app.get(
     "/system/pfp/:id",
     [validatedRequest, flexUserRoleValid([ROLES.all])],

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -38,7 +38,7 @@ const SystemSettings = {
     "footer_data",
     "support_email",
     "sso_url",
-    
+
     "text_splitter_chunk_size",
     "text_splitter_chunk_overlap",
     "agent_search_provider",

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -18,6 +18,7 @@ const SystemSettings = {
   publicFields: [
     "footer_data",
     "support_email",
+    "sso_url",
     "text_splitter_chunk_size",
     "text_splitter_chunk_overlap",
     "max_embed_chunk_size",
@@ -36,7 +37,8 @@ const SystemSettings = {
     "telemetry_id",
     "footer_data",
     "support_email",
-
+    "sso_url",
+    
     "text_splitter_chunk_size",
     "text_splitter_chunk_overlap",
     "agent_search_provider",


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [X] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs


### What is in this change?

This update lets you add a custom URL in the branding settings, which will display a Single Sign-On (SSO) button right on the login screen. When users click it, they’ll be redirected to the specified URL — making it easier to hook into external authentication systems without modifying the core code.


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [X] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [X] I have tested my code functionality
- [X] Docker build succeeds locally
