### PR TITLE
LMStudio 0 value embeddings patch

### DIFF
--- a/server/utils/EmbeddingEngines/lmstudio/index.js
+++ b/server/utils/EmbeddingEngines/lmstudio/index.js
@@ -63,6 +63,7 @@ class LMStudioEmbedder {
           .create({
             model: this.model,
             input: chunk,
+            encoding_format: "base64",
           })
           .then((result) => {
             const embedding = result.data?.[0]?.embedding;


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4080 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fixes a bug where when trying to call on the LMStudio embedding model to embed text, it would return all embedding values as 0 causing all chunks to show as context when chatting
- Fixed by adding ```"encoding_format" : "base64"``` to the LMStudio backend via the OpenAI package

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

- NOTE: Discovered that in here https://github.com/Mintplex-Labs/anything-llm/blob/07129e81f8a37d0f63e861659598c7a248d9a74e/server/utils/vectorDbProviders/lance/index.js#L128 when using reranking, the reranking score always tends to be very small and appears as 0% similarity in the UI
- We may want to scale this number to be larger so it appears in a way that makes more sense to the user

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
