### PR TITLE
Fix Typo in Milvus Provider and Update Comment in Prisma Schema

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -185,7 +185,7 @@ model workspace_chats {
   include        Boolean  @default(true)
   user_id        Int?
   thread_id      Int? // No relation to prevent whole table migration
-  api_session_id String? // String identifier for only the dev API to parition chats in any mode.
+  api_session_id String? // String identifier for only the dev API to partition chats in any mode.
   createdAt      DateTime @default(now())
   lastUpdatedAt  DateTime @default(now())
   feedbackScore  Boolean?

--- a/server/utils/vectorDbProviders/milvus/index.js
+++ b/server/utils/vectorDbProviders/milvus/index.js
@@ -118,7 +118,7 @@ const Milvus = {
           },
           {
             name: "metadata",
-            decription: "metadata",
+            description: "metadata",
             data_type: DataType.JSON,
           },
         ],


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Corrects a typo in the Milvus vector DB provider (`decription` → `description`) for the metadata field.
2. Updates the comment for the `api_session_id` field in the Prisma schema for `workspace_chats` to clarify its purpose.

