### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/frontend/src/utils/chat/plugins/markdown-katex.js
+++ b/frontend/src/utils/chat/plugins/markdown-katex.js
@@ -106,7 +106,7 @@ function math_inline(state, silent) {
     match += 1;
   }
 
-  // No closing delimter found.  Consume $ and continue.
+  // No closing delimiter found.  Consume $ and continue.
   if (match === -1) {
     if (!silent) {
       state.pending += "$";

--- a/server/utils/prisma/PRISMA.md
+++ b/server/utils/prisma/PRISMA.md
@@ -20,7 +20,7 @@ In the project root's `package.json`, there are several scripts set up to help y
 - **prisma:migrate**: Runs the migrations to ensure the database is in sync with the schema.
 - **prisma:seed**: Seeds the database with initial data.
 - **prisma:setup**: A convenience script that runs `prisma:generate`, `prisma:migrate`, and `prisma:seed` in sequence.
-- **sqlite:migrate**: (To be run from the `server` directory) This script is for users transitioning from the old SQLite custom ORM setup to Prisma and will migrate all exisiting data over to Prisma. If you're a new user, your setup will already use Prisma.
+- **sqlite:migrate**: (To be run from the `server` directory) This script is for users transitioning from the old SQLite custom ORM setup to Prisma and will migrate all existing data over to Prisma. If you're a new user, your setup will already use Prisma.
 
 To run any of these scripts, use `yarn` followed by the script name from the project root directory. For example:
 


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in both the frontend and server documentation:
- In frontend/src/utils/chat/plugins/markdown-katex.js, the comment "delimter" was corrected to "delimiter".
- In server/utils/prisma/PRISMA.md, the word "exisiting" was corrected to "existing".

These changes improve code readability and documentation accuracy. No functional code changes were made.