### PR TITLE
Fix model map staleness behavior or fallback

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ['3866-feat-import-agent-flows-from-community-hub'] # put your current branch to create a build. Core team only.
+    branches: ['model-map-staleness'] # put your current branch to create a build. Core team only.
     paths-ignore:
       - '**.md'
       - 'cloud-deployments/*'

--- a/server/utils/AiProviders/modelMap/index.js
+++ b/server/utils/AiProviders/modelMap/index.js
@@ -21,7 +21,7 @@ class ContextWindowFinder {
   };
   static expiryMs = 1000 * 60 * 60 * 24 * 3; // 3 days
   static remoteUrl =
-    "https://raw22.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 
   cacheLocation = path.resolve(
     process.env.STORAGE_DIR

--- a/server/utils/AiProviders/modelMap/index.js
+++ b/server/utils/AiProviders/modelMap/index.js
@@ -21,7 +21,7 @@ class ContextWindowFinder {
   };
   static expiryMs = 1000 * 60 * 60 * 24 * 3; // 3 days
   static remoteUrl =
-    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+    "https://raw22.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 
   cacheLocation = path.resolve(
     process.env.STORAGE_DIR
@@ -30,13 +30,15 @@ class ContextWindowFinder {
   );
   cacheFilePath = path.resolve(this.cacheLocation, "context-windows.json");
   cacheFileExpiryPath = path.resolve(this.cacheLocation, ".cached_at");
+  seenStaleCacheWarning = false;
 
   constructor() {
     if (ContextWindowFinder.instance) return ContextWindowFinder.instance;
     ContextWindowFinder.instance = this;
     if (!fs.existsSync(this.cacheLocation))
       fs.mkdirSync(this.cacheLocation, { recursive: true });
-    if (!this.cache) this.#pullRemoteModelMap();
+    if (this.isCacheStale || !fs.existsSync(this.cacheFilePath))
+      this.#pullRemoteModelMap();
   }
 
   log(text, ...args) {
@@ -53,13 +55,38 @@ class ContextWindowFinder {
     return Date.now() - cachedAt > ContextWindowFinder.expiryMs;
   }
 
-  get cache() {
-    if (!fs.existsSync(this.cacheFilePath)) return null;
-    if (!this.isCacheStale)
-      return JSON.parse(
-        fs.readFileSync(this.cacheFilePath, { encoding: "utf8" })
+  /**
+   * Gets the cached model map.
+   *
+   * Always returns the available model map - even if it is expired since re-pulling
+   * the model map only occurs on container start/system start.
+   * @returns {Record<string, Record<string, number>> | null} - The cached model map
+   */
+  get cachedModelMap() {
+    if (!fs.existsSync(this.cacheFilePath)) {
+      this.log("--------------------------------");
+      this.log("[WARNING] Model map cache is not found!");
+      this.log(
+        "Invalid context windows will be returned leading to inaccurate model responses"
       );
-    return null;
+      this.log("or smaller context windows than expected.");
+      this.log(
+        "You can fix this by restarting AnythingLLM so the model map is re-pulled."
+      );
+      this.log("--------------------------------");
+      return null;
+    }
+
+    if (this.isCacheStale && !this.seenStaleCacheWarning) {
+      this.log(
+        "Model map cache is stale - some model context windows may be incorrect. This is OK and the model map will be re-pulled on next boot."
+      );
+      this.seenStaleCacheWarning = true;
+    }
+
+    return JSON.parse(
+      fs.readFileSync(this.cacheFilePath, { encoding: "utf8" })
+    );
   }
 
   /**
@@ -151,14 +178,21 @@ class ContextWindowFinder {
 
   /**
    * Gets the context window for a given provider and model.
-   * @param {string} provider - The provider to get the context window for
-   * @param {string} model - The model to get the context window for
-   * @returns {number} - The context window for the given provider and model
+   *
+   * If the provider is not found, null is returned.
+   * If the model is not found, the provider's entire model map is returned.
+   *
+   * if both provider and model are provided, the context window for the given model is returned.
+   * @param {string|null} provider - The provider to get the context window for
+   * @param {string|null} model - The model to get the context window for
+   * @returns {number|null} - The context window for the given provider and model
    */
   get(provider = null, model = null) {
-    if (!provider || !this.cache || !this.cache[provider]) return null;
-    if (!model) return this.cache[provider];
-    const modelContextWindow = this.cache[provider][model];
+    if (!provider || !this.cachedModelMap || !this.cachedModelMap[provider])
+      return null;
+    if (!model) return this.cachedModelMap[provider];
+
+    const modelContextWindow = this.cachedModelMap[provider][model];
     if (!modelContextWindow) {
       this.log("Invalid access to model context window - not found in cache", {
         provider,

--- a/server/utils/AiProviders/modelMap/index.js
+++ b/server/utils/AiProviders/modelMap/index.js
@@ -37,6 +37,8 @@ class ContextWindowFinder {
     ContextWindowFinder.instance = this;
     if (!fs.existsSync(this.cacheLocation))
       fs.mkdirSync(this.cacheLocation, { recursive: true });
+
+    // If the cache is stale or not found at all, pull the model map from remote
     if (this.isCacheStale || !fs.existsSync(this.cacheFilePath))
       this.#pullRemoteModelMap();
   }
@@ -64,16 +66,13 @@ class ContextWindowFinder {
    */
   get cachedModelMap() {
     if (!fs.existsSync(this.cacheFilePath)) {
-      this.log("--------------------------------");
-      this.log("[WARNING] Model map cache is not found!");
-      this.log(
-        "Invalid context windows will be returned leading to inaccurate model responses"
-      );
-      this.log("or smaller context windows than expected.");
-      this.log(
-        "You can fix this by restarting AnythingLLM so the model map is re-pulled."
-      );
-      this.log("--------------------------------");
+      this.log(`\x1b[33m
+--------------------------------
+[WARNING] Model map cache is not found!
+Invalid context windows will be returned leading to inaccurate model responses
+or smaller context windows than expected.
+You can fix this by restarting AnythingLLM so the model map is re-pulled.
+--------------------------------\x1b[0m`);
       return null;
     }
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs


### What is in this change?
- Fixes issue where a stale model map while the container is running returns `null` - which means previously working model map lookups now fallback to a much smaller window. Resulting in worse LLM behavior.

Since the model map only syncs on container start, we should allow stale maps to be used, but just log that once in the logs so the user knows, since no current async pulling occurs while the container is running.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

This issue can occur is the model map in storage goes missing or expires while the container is running, leading to lookup failures suddenly or randomly, depending on the last time the container booted.

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
