### PR TITLE
fix to support: feat2864 - using local credentials file with Amazon Bedrock

### DIFF
--- a/server/utils/AiProviders/bedrock/index.js
+++ b/server/utils/AiProviders/bedrock/index.js
@@ -107,7 +107,7 @@ class AWSBedrockLLM {
       // IAM role is used for long-term credentials implied by system process
       // is filled by the AWS SDK automatically if we pass in no credentials
       case "iam_role":
-        return {};
+        return undefined; // No explicit credentials needed, AWS SDK will use the IAM role of the instance or local credential if returning undefined.
       default:
         return {};
     }


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

connect #2864


### What is in this change?

This PR fixes an authentication bug in the AWS Bedrock provider where passing an empty object {} as credentials caused the AWS SDK to reject the configuration with the error:
Resolved credential object is not valid.

The credentials getter in server/utils/AiProviders/bedrock/index.js now returns undefined instead of {} for iam_role and default cases. This enables the AWS SDK to correctly fall back to its default credential provider chain (e.g., local credentials file, environment, or EC2/ECS IAM role), restoring support for local development and environments that use assumed roles.

### Additional Information

Verified that returning undefined allows the AWS SDK to use local credentials as expected.
No other logic or side effects are introduced by this change.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
