### PR TITLE
remove LLM Instruction `inputVariable` requirement

### DIFF
--- a/frontend/src/pages/Admin/AgentBuilder/BlockList/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/BlockList/index.jsx
@@ -115,7 +115,6 @@ const BLOCK_INFO = {
     description: "Process data using LLM instructions",
     defaultConfig: {
       instruction: "",
-      inputVariable: "",
       resultVariable: "",
     },
     getSummary: (config) => config.instruction || "No instruction",

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/LLMInstructionNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/LLMInstructionNode/index.jsx
@@ -9,17 +9,6 @@ export default function LLMInstructionNode({
     <div className="space-y-4">
       <div>
         <label className="block text-sm font-medium text-theme-text-primary mb-2">
-          Input Variable
-        </label>
-        {renderVariableSelect(
-          config.inputVariable,
-          (value) => onConfigChange({ ...config, inputVariable: value }),
-          "Select input variable"
-        )}
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-theme-text-primary mb-2">
           Instruction
         </label>
         <textarea

--- a/server/utils/agentFlows/executors/llm-instruction.js
+++ b/server/utils/agentFlows/executors/llm-instruction.js
@@ -1,23 +1,16 @@
 /**
  * Execute an LLM instruction flow step
  * @param {Object} config Flow step configuration
- * @param {{introspect: Function, variables: Object, logger: Function}} context Execution context with introspect function
+ * @param {{introspect: Function, logger: Function}} context Execution context with introspect function
  * @returns {Promise<string>} Processed result
  */
 async function executeLLMInstruction(config, context) {
-  const { instruction, inputVariable, resultVariable } = config;
-  const { introspect, variables, logger, aibitat } = context;
+  const { instruction, resultVariable } = config;
+  const { introspect, logger, aibitat } = context;
   logger(
     `\x1b[43m[AgentFlowToolExecutor]\x1b[0m - executing LLM Instruction block`
   );
   introspect(`Processing data with LLM instruction...`);
-
-  if (!variables[inputVariable]) {
-    logger(`Input variable ${inputVariable} (${inputVariable}) not found`);
-    throw new Error(
-      `Input variable ${inputVariable} (${inputVariable}) not found`
-    );
-  }
 
   try {
     logger(
@@ -26,16 +19,12 @@ async function executeLLMInstruction(config, context) {
     introspect(`Sending request to LLM...`);
 
     // Ensure the input is a string since we are sending it to the LLM direct as a message
-    let input = variables[inputVariable];
+    let input = instruction;
     if (typeof input === "object") input = JSON.stringify(input);
     if (typeof input !== "string") input = String(input);
 
     const provider = aibitat.getProviderForConfig(aibitat.defaultProvider);
     const completion = await provider.complete([
-      {
-        role: "system",
-        content: `Follow these instructions carefully: ${instruction}`,
-      },
       {
         role: "user",
         content: input,

--- a/server/utils/agentFlows/flowTypes.js
+++ b/server/utils/agentFlows/flowTypes.js
@@ -104,10 +104,6 @@ const FLOW_TYPES = {
         type: "string",
         description: "The instruction for the LLM to follow",
       },
-      inputVariable: {
-        type: "string",
-        description: "Variable containing the input data to process",
-      },
       resultVariable: {
         type: "string",
         description: "Variable to store the processed result",


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

connect #3863

### What is in this change?

- With #3863 we have object response traversal for JSON objects (if available)
- Since variable are already filled in globally per block, there is no reason to require `inputVariable` in this block since it has no impact on the rendered instruction - any variable can be used.

There is a world where multiple API calls are run and stored in various result vars that then come together at the instruction block in various ways. This makes a singular `inputVariable` redundant and confusing to users.

<!-- Describe the changes in this PR that are impactful to the repo. -->

### Additional Information

- Existing blocks with `inputVariables` will be ignored, but because of the above nothing will change.

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
