### PR TITLE
Fix MCP Start/Stop Toast Text

### DIFF
--- a/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
@@ -43,7 +43,7 @@ function ManageServerMenu({ server, toggleServer, onDelete }) {
       setRunning(!running);
       toggleServer(server.name);
       showToast(
-        `MCP server ${server.name} ${running ? "started" : "stopped"} successfully.`,
+        `MCP server ${server.name} ${running ? "stopped" : "started"} successfully.`,
         "success",
         { clear: true }
       );

--- a/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
@@ -41,13 +41,13 @@ function ManageServerMenu({ server, toggleServer, onDelete }) {
     const { success, error } = await MCPServers.toggleServer(server.name);
     if (success) {
       const newState = !running;
+      setRunning(newState);
       toggleServer(server.name);
       showToast(
         `MCP server ${server.name} ${newState ? "started" : "stopped"} successfully.`,
         "success",
         { clear: true }
       );
-      setRunning(newState);
     } else {
       showToast(error || "Failed to toggle MCP server.", "error", {
         clear: true,

--- a/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
@@ -40,13 +40,14 @@ function ManageServerMenu({ server, toggleServer, onDelete }) {
 
     const { success, error } = await MCPServers.toggleServer(server.name);
     if (success) {
+      const newState = !running;
       toggleServer(server.name);
       showToast(
-        `MCP server ${server.name} ${running ? "stopped" : "started"} successfully.`,
+        `MCP server ${server.name} ${newState ? "started" : "stopped"} successfully.`,
         "success",
         { clear: true }
       );
-      setRunning(!running);
+      setRunning(newState);
     } else {
       showToast(error || "Failed to toggle MCP server.", "error", {
         clear: true,

--- a/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
@@ -40,13 +40,13 @@ function ManageServerMenu({ server, toggleServer, onDelete }) {
 
     const { success, error } = await MCPServers.toggleServer(server.name);
     if (success) {
-      setRunning(!running);
       toggleServer(server.name);
       showToast(
         `MCP server ${server.name} ${running ? "stopped" : "started"} successfully.`,
         "success",
         { clear: true }
       );
+      setRunning(!running);
     } else {
       showToast(error || "Failed to toggle MCP server.", "error", {
         clear: true,


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
Fixes the toast message for starting/stopping an MCP server to correctly reflect the server's state at the time of the toggle. The previous implementation could show the wrong state due to asynchronous state updates. The fix uses the existing running value before calling setRunning.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
