### PR TITLE
Fix broken YT scraping with YT API

### DIFF
--- a/collector/utils/extensions/YoutubeTranscript/YoutubeLoader/test-youtube-transcript.js
+++ b/collector/utils/extensions/YoutubeTranscript/YoutubeLoader/test-youtube-transcript.js
@@ -1,0 +1,14 @@
+// Test the YoutubeTranscript class
+
+const { YoutubeTranscript } = require('./youtube-transcript.js');
+
+(async () => {
+  try {
+    console.log('Testing YouTube transcript with video BJjsfNO5JTo...');
+    const transcript = await YoutubeTranscript.fetchTranscript('BJjsfNO5JTo', { lang: 'en' });
+    console.log('Success! Transcript length:', transcript.length);
+    console.log('First 200 characters:', transcript.substring(0, 200) + '...');
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+})(); 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4004


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
Use Youtube API https://www.youtube.com/youtubei/v1/get_transcript to get transcript instead of https://www.youtube.com/ptracking from youtube scripts. For unknown reason, https://www.youtube.com/ptracking returns empty content for xml transcript and causes current yt scraping fails.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->
As Youtube API has rate limit, scraping may fails after reaching api limit. For long term solution, it's better to offload ty scraping to npm package [youtubei](https://www.npmjs.com/package/youtubei.js) like https://github.com/LuanRT/YouTube.js/blob/main/examples/transcript/index.ts.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
