### PR TITLE
Fix typos in blog post example and save-file-browser plugin

### DIFF
--- a/server/utils/agents/aibitat/example/blog-post-coding.js
+++ b/server/utils/agents/aibitat/example/blog-post-coding.js
@@ -45,7 +45,7 @@ async function main() {
     content: `We have got this draft of the new blog post, let us start working on it.
     --- BEGIN DRAFT OF POST ---
     
-    Maui is a beautiful island in the state of Hawaii and is world-renown for its whale watching season. Here are 2 other additional things to do in Maui, HI:
+    Maui is a beautiful island in the state of Hawaii and is world-renowned for its whale watching season. Here are 2 additional things to do in Maui, HI:
     
     --- END DRAFT OF POST ---
     `,

--- a/server/utils/agents/aibitat/example/blog-post-coding.js
+++ b/server/utils/agents/aibitat/example/blog-post-coding.js
@@ -45,7 +45,7 @@ async function main() {
     content: `We have got this draft of the new blog post, let us start working on it.
     --- BEGIN DRAFT OF POST ---
     
-    Maui is a beautiful island in the state of Hawaii and is world-reknown for its whale watching season. Here are 2 other additional things to do in Maui, HI:
+    Maui is a beautiful island in the state of Hawaii and is world-renown for its whale watching season. Here are 2 other additional things to do in Maui, HI:
     
     --- END DRAFT OF POST ---
     `,

--- a/server/utils/agents/aibitat/plugins/save-file-browser.js
+++ b/server/utils/agents/aibitat/plugins/save-file-browser.js
@@ -15,7 +15,7 @@ const saveFileInBrowser = {
           tracker: new Deduplicator(),
           name: this.name,
           description:
-            "Save content to a file when the user explicity asks for a download of the file.",
+            "Save content to a file when the user explicitly asks for a download of the file.",
           examples: [
             {
               prompt: "Save me that to a file named 'output'",


### PR DESCRIPTION


Description:
This pull request corrects two minor typos in the codebase:
1. In server/utils/agents/aibitat/example/blog-post-coding.js, the word "reknown" was corrected to "renown".
2. In server/utils/agents/aibitat/plugins/save-file-browser.js, the word "explicity" was corrected to "explicitly".

