### PR TITLE
Fix text wrapping in directory tooltip

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
@@ -350,13 +350,15 @@ function DirectoryTooltips() {
       id="directory-item"
       place="bottom"
       delayShow={800}
-      className="tooltip invert light:invert-0 z-99 max-w-[200px]"
+      className="tooltip invert light:invert-0 z-99 max-w-[400px]"
       render={({ content }) => {
         const data = safeJsonParse(content, null);
         if (!data) return null;
         return (
           <div className="text-xs">
-            <p className="text-white light:invert font-medium">{data.title}</p>
+            <p className="text-white light:invert font-medium break-all">
+              {data.title}
+            </p>
             <div className="flex mt-1 gap-x-2">
               <p className="">
                 Date: <b>{data.date}</b>

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
@@ -350,7 +350,7 @@ function DirectoryTooltips() {
       id="directory-item"
       place="bottom"
       delayShow={800}
-      className="tooltip invert light:invert-0 z-99 max-w-[400px]"
+      className="tooltip invert light:invert-0 z-99 max-w-[200px]"
       render={({ content }) => {
         const data = safeJsonParse(content, null);
         if (!data) return null;

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/index.jsx
@@ -430,7 +430,7 @@ function WorkspaceDocumentTooltips() {
           if (!data) return null;
           return (
             <div className="text-xs">
-              <p className="text-white light:invert font-medium">
+              <p className="text-white light:invert font-medium break-all">
                 {data.title}
               </p>
               <div className="flex mt-1 gap-x-2">


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3963 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fix tooltips with long filenames from getting cut off
- Widened max width and uses `break-all` to ensure text wraps properly

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
