### PR TITLE
3416 file picker load times

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,6 @@
     "@qdrant/js-client-rest": "^1.9.0",
     "@xenova/transformers": "^2.14.0",
     "@zilliz/milvus2-sdk-node": "^2.3.5",
-    "JSONStream": "^1.3.5",
     "adm-zip": "^0.5.16",
     "apache-arrow": "19.0.0",
     "bcrypt": "^5.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "@qdrant/js-client-rest": "^1.9.0",
     "@xenova/transformers": "^2.14.0",
     "@zilliz/milvus2-sdk-node": "^2.3.5",
+    "JSONStream": "^1.3.5",
     "adm-zip": "^0.5.16",
     "apache-arrow": "19.0.0",
     "bcrypt": "^5.1.0",

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -25,8 +25,6 @@ async function fileData(filePath = null) {
 }
 
 async function viewLocalFiles() {
-  const start = Date.now();
-
   if (!fs.existsSync(documentsPath)) fs.mkdirSync(documentsPath);
   const filePromises = [];
   const liveSyncAvailable = await DocumentSyncQueue.enabled();
@@ -89,7 +87,6 @@ async function viewLocalFiles() {
     ...directory.items.filter((folder) => folder.name !== "custom-documents"),
   ].filter((i) => !!i);
 
-  console.log(`Time taken to load documents: ${Date.now() - start}ms`);
   return directory;
 }
 
@@ -268,7 +265,7 @@ function hasVectorCachedFiles() {
       fs.readdirSync(vectorCachePath)?.filter((name) => name.endsWith(".json"))
         .length !== 0
     );
-  } catch { }
+  } catch {}
   return false;
 }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

closes #3497
closes https://github.com/Mintplex-Labs/anything-llm/pull/3416
connect #3135

### What is in this change?
- Implements a conditional readStreaming for rendering of the local file picker.
- The current file size limit is 150mb, as most files are less than this value.
- Most users will not notice a delay or change in the load times since this path is unlikely to be hit often.
- Will run concurrent IO for streaming files while also pruning the `pageContent` to reduce memory overhead.
- While streaming a file does take longer if hit, it is more optimized now to not load the whole file into memory at once and the page content will be dumped at the end.

### Additional Information
- we did try a streaming JSON parser, however this impacted the performance even worse (+400% time) and that tradeoff is simply not worth it at this time.
- The inclusion of lazy loading folders will allow us to raise the threshold and then we get the best of both.


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
