### PR TITLE
Add option to control KoboldCPP max response tokens

### DIFF
--- a/frontend/src/components/LLMSelection/KoboldCPPOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/KoboldCPPOptions/index.jsx
@@ -22,9 +22,16 @@ export default function KoboldCPPOptions({ settings }) {
   const [tokenLimit, setTokenLimit] = useState(
     settings?.KoboldCPPTokenLimit || 4096
   );
+  const [maxTokens, setMaxTokens] = useState(
+    settings?.KoboldCPPMaxTokens || 2048
+  );
 
   const handleTokenLimitChange = (e) => {
     setTokenLimit(Number(e.target.value));
+  };
+
+  const handleMaxTokensChange = (e) => {
+    setMaxTokens(Number(e.target.value));
   };
 
   return (
@@ -52,6 +59,26 @@ export default function KoboldCPPOptions({ settings }) {
           />
           <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
             Maximum number of tokens for context and response.
+          </p>
+        </div>
+        <div className="flex flex-col w-60">
+          <label className="text-white text-sm font-semibold block mb-2">
+            Max response tokens
+          </label>
+          <input
+            type="number"
+            name="KoboldCPPMaxTokens"
+            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            placeholder="2048"
+            min={1}
+            value={maxTokens}
+            onChange={handleMaxTokensChange}
+            onScroll={(e) => e.target.blur()}
+            required={true}
+            autoComplete="off"
+          />
+          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            Maximum number of tokens for the response.
           </p>
         </div>
       </div>

--- a/server/.env.example
+++ b/server/.env.example
@@ -78,6 +78,7 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # KOBOLD_CPP_BASE_PATH='http://127.0.0.1:5000/v1'
 # KOBOLD_CPP_MODEL_PREF='koboldcpp/codellama-7b-instruct.Q4_K_S'
 # KOBOLD_CPP_MODEL_TOKEN_LIMIT=4096
+# KOBOLD_CPP_MAX_TOKENS=2048
 
 # LLM_PROVIDER='textgenwebui'
 # TEXT_GEN_WEB_UI_BASE_PATH='http://127.0.0.1:5000/v1'

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -513,6 +513,7 @@ const SystemSettings = {
       KoboldCPPModelPref: process.env.KOBOLD_CPP_MODEL_PREF,
       KoboldCPPBasePath: process.env.KOBOLD_CPP_BASE_PATH,
       KoboldCPPTokenLimit: process.env.KOBOLD_CPP_MODEL_TOKEN_LIMIT,
+      KoboldCPPMaxTokens: process.env.KOBOLD_CPP_MAX_TOKENS,
 
       // Text Generation Web UI Keys
       TextGenWebUIBasePath: process.env.TEXT_GEN_WEB_UI_BASE_PATH,

--- a/server/utils/AiProviders/koboldCPP/index.js
+++ b/server/utils/AiProviders/koboldCPP/index.js
@@ -32,6 +32,7 @@ class KoboldCPPLLM {
 
     this.embedder = embedder ?? new NativeEmbedder();
     this.defaultTemp = 0.7;
+    this.maxTokens = Number(process.env.KOBOLD_CPP_MAX_TOKENS) || 2048;
     this.log(`Inference API: ${this.basePath} Model: ${this.model}`);
   }
 
@@ -132,6 +133,7 @@ class KoboldCPPLLM {
           model: this.model,
           messages,
           temperature,
+          max_tokens: this.maxTokens,
         })
         .catch((e) => {
           throw new Error(e.message);
@@ -168,6 +170,7 @@ class KoboldCPPLLM {
         stream: true,
         messages,
         temperature,
+        max_tokens: this.maxTokens,
       }),
       messages
     );

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -163,6 +163,10 @@ const KEY_MAPPING = {
     envKey: "KOBOLD_CPP_MODEL_TOKEN_LIMIT",
     checks: [nonZero],
   },
+  KoboldCPPMaxTokens: {
+    envKey: "KOBOLD_CPP_MAX_TOKENS",
+    checks: [nonZero],
+  },
 
   // Text Generation Web UI Settings
   TextGenWebUIBasePath: {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3708 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

_After some trial and error it was discovered that KoboldCPP uses the `max_tokens` param to control the size of the maximum amount of tokens in the response (this is not documented anywhere in their documentation)_

KoboldCPP defaults to using 512 as the maximum amount of response tokens if not explicitly specified in the API call to their OpenAI compatible server

- Add option to KoboldCPP options to allow for setting the maximum response tokens
- Update `.env.example` to allow for configuring this option via `.env`

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
