### PR TITLE
fixed drupal connector

### DIFF
--- a/collector/utils/extensions/DrupalWiki/DrupalWiki/index.js
+++ b/collector/utils/extensions/DrupalWiki/DrupalWiki/index.js
@@ -180,10 +180,6 @@ class DrupalWiki {
     // show up (deduplication).
     const targetUUID = `${hostname}.${page.spaceId}.${page.id}.${page.created}`;
     const wordCount = page.processedBody.split(" ").length;
-    const tokenCount =
-      page.processedBody.length > 0
-        ? tokenizeString(page.processedBody).length
-        : 0;
     const data = {
       id: targetUUID,
       url: `drupalwiki://${page.url}`,
@@ -195,7 +191,7 @@ class DrupalWiki {
       published: new Date().toLocaleString(),
       wordCount: wordCount,
       pageContent: page.processedBody,
-      token_count_estimate: tokenCount,
+      token_count_estimate: tokenizeString(page.processedBody),
     };
 
     const fileName = sanitizeFileName(`${slugify(page.title)}-${data.id}`);


### PR DESCRIPTION
https://github.com/Mintplex-Labs/anything-llm/issues/3875#issuecomment-2913211343


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3875


### What is in this change?

This pull request simplifies the handling of token count estimation in the `DrupalWiki` class by removing unnecessary conditional logic and directly computing the token count where it is used.

Code simplification:

* Removed the `tokenCount` variable and its associated conditional logic for calculating token count, simplifying the code by directly calling `tokenizeString(page.processedBody)` in the `token_count_estimate` property. (`collector/utils/extensions/DrupalWiki/DrupalWiki/index.js`, [[1]](diffhunk://#diff-8dcfecb31d5c2936f18c14744cd80413bde8f447e716c0ab5086ba32994a203fL183-L186) [[2]](diffhunk://#diff-8dcfecb31d5c2936f18c14744cd80413bde8f447e716c0ab5086ba32994a203fL198-R194)

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
