### PR TITLE
Update common.js spellcheck for zh_TW

### DIFF
--- a/frontend/src/locales/zh_TW/common.js
+++ b/frontend/src/locales/zh_TW/common.js
@@ -761,8 +761,8 @@ const TRANSLATIONS = {
         description: "自動朗讀 AI 的回應內容",
       },
       spellcheck: {
-        title: null,
-        description: null,
+        title: "拼字檢查功能",
+        description: "在聊天輸入框中啟用或停用拼字檢查",
       },
     },
     items: {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### What is in this change?

Add a missing locale item for zh_TW 

Before (it fell back to simplified Chinese which is not desired because zh_TW is traditional Chinese):
![image](https://github.com/user-attachments/assets/b64beb32-7d2a-4f16-9961-ace94b531556)

After:
![image](https://github.com/user-attachments/assets/835a24ce-2f66-4427-bcf9-283ce9dd454f)
