### PR TITLE
feat: Add Korean (ko) locale translations

### DIFF
--- a/frontend/src/locales/ko/common.js
+++ b/frontend/src/locales/ko/common.js
@@ -1,51 +1,58 @@
-// Anything with "null" requires a translation. Contribute to translation via a PR!
 const TRANSLATIONS = {
   onboarding: {
-    survey: {
-      email: null,
-      useCase: null,
-      useCaseWork: null,
-      useCasePersonal: null,
-      useCaseOther: null,
-      comment: null,
-      commentPlaceholder: null,
-      skip: null,
-      thankYou: null,
-      title: null,
-      description: null,
-    },
     home: {
-      title: null,
-      getStarted: null,
+      title: "방문을 환영합니다",
+      getStarted: "시작하기",
     },
     llm: {
-      title: null,
-      description: null,
+      title: "LLM 기본 설정",
+      description:
+        "AnythingLLM은 다양한 LLM 제공자와 연동할 수 있습니다. 여기서 선택한 서비스가 채팅을 담당하게 됩니다.",
     },
     userSetup: {
-      title: null,
-      description: null,
-      howManyUsers: null,
-      justMe: null,
-      myTeam: null,
-      instancePassword: null,
-      setPassword: null,
-      passwordReq: null,
-      passwordWarn: null,
-      adminUsername: null,
-      adminUsernameReq: null,
-      adminPassword: null,
-      adminPasswordReq: null,
-      teamHint: null,
+      title: "사용자 설정",
+      description: "사용자 설정을 구성하세요.",
+      howManyUsers: "이 인스턴스를 사용할 사용자는 몇 명인가요?",
+      justMe: "나만 사용",
+      myTeam: "팀 사용",
+      instancePassword: "인스턴스 비밀번호",
+      setPassword: "비밀번호를 설정하시겠습니까?",
+      passwordReq: "비밀번호는 최소 8자 이상이어야 합니다.",
+      passwordWarn: "이 비밀번호는 복구 방법이 없으니 꼭 안전하게 보관하세요.",
+      adminUsername: "관리자 계정 사용자명",
+      adminUsernameReq:
+        "사용자명은 6자 이상이어야 하며, 소문자, 숫자, 밑줄(_), 하이픈(-)만 사용할 수 있습니다. 공백은 허용되지 않습니다.",
+      adminPassword: "관리자 계정 비밀번호",
+      adminPasswordReq: "비밀번호는 최소 8자 이상이어야 합니다.",
+      teamHint:
+        "기본적으로 본인이 유일한 관리자가 됩니다. 온보딩이 완료되면 다른 사용자를 초대하거나 관리자로 지정할 수 있습니다. 비밀번호를 분실하면 관리자만 비밀번호를 재설정할 수 있으니 꼭 기억해 두세요.",
     },
     data: {
-      title: null,
-      description: null,
-      settingsHint: null,
+      title: "데이터 처리 및 개인정보 보호",
+      description:
+        "AnythingLLM은 여러분의 개인정보에 대한 투명성과 제어권을 최우선으로 생각합니다.",
+      settingsHint: "이 설정은 언제든지 설정 메뉴에서 다시 변경할 수 있습니다.",
+    },
+    survey: {
+      title: "AnythingLLM에 오신 것을 환영합니다",
+      description:
+        "여러분의 필요에 맞는 AnythingLLM을 만들 수 있도록 도와주세요. (선택 사항)",
+
+      email: "이메일을 입력해 주세요",
+      useCase: "AnythingLLM을 어떤 용도로 사용하실 예정인가요?",
+      useCaseWork: "업무용",
+      useCasePersonal: "개인용",
+      useCaseOther: "기타",
+      comment: "AnythingLLM을 어떻게 알게 되셨나요?",
+      commentPlaceholder:
+        "Reddit, Twitter, GitHub, YouTube 등 - 어떻게 알게 되셨는지 알려주세요!",
+      skip: "설문 건너뛰기",
+      thankYou: "소중한 의견 감사합니다!",
     },
     workspace: {
-      title: null,
-      description: null,
+      title: "첫 번째 워크스페이스 만들기",
+      description:
+        "첫 번째 워크스페이스를 생성하고 AnythingLLM을 시작해보세요.",
     },
   },
   common: {
@@ -58,10 +65,12 @@ const TRANSLATIONS = {
     save: "저장",
     previous: "이전",
     next: "다음",
-    optional: null,
-    yes: null,
-    no: null,
+    optional: "선택 사항",
+    yes: "예",
+    no: "아니오",
   },
+
+  // Setting Sidebar menu items.
   settings: {
     title: "인스턴스 설정",
     system: "일반 설정",
@@ -89,11 +98,13 @@ const TRANSLATIONS = {
     "experimental-features": "실험적 기능",
     contact: "지원팀 연락",
     "browser-extension": "브라우저 확장 프로그램",
-    "system-prompt-variables": null,
-    interface: null,
-    branding: null,
-    chat: null,
+    "system-prompt-variables": "System Prompt Variables",
+    interface: "UI 환경 설정",
+    branding: "브랜딩 및 화이트라벨링",
+    chat: "채팅",
   },
+
+  // Page Definitions
   login: {
     "multi-user": {
       welcome: "웰컴!",
@@ -116,10 +127,118 @@ const TRANSLATIONS = {
       "back-to-login": "로그인으로 돌아가기",
     },
   },
+
+  welcomeMessage: {
+    part1:
+      "AnythingLLM에 오신 것을 환영합니다! AnythingLLM은 Mintplex Labs에서 개발한 오픈소스 AI 도구로, 어떤 것이든 학습된 챗봇으로 만들어 대화하고 질문할 수 있습니다. AnythingLLM은 BYOK(키 직접 제공) 방식의 소프트웨어로, 사용자가 원하는 외부 서비스 이용료 외에는 별도의 구독이나 비용이 없습니다.",
+    part2:
+      "AnythingLLM은 OpenAI, GPT-4, LangChain, PineconeDB, ChromaDB 등 강력한 AI 서비스들을 손쉽게 하나로 묶어 생산성을 100배 높여주는 가장 쉬운 방법입니다.",
+    part3:
+      "AnythingLLM은 별도의 GPU 없이도 여러분의 컴퓨터에서 가볍게 완전히 로컬로 실행할 수 있습니다. 클라우드 및 온프레미스 설치도 지원합니다.\nAI 도구 생태계는 매일 더 강력해지고 있습니다. AnythingLLM은 이를 쉽게 활용할 수 있게 도와줍니다.",
+    githubIssue: "GitHub에서 이슈 만들기",
+    user1: "어떻게 시작하나요?!",
+    part4:
+      "아주 간단합니다. 모든 자료는 '워크스페이스'라는 버킷에 정리됩니다. 워크스페이스는 파일, 문서, 이미지, PDF 등 다양한 자료를 담는 공간이며, 이 파일들은 LLM이 이해하고 대화에 활용할 수 있도록 변환됩니다.\n\n언제든 파일을 추가하거나 삭제할 수 있습니다.",
+    createWorkspace: "첫 워크스페이스 만들기",
+    user2: "이거 AI 드롭박스 같은 건가요? 채팅은 어떻게 하나요? 챗봇 맞죠?",
+    part5:
+      "AnythingLLM은 단순한 드롭박스 그 이상입니다.\n\nAnythingLLM은 데이터와 대화하는 두 가지 방식을 제공합니다:\n\n<i>질의(Query):</i> 워크스페이스에 있는 문서를 바탕으로 데이터를 찾거나 추론 결과를 반환합니다. 문서를 더 추가할수록 더 똑똑해집니다!\n\n<i>대화(Conversational):</i> 문서와 진행 중인 채팅 내역이 동시에 LLM의 지식에 반영됩니다. 실시간 정보 추가, 오해나 오류 수정에 유용합니다.\n\n채팅 중 언제든 두 모드 간 전환이 가능합니다.",
+    user3: "와, 정말 대단하네요! 바로 써보고 싶어요!",
+    part6: "즐겁게 사용하세요!",
+    starOnGitHub: "GitHub에 스타 누르기",
+    contact: "Mintplex Labs에 문의하기",
+  },
+
+  "main-page": {
+    noWorkspaceError: "채팅을 시작하기 전에 워크스페이스를 먼저 만들어주세요.",
+    checklist: {
+      title: "시작하기",
+      tasksLeft: "남은 작업",
+      completed: "이제 곧 AnythingLLM 전문가가 되실 거예요!",
+      dismiss: "닫기",
+      tasks: {
+        create_workspace: {
+          title: "워크스페이스 만들기",
+          description: "처음으로 워크스페이스를 만들어 시작해보세요",
+          action: "만들기",
+        },
+        send_chat: {
+          title: "채팅 보내기",
+          description: "AI 어시스턴트와 대화를 시작해보세요",
+          action: "채팅",
+        },
+        embed_document: {
+          title: "문서 임베드하기",
+          description: "워크스페이스에 첫 번째 문서를 추가해보세요",
+          action: "임베드",
+        },
+        setup_system_prompt: {
+          title: "시스템 프롬프트 설정",
+          description: "AI 어시스턴트의 동작 방식을 설정하세요",
+          action: "설정",
+        },
+        define_slash_command: {
+          title: "슬래시 명령어 정의",
+          description: "어시스턴트용 맞춤 명령어를 만들어보세요",
+          action: "정의",
+        },
+        visit_community: {
+          title: "커뮤니티 허브 방문",
+          description: "커뮤니티 자료와 템플릿을 둘러보세요",
+          action: "둘러보기",
+        },
+      },
+    },
+    quickLinks: {
+      title: "바로가기",
+      sendChat: "채팅 보내기",
+      embedDocument: "문서 임베드",
+      createWorkspace: "워크스페이스 만들기",
+    },
+    exploreMore: {
+      title: "더 많은 기능 살펴보기",
+      features: {
+        customAgents: {
+          title: "맞춤형 AI 에이전트",
+          description: "코딩 없이 강력한 AI 에이전트와 자동화를 구축하세요.",
+          primaryAction: "@agent로 채팅하기",
+          secondaryAction: "에이전트 플로우 만들기",
+        },
+        slashCommands: {
+          title: "슬래시 명령어",
+          description:
+            "맞춤 슬래시 명령어로 시간을 절약하고 프롬프트를 빠르게 입력하세요.",
+          primaryAction: "슬래시 명령어 만들기",
+          secondaryAction: "허브에서 둘러보기",
+        },
+        systemPrompts: {
+          title: "시스템 프롬프트",
+          description:
+            "시스템 프롬프트를 수정해 워크스페이스의 AI 답변을 원하는 대로 맞춤 설정하세요.",
+          primaryAction: "시스템 프롬프트 수정",
+          secondaryAction: "프롬프트 변수 관리",
+        },
+      },
+    },
+    announcements: {
+      title: "업데이트 및 공지사항",
+    },
+    resources: {
+      title: "자료실",
+      links: {
+        docs: "문서 보기",
+        star: "Github에 스타 누르기",
+      },
+      keyboardShortcuts: "단축키 안내",
+    },
+  },
+
   "new-workspace": {
     title: "새 워크스페이스",
     placeholder: "내 워크스페이스",
   },
+
+  // Workspace Settings menu items
   "workspaces—settings": {
     general: "일반 설정",
     chat: "채팅 설정",
@@ -127,27 +246,8 @@ const TRANSLATIONS = {
     members: "구성원",
     agent: "에이전트 구성",
   },
-  welcomeMessage: {
-    part1:
-      "AnythingLLM에 오신 것을 환영합니다. AnythingLLM은 Mintplex Labs에서 개발한 오픈 소스 AI 도구로, 어떤 것이든 훈련된 챗봇으로 변환하여 쿼리하고 대화할 수 있습니다. AnythingLLM은 BYOK(Bring Your Own Key) 소프트웨어이므로 사용하려는 서비스 외에는 구독료나 기타 비용이 없습니다.",
-    part2:
-      "AnythingLLM은 OpenAi, GPT-4, LangChain, PineconeDB, ChromaDB 등 강력한 AI 제품을 번거로움 없이 깔끔하게 패키지로 묶어 생산성을 100배 향상시키는 가장 쉬운 방법입니다.",
-    part3:
-      "AnythingLLM은 로컬 컴퓨터에서 완전히 작동하며, 거의 리소스를 사용하지 않으므로 존재조차 느끼지 못할 것입니다! GPU가 필요하지 않습니다. 클라우드 및 온프레미스 설치도 가능합니다.\nAI 도구 생태계는 날로 강력해지고 있습니다. AnythingLLM은 이를 쉽게 사용할 수 있게 해줍니다.",
-    githubIssue: "GitHub에 이슈 생성하기",
-    user1: "어떻게 시작하나요?!",
-    part4:
-      '간단합니다. 모든 컬렉션은 "워크스페이스"라고 부르는 버킷으로 구성됩니다. 워크스페이스는 문서, 이미지, PDF 및 기타 파일의 버킷으로, LLM이 이해하고 대화에서 사용할 수 있는 형태로 변환합니다.\n\n언제든지 파일을 추가하고 삭제할 수 있습니다.',
-    createWorkspace: "첫 번째 워크스페이스 생성하기",
-    user2:
-      "이것은 AI 드롭박스와 같은 건가요? 채팅은 어떤가요? 이건 챗봇 아닌가요?",
-    part5:
-      "AnythingLLM은 더 스마트한 Dropbox 이상의 것입니다.\n\nAnythingLLM은 데이터와 대화할 수 있는 두 가지 방법을 제공합니다:\n\n<i>쿼리:</i> 워크스페이스 내 문서에서 찾아낸 데이터나 추론 결과만 채팅으로 제공합니다. 워크스페이스에 문서를 더 많이 추가할수록 더 똑똑해집니다!\n\n<i>대화:</i> 문서와 실시간 채팅 기록이 동시에 LLM의 지식에 기여합니다. 실시간 텍스트 정보나 LLM의 오해를 바로잡는 데 매우 유용합니다.\n\n채팅 중간에 <i>모드를 전환할 수 있습니다!</i>",
-    user3: "와, 이거 정말 놀랍네요, 당장 사용해보고 싶어요!",
-    part6: "즐기세요!",
-    starOnGitHub: "GitHub에 별표 달기",
-    contact: "Mintplex Labs에 연락하기",
-  },
+
+  // General Appearance
   general: {
     vector: {
       title: "벡터 수",
@@ -181,6 +281,8 @@ const TRANSLATIONS = {
         "워크스페이스 전체를 삭제합니다. 이 작업은 벡터 데이터베이스에 있는 모든 벡터 임베딩을 제거합니다.\n\n원본 소스 파일은 그대로 유지됩니다. 이 작업은 되돌릴 수 없습니다.",
     },
   },
+
+  // Chat Settings
   chat: {
     llm: {
       title: "워크스페이스 LLM 제공자",
@@ -217,19 +319,20 @@ const TRANSLATIONS = {
         " 45개 이상은 메시지 크기에 따라 채팅 실패가 발생할 수 있습니다.",
     },
     prompt: {
-      title: "프롬프트",
+      title: "시스템 프롬프트",
       description:
         "이 워크스페이스에서 사용할 프롬프트입니다. AI가 응답을 생성하기 위해 문맥과 지침을 정의합니다. AI가 질문에 대하여 정확한 응답을 생성할 수 있도록 신중하게 프롬프트를 제공해야 합니다.",
       history: {
-        title: null,
-        clearAll: null,
-        noHistory: null,
-        restore: null,
-        delete: null,
-        deleteConfirm: null,
-        clearAllConfirm: null,
-        expand: null,
-        publish: null,
+        title: "시스템 프롬프트 기록",
+        clearAll: "전체 삭제",
+        noHistory: "저장된 시스템 프롬프트 기록이 없습니다",
+        restore: "복원",
+        delete: "삭제",
+        publish: "커뮤니티 허브에 게시",
+        deleteConfirm: "이 기록 항목을 삭제하시겠습니까?",
+        clearAllConfirm:
+          "모든 기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+        expand: "확장",
       },
     },
     refusal: {
@@ -237,8 +340,9 @@ const TRANSLATIONS = {
       "desc-start": "쿼리 모드에서",
       query: "응답에 사용할 수 있는",
       "desc-end": "컨텍스트를 찾을 수 없을 때 거부 응답 내용을 작성합니다.",
-      "tooltip-title": null,
-      "tooltip-description": null,
+      "tooltip-title": "왜 이 메시지가 표시되나요?",
+      "tooltip-description":
+        "현재 쿼리 모드에서는 문서의 정보만을 사용합니다. 더 자유로운 대화를 원하시면 채팅 모드로 전환하거나, 채팅 모드에 대한 자세한 내용은 문서를 참고하세요.",
     },
     temperature: {
       title: "LLM 온도",
@@ -248,6 +352,8 @@ const TRANSLATIONS = {
       hint: "대부분의 LLM은 유효한 값의 다양한 허용 범위를 가지고 있습니다. 해당 정보는 LLM 제공자에게 문의하세요.",
     },
   },
+
+  // Vector Database
   "vector-workspace": {
     identifier: "벡터 데이터베이스 식별자",
     snippets: {
@@ -274,6 +380,8 @@ const TRANSLATIONS = {
       success: "워크스페이스 벡터 데이터베이스가 재설정되었습니다!",
     },
   },
+
+  // Agent Configuration
   agent: {
     "performance-warning":
       "도구 호출을 명시적으로 지원하지 않는 LLM의 성능은 모델의 기능과 정확도에 크게 좌우됩니다. 일부 기능은 제한되거나 작동하지 않을 수 있습니다.",
@@ -331,6 +439,8 @@ const TRANSLATIONS = {
       },
     },
   },
+
+  // Workspace Chats
   recorded: {
     title: "워크스페이스 채팅",
     description:
@@ -345,6 +455,105 @@ const TRANSLATIONS = {
       at: "보낸 시각",
     },
   },
+
+  customization: {
+    interface: {
+      title: "UI 환경 설정",
+      description: "AnythingLLM의 UI 환경을 원하는 대로 설정하세요.",
+    },
+    branding: {
+      title: "브랜딩 및 화이트라벨링",
+      description:
+        "AnythingLLM 인스턴스에 맞춤 브랜딩을 적용해 화이트라벨링할 수 있습니다.",
+    },
+    chat: {
+      title: "채팅",
+      description: "AnythingLLM의 채팅 환경을 원하는 대로 설정하세요.",
+      auto_submit: {
+        title: "음성 입력 자동 전송",
+        description:
+          "일정 시간 동안 음성이 감지되지 않으면 음성 입력을 자동으로 전송합니다.",
+      },
+      auto_speak: {
+        title: "응답 자동 음성 출력",
+        description: "AI의 응답을 자동으로 음성으로 들려줍니다.",
+      },
+      spellcheck: {
+        title: "맞춤법 검사 활성화",
+        description: "채팅 입력란에서 맞춤법 검사를 켜거나 끌 수 있습니다.",
+      },
+    },
+    items: {
+      theme: {
+        title: "테마",
+        description: "애플리케이션의 색상 테마를 선택하세요.",
+      },
+      "show-scrollbar": {
+        title: "스크롤바 표시",
+        description: "채팅 창에서 스크롤바를 표시하거나 숨길 수 있습니다.",
+      },
+      "support-email": {
+        title: "지원 이메일",
+        description:
+          "사용자가 도움이 필요할 때 접근할 수 있는 지원 이메일 주소를 설정하세요.",
+      },
+      "app-name": {
+        title: "이름",
+        description:
+          "로그인 페이지에 모든 사용자에게 표시될 애플리케이션 이름을 설정하세요.",
+      },
+      "chat-message-alignment": {
+        title: "채팅 메시지 정렬",
+        description: "채팅 인터페이스에서 메시지 정렬 방식을 선택하세요.",
+      },
+      "display-language": {
+        title: "표시 언어",
+        description:
+          "AnythingLLM의 UI에 사용할 언어를 선택하세요. 번역이 제공되는 경우에만 적용됩니다.",
+      },
+      logo: {
+        title: "브랜드 로고",
+        description: "모든 페이지에 표시할 맞춤 로고를 업로드하세요.",
+        add: "맞춤 로고 추가",
+        recommended: "권장 크기: 800 x 200",
+        remove: "제거",
+        replace: "교체",
+      },
+      "welcome-messages": {
+        title: "환영 메시지",
+        description:
+          "사용자에게 표시될 환영 메시지를 맞춤 설정하세요. 관리자 권한이 없는 사용자만 이 메시지를 볼 수 있습니다.",
+        new: "새 메시지",
+        system: "시스템",
+        user: "사용자",
+        message: "메시지",
+        assistant: "AnythingLLM 채팅 어시스턴트",
+        "double-click": "더블 클릭하여 편집...",
+        save: "메시지 저장",
+      },
+      "browser-appearance": {
+        title: "브라우저 표시 설정",
+        description:
+          "앱이 열려 있을 때 브라우저 탭과 제목의 표시 방식을 맞춤 설정하세요.",
+        tab: {
+          title: "탭 제목",
+          description:
+            "앱이 브라우저에서 열려 있을 때 사용할 맞춤 탭 제목을 설정하세요.",
+        },
+        favicon: {
+          title: "파비콘",
+          description: "브라우저 탭에 사용할 맞춤 파비콘을 지정하세요.",
+        },
+      },
+      "sidebar-footer": {
+        title: "사이드바 하단 항목",
+        description: "사이드바 하단에 표시될 푸터 항목을 맞춤 설정하세요.",
+        icon: "아이콘",
+        link: "링크",
+      },
+    },
+  },
+
   api: {
     title: "API 키",
     description:
@@ -357,6 +566,7 @@ const TRANSLATIONS = {
       created: "생성일",
     },
   },
+
   llm: {
     title: "LLM 기본 설정",
     description:
@@ -364,16 +574,17 @@ const TRANSLATIONS = {
     provider: "LLM 제공자",
     providers: {
       azure_openai: {
-        azure_service_endpoint: null,
-        api_key: null,
-        chat_deployment_name: null,
-        chat_model_token_limit: null,
-        model_type: null,
-        default: null,
-        reasoning: null,
+        azure_service_endpoint: "Azure 서비스 엔드포인트",
+        api_key: "API 키",
+        chat_deployment_name: "채팅 배포 이름",
+        chat_model_token_limit: "채팅 모델 토큰 한도",
+        model_type: "모델 유형",
+        default: "기본값",
+        reasoning: "추론",
       },
     },
   },
+
   transcription: {
     title: "텍스트 변환 모델 기본 설정",
     description:
@@ -384,6 +595,7 @@ const TRANSLATIONS = {
     "warn-recommend": "최소 2GB RAM과 10Mb 보다 작은 파일 업로드를 권장합니다.",
     "warn-end": "내장된 모델은 첫 번째 사용 시 자동으로 다운로드됩니다.",
   },
+
   embedding: {
     title: "임베딩 기본 설정",
     "desc-start":
@@ -396,6 +608,7 @@ const TRANSLATIONS = {
         "AnythingLLM의 기본 임베딩 엔진을 사용할 때는 설정이 필요하지 않습니다.",
     },
   },
+
   text: {
     title: "텍스트 분할 및 청킹 기본 설정",
     "desc-start":
@@ -410,12 +623,14 @@ const TRANSLATIONS = {
       description: "단일 벡터에 들어갈 수 있는 최대 문자 길이입니다.",
       recommend: "임베드 모델 최대 길이는",
     },
+
     overlap: {
       title: "텍스트 청크 겹침",
       description:
         "청킹 동안 두 인접 텍스트 청크 간에 겹칠 수 있는 최대 문자 수입니다.",
     },
   },
+
   vector: {
     title: "벡터 데이터베이스",
     description:
@@ -425,6 +640,8 @@ const TRANSLATIONS = {
       description: "LanceDB를 선택하면 설정이 필요 없습니다.",
     },
   },
+
+  // Embeddable Chat Widgets
   embeddable: {
     title: "임베드 가능한 채팅 위젯",
     description:
@@ -434,9 +651,10 @@ const TRANSLATIONS = {
       workspace: "워크스페이스",
       chats: "보낸 채팅",
       active: "활성 도메인",
-      created: null,
+      created: "생성일",
     },
   },
+
   "embed-chats": {
     title: "임베드 채팅",
     export: "내보내기",
@@ -449,6 +667,7 @@ const TRANSLATIONS = {
       at: "보낸 시각",
     },
   },
+
   multi: {
     title: "다중 사용자 모드",
     description:
@@ -473,6 +692,8 @@ const TRANSLATIONS = {
       password: "인스턴스 비밀번호",
     },
   },
+
+  // Event Logs
   event: {
     title: "이벤트 로그",
     description:
@@ -484,6 +705,8 @@ const TRANSLATIONS = {
       occurred: "발생 시각",
     },
   },
+
+  // Privacy & Data-Handling
   privacy: {
     title: "개인정보와 데이터 처리",
     description:
@@ -493,507 +716,395 @@ const TRANSLATIONS = {
     vector: "벡터 데이터베이스",
     anonymous: "익명 원격 분석 활성화",
   },
+
   connectors: {
-    "search-placeholder": null,
-    "no-connectors": null,
+    "search-placeholder": "데이터 커넥터 검색",
+    "no-connectors": "데이터 커넥터를 찾을 수 없습니다.",
+    obsidian: {
+      name: "Obsidian",
+      description: "Obsidian 볼트를 한 번에 가져옵니다.",
+      vault_location: "볼트 위치",
+      vault_description:
+        "모든 노트와 연결을 가져오려면 Obsidian 볼트 폴더를 선택하세요.",
+      selected_files: "{{count}}개의 마크다운 파일을 찾았습니다",
+      importing: "볼트 가져오는 중...",
+      import_vault: "볼트 가져오기",
+      processing_time: "볼트 크기에 따라 시간이 다소 소요될 수 있습니다.",
+      vault_warning:
+        "충돌을 방지하려면 Obsidian 볼트가 현재 열려 있지 않은지 확인하세요.",
+    },
     github: {
-      name: null,
-      description: null,
-      URL: null,
-      URL_explained: null,
-      token: null,
-      optional: null,
-      token_explained: null,
-      token_explained_start: null,
-      token_explained_link1: null,
-      token_explained_middle: null,
-      token_explained_link2: null,
-      token_explained_end: null,
-      ignores: null,
-      git_ignore: null,
-      task_explained: null,
-      branch: null,
-      branch_loading: null,
-      branch_explained: null,
-      token_information: null,
-      token_personal: null,
+      name: "GitHub 저장소",
+      description:
+        "공개 또는 비공개 GitHub 저장소 전체를 한 번의 클릭으로 가져옵니다.",
+      URL: "GitHub 저장소 URL",
+      URL_explained: "가져오려는 GitHub 저장소의 URL을 입력하세요.",
+      token: "GitHub 액세스 토큰",
+      optional: "선택 사항",
+      token_explained: "요청 제한을 방지하기 위한 액세스 토큰입니다.",
+      token_explained_start: "",
+      token_explained_link1: "개인 액세스 토큰",
+      token_explained_middle:
+        "이 없으면 GitHub API의 요청 제한으로 인해 가져올 수 있는 파일 수가 제한될 수 있습니다. ",
+      token_explained_link2: "임시 액세스 토큰을 생성",
+      token_explained_end: "하여 이 문제를 피할 수 있습니다.",
+      ignores: "파일 무시 목록",
+      git_ignore:
+        "수집 중 무시할 파일을 .gitignore 형식으로 입력하세요. 저장하려면 각 항목 입력 후 엔터를 누르세요.",
+      task_explained:
+        "가져오기가 완료되면 모든 파일이 문서 선택기에서 워크스페이스에 임베딩할 수 있도록 제공됩니다.",
+      branch: "가져올 브랜치",
+      branch_loading: "-- 사용 가능한 브랜치 불러오는 중 --",
+      branch_explained: "가져오려는 브랜치를 선택하세요.",
+      token_information:
+        "<b>GitHub 액세스 토큰</b>을 입력하지 않으면 GitHub의 공개 API 요청 제한으로 인해 이 데이터 커넥터는 저장소의 <b>최상위</b> 파일만 수집할 수 있습니다.",
+      token_personal:
+        "여기에서 GitHub 계정으로 무료 개인 액세스 토큰을 발급받을 수 있습니다.",
     },
     gitlab: {
-      name: null,
-      description: null,
-      URL: null,
-      URL_explained: null,
-      token: null,
-      optional: null,
-      token_explained: null,
-      token_description: null,
-      token_explained_start: null,
-      token_explained_link1: null,
-      token_explained_middle: null,
-      token_explained_link2: null,
-      token_explained_end: null,
-      fetch_issues: null,
-      ignores: null,
-      git_ignore: null,
-      task_explained: null,
-      branch: null,
-      branch_loading: null,
-      branch_explained: null,
-      token_information: null,
-      token_personal: null,
+      name: "GitLab 저장소",
+      description:
+        "공개 또는 비공개 GitLab 저장소 전체를 한 번의 클릭으로 가져옵니다.",
+      URL: "GitLab 저장소 URL",
+      URL_explained: "가져오려는 GitLab 저장소의 URL을 입력하세요.",
+      token: "GitLab 액세스 토큰",
+      optional: "선택 사항",
+      token_explained: "요청 제한을 방지하기 위한 액세스 토큰입니다.",
+      token_description: "GitLab API에서 추가로 가져올 엔터티를 선택하세요.",
+      token_explained_start: "",
+      token_explained_link1: "개인 액세스 토큰",
+      token_explained_middle:
+        "이 없으면 GitLab API의 요청 제한으로 인해 가져올 수 있는 파일 수가 제한될 수 있습니다. ",
+      token_explained_link2: "임시 액세스 토큰을 생성",
+      token_explained_end: "하여 이 문제를 피할 수 있습니다.",
+      fetch_issues: "이슈를 문서로 가져오기",
+      ignores: "파일 무시 목록",
+      git_ignore:
+        "수집 중 무시할 파일을 .gitignore 형식으로 입력하세요. 저장하려면 각 항목 입력 후 엔터를 누르세요.",
+      task_explained:
+        "가져오기가 완료되면 모든 파일이 문서 선택기에서 워크스페이스에 임베딩할 수 있도록 제공됩니다.",
+      branch: "가져올 브랜치",
+      branch_loading: "-- 사용 가능한 브랜치 불러오는 중 --",
+      branch_explained: "가져오려는 브랜치를 선택하세요.",
+      token_information:
+        "<b>GitLab 액세스 토큰</b>을 입력하지 않으면 GitLab의 공개 API 요청 제한으로 인해 이 데이터 커넥터는 저장소의 <b>최상위</b> 파일만 수집할 수 있습니다.",
+      token_personal:
+        "여기에서 GitLab 계정으로 무료 개인 액세스 토큰을 발급받을 수 있습니다.",
     },
     youtube: {
-      name: null,
-      description: null,
-      URL: null,
-      URL_explained_start: null,
-      URL_explained_link: null,
-      URL_explained_end: null,
-      task_explained: null,
-      language: null,
-      language_explained: null,
-      loading_languages: null,
+      name: "YouTube 자막 가져오기",
+      description: "링크를 통해 YouTube 동영상 전체의 자막을 가져옵니다.",
+      URL: "YouTube 동영상 URL",
+      URL_explained_start:
+        "자막을 가져올 YouTube 동영상의 URL을 입력하세요. 동영상에는 반드시 ",
+      URL_explained_link: "자막(Closed Captions)",
+      URL_explained_end: " 이 활성화되어 있어야 합니다.",
+      task_explained:
+        "가져오기가 완료되면 자막이 문서 선택기에서 워크스페이스에 임베딩할 수 있도록 제공됩니다.",
+      language: "자막 언어",
+      language_explained: "가져오려는 자막의 언어를 선택하세요.",
+      loading_languages: "-- 사용 가능한 언어 불러오는 중 --",
     },
     "website-depth": {
-      name: null,
-      description: null,
-      URL: null,
-      URL_explained: null,
-      depth: null,
-      depth_explained: null,
-      max_pages: null,
-      max_pages_explained: null,
-      task_explained: null,
+      name: "웹사이트 대량 링크 수집",
+      description:
+        "웹사이트와 하위 링크를 지정한 깊이까지 크롤링하여 수집합니다.",
+      URL: "웹사이트 URL",
+      URL_explained: "수집하려는 웹사이트의 URL을 입력하세요.",
+      depth: "크롤링 깊이",
+      depth_explained:
+        "시작 URL에서 몇 단계의 하위 링크까지 따라가서 수집할지 지정합니다.",
+      max_pages: "최대 페이지 수",
+      max_pages_explained: "수집할 최대 링크(페이지) 개수를 설정합니다.",
+      task_explained:
+        "수집이 완료되면 모든 크롤링된 콘텐츠가 문서 선택기에서 워크스페이스에 임베딩할 수 있도록 제공됩니다.",
     },
     confluence: {
-      name: null,
-      description: null,
-      deployment_type: null,
-      deployment_type_explained: null,
-      base_url: null,
-      base_url_explained: null,
-      space_key: null,
-      space_key_explained: null,
-      username: null,
-      username_explained: null,
-      auth_type: null,
-      auth_type_explained: null,
-      auth_type_username: null,
-      auth_type_personal: null,
-      token: null,
-      token_explained_start: null,
-      token_explained_link: null,
-      token_desc: null,
-      pat_token: null,
-      pat_token_explained: null,
-      task_explained: null,
+      name: "Confluence",
+      description: "한 번의 클릭으로 전체 Confluence 페이지를 가져옵니다.",
+      deployment_type: "Confluence 배포 유형",
+      deployment_type_explained:
+        "Confluence 인스턴스가 Atlassian 클라우드에 호스팅되어 있는지, 자체 서버에 설치되어 있는지 선택하세요.",
+      base_url: "Confluence 기본 URL",
+      base_url_explained: "Confluence 공간의 기본 URL을 입력하세요.",
+      space_key: "Confluence 스페이스 키",
+      space_key_explained:
+        "가져올 Confluence 스페이스의 키입니다. 보통 ~로 시작합니다.",
+      username: "Confluence 사용자명",
+      username_explained: "Confluence 계정의 사용자명을 입력하세요.",
+      auth_type: "Confluence 인증 방식",
+      auth_type_explained:
+        "Confluence 페이지에 접근할 때 사용할 인증 방식을 선택하세요.",
+      auth_type_username: "사용자명 + 액세스 토큰",
+      auth_type_personal: "개인 액세스 토큰",
+      token: "Confluence 액세스 토큰",
+      token_explained_start:
+        "인증을 위해 액세스 토큰이 필요합니다. 액세스 토큰은",
+      token_explained_link: "여기에서 생성할 수 있습니다",
+      token_desc: "인증용 액세스 토큰",
+      pat_token: "Confluence 개인 액세스 토큰",
+      pat_token_explained: "Confluence 계정의 개인 액세스 토큰입니다.",
+      task_explained:
+        "가져오기가 완료되면 페이지 내용이 문서 선택기에서 워크스페이스에 임베딩할 수 있도록 제공됩니다.",
     },
+
     manage: {
-      documents: null,
-      "data-connectors": null,
-      "desktop-only": null,
-      dismiss: null,
-      editing: null,
+      documents: "문서 관리",
+      "data-connectors": "데이터 커넥터",
+      "desktop-only":
+        "이 설정은 데스크톱 환경에서만 편집할 수 있습니다. 계속하려면 데스크톱에서 이 페이지에 접속해 주세요.",
+      dismiss: "닫기",
+      editing: "편집 중",
     },
     directory: {
-      "my-documents": null,
-      "new-folder": null,
-      "search-document": null,
-      "no-documents": null,
-      "move-workspace": null,
-      name: null,
-      "delete-confirmation": null,
-      "removing-message": null,
-      "move-success": null,
-      date: null,
-      type: null,
-      no_docs: null,
-      select_all: null,
-      deselect_all: null,
-      remove_selected: null,
-      costs: null,
-      save_embed: null,
+      "my-documents": "내 문서",
+      "new-folder": "새 폴더",
+      "search-document": "문서 검색",
+      "no-documents": "문서 없음",
+      "move-workspace": "워크스페이스로 이동",
+      name: "이름",
+      "delete-confirmation":
+        "이 파일과 폴더를 삭제하시겠습니까?\n삭제 시 시스템에서 완전히 제거되며, 기존 워크스페이스에서도 자동으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.",
+      "removing-message":
+        "{{count}}개의 문서와 {{folderCount}}개의 폴더를 삭제하는 중입니다. 잠시만 기다려 주세요.",
+      "move-success": "{{count}}개의 문서를 성공적으로 이동했습니다.",
+      date: "날짜",
+      type: "유형",
+      no_docs: "문서 없음",
+      select_all: "전체 선택",
+      deselect_all: "전체 선택 해제",
+      remove_selected: "선택 항목 삭제",
+      costs: "*임베딩 1회 비용",
+      save_embed: "저장 및 임베딩",
     },
     upload: {
-      "processor-offline": null,
-      "processor-offline-desc": null,
-      "click-upload": null,
-      "file-types": null,
-      "or-submit-link": null,
-      "placeholder-link": null,
-      fetching: null,
-      "fetch-website": null,
-      "privacy-notice": null,
+      "processor-offline": "문서 처리기가 오프라인 상태입니다",
+      "processor-offline-desc":
+        "현재 문서 처리기가 오프라인이어서 파일을 업로드할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+      "click-upload": "클릭하여 업로드하거나 파일을 끌어다 놓으세요",
+      "file-types":
+        "텍스트 파일, CSV, 스프레드시트, 오디오 파일 등 다양한 파일을 지원합니다!",
+      "or-submit-link": "또는 링크 제출",
+      "placeholder-link": "https://example.com",
+      fetching: "가져오는 중...",
+      "fetch-website": "웹사이트 가져오기",
+      "privacy-notice":
+        "이 파일들은 이 AnythingLLM 인스턴스에서 실행 중인 문서 처리기로 업로드됩니다. 파일은 제3자에게 전송되거나 공유되지 않습니다.",
     },
     pinning: {
-      what_pinning: null,
-      pin_explained_block1: null,
-      pin_explained_block2: null,
-      pin_explained_block3: null,
-      accept: null,
+      what_pinning: "문서 고정이란 무엇인가요?",
+      pin_explained_block1:
+        "AnythingLLM에서 문서를 <b>고정</b>하면 해당 문서의 전체 내용을 프롬프트 창에 삽입하여 LLM이 완전히 이해할 수 있도록 합니다.",
+      pin_explained_block2:
+        "이 기능은 <b>대용량 컨텍스트 모델</b>이나 지식 기반에 중요한 소형 파일에 가장 적합합니다.",
+      pin_explained_block3:
+        "기본 설정만으로 원하는 답변을 얻지 못할 때, 문서 고정은 한 번의 클릭으로 더 높은 품질의 답변을 얻을 수 있는 좋은 방법입니다.",
+      accept: "확인했습니다",
     },
     watching: {
-      what_watching: null,
-      watch_explained_block1: null,
-      watch_explained_block2: null,
-      watch_explained_block3_start: null,
-      watch_explained_block3_link: null,
-      watch_explained_block3_end: null,
-      accept: null,
-    },
-    obsidian: {
-      name: null,
-      description: null,
-      vault_location: null,
-      vault_description: null,
-      selected_files: null,
-      importing: null,
-      import_vault: null,
-      processing_time: null,
-      vault_warning: null,
+      what_watching: "문서 감시는 무엇을 하나요?",
+      watch_explained_block1:
+        "AnythingLLM에서 문서를 <b>감시</b>하면 원본 소스에서 정기적으로 문서 내용을 <i>자동으로</i> 동기화합니다. 이 파일이 관리되는 모든 워크스페이스의 내용이 자동으로 업데이트됩니다.",
+      watch_explained_block2:
+        "이 기능은 현재 온라인 기반 콘텐츠만 지원하며, 수동으로 업로드한 문서에는 사용할 수 없습니다.",
+      watch_explained_block3_start: "감시 중인 문서는 ",
+      watch_explained_block3_link: "파일 관리자",
+      watch_explained_block3_end: " 관리자 화면에서 관리할 수 있습니다.",
+      accept: "확인했습니다",
     },
   },
+
   chat_window: {
-    welcome: null,
-    get_started: null,
-    get_started_default: null,
-    upload: null,
-    or: null,
-    send_chat: null,
-    send_message: null,
-    attach_file: null,
-    slash: null,
-    agents: null,
-    text_size: null,
-    microphone: null,
-    send: null,
-    attachments_processing: null,
-    tts_speak_message: null,
-    copy: null,
-    regenerate: null,
-    regenerate_response: null,
-    good_response: null,
-    more_actions: null,
-    hide_citations: null,
-    show_citations: null,
-    pause_tts_speech_message: null,
-    fork: null,
-    delete: null,
-    save_submit: null,
-    cancel: null,
-    edit_prompt: null,
-    edit_response: null,
-    at_agent: null,
-    default_agent_description: null,
-    custom_agents_coming_soon: null,
-    slash_reset: null,
-    preset_reset_description: null,
-    add_new_preset: null,
-    command: null,
-    your_command: null,
-    placeholder_prompt: null,
-    description: null,
-    placeholder_description: null,
-    save: null,
-    small: null,
-    normal: null,
-    large: null,
+    welcome: "새 워크스페이스에 오신 것을 환영합니다.",
+    get_started: "시작하려면",
+    get_started_default: "시작하려면",
+    upload: "문서 업로드",
+    or: "또는",
+    attachments_processing:
+      "첨부 파일을 처리 중입니다. 잠시만 기다려 주세요...",
+    send_chat: "채팅을 보내세요.",
+    send_message: "메시지 보내기",
+    attach_file: "이 채팅에 파일 첨부",
+    slash: "채팅에서 사용할 수 있는 모든 슬래시 명령어 보기",
+    agents: "채팅에 사용할 수 있는 모든 에이전트 보기",
+    text_size: "텍스트 크기 변경",
+    microphone: "프롬프트를 음성으로 입력",
+    send: "프롬프트 메시지를 워크스페이스로 전송",
+    tts_speak_message: "TTS로 메시지 읽기",
+    copy: "복사",
+    regenerate: "다시 생성",
+    regenerate_response: "응답 다시 생성",
+    good_response: "좋은 답변",
+    more_actions: "더 많은 작업",
+    hide_citations: "인용 숨기기",
+    show_citations: "인용 보기",
+    pause_tts_speech_message: "TTS 음성 읽기 일시정지",
+    fork: "포크",
+    delete: "삭제",
+    save_submit: "저장 및 제출",
+    cancel: "취소",
+    edit_prompt: "프롬프트 수정",
+    edit_response: "응답 수정",
+    at_agent: "@agent",
+    default_agent_description: " - 이 워크스페이스의 기본 에이전트입니다.",
+    custom_agents_coming_soon: "커스텀 에이전트 기능이 곧 제공됩니다!",
+    slash_reset: "/reset",
+    preset_reset_description: "채팅 기록을 초기화하고 새 채팅을 시작합니다",
+    add_new_preset: "새 프리셋 추가",
+    command: "명령어",
+    your_command: "your-command",
+    placeholder_prompt: "이 내용이 프롬프트 앞에 삽입됩니다.",
+    description: "설명",
+    placeholder_description: "LLM에 대한 시로 응답합니다.",
+    save: "저장",
+    small: "작게",
+    normal: "보통",
+    large: "크게",
     workspace_llm_manager: {
-      search: null,
-      loading_workspace_settings: null,
-      available_models: null,
-      available_models_description: null,
-      save: null,
-      saving: null,
-      missing_credentials: null,
-      missing_credentials_description: null,
+      search: "LLM 제공자 검색",
+      loading_workspace_settings: "워크스페이스 설정을 불러오는 중...",
+      available_models: "{{provider}}의 사용 가능한 모델",
+      available_models_description:
+        "이 워크스페이스에서 사용할 모델을 선택하세요.",
+      save: "이 모델 사용하기",
+      saving: "모델을 워크스페이스 기본값으로 설정 중...",
+      missing_credentials: "이 제공자의 인증 정보가 없습니다!",
+      missing_credentials_description: "클릭하여 인증 정보를 설정하세요",
     },
   },
+
   profile_settings: {
-    edit_account: null,
-    profile_picture: null,
-    remove_profile_picture: null,
-    username: null,
-    username_description: null,
-    new_password: null,
-    passwort_description: null,
-    cancel: null,
-    update_account: null,
-    theme: null,
-    language: null,
-    failed_upload: null,
-    upload_success: null,
-    failed_remove: null,
-    profile_updated: null,
-    failed_update_user: null,
-    account: null,
-    support: null,
-    signout: null,
+    edit_account: "계정 정보 수정",
+    profile_picture: "프로필 사진",
+    remove_profile_picture: "프로필 사진 삭제",
+    username: "사용자명",
+    username_description:
+      "사용자명은 소문자, 숫자, 밑줄(_), 하이픈(-)만 사용할 수 있으며, 공백은 허용되지 않습니다.",
+    new_password: "새 비밀번호",
+    passwort_description: "비밀번호는 최소 8자 이상이어야 합니다.",
+    cancel: "취소",
+    update_account: "계정 정보 업데이트",
+    theme: "테마 설정",
+    language: "선호 언어",
+    failed_upload: "프로필 사진 업로드 실패: {{error}}",
+    upload_success: "프로필 사진이 업로드되었습니다.",
+    failed_remove: "프로필 사진 삭제 실패: {{error}}",
+    profile_updated: "프로필이 업데이트되었습니다.",
+    failed_update_user: "사용자 정보 업데이트 실패: {{error}}",
+    account: "계정",
+    support: "지원",
+    signout: "로그아웃",
   },
-  customization: {
-    interface: {
-      title: null,
-      description: null,
-    },
-    branding: {
-      title: null,
-      description: null,
-    },
-    chat: {
-      title: null,
-      description: null,
-      auto_submit: {
-        title: null,
-        description: null,
-      },
-      auto_speak: {
-        title: null,
-        description: null,
-      },
-      spellcheck: {
-        title: null,
-        description: null,
-      },
-    },
-    items: {
-      theme: {
-        title: null,
-        description: null,
-      },
-      "show-scrollbar": {
-        title: null,
-        description: null,
-      },
-      "support-email": {
-        title: null,
-        description: null,
-      },
-      "app-name": {
-        title: null,
-        description: null,
-      },
-      "chat-message-alignment": {
-        title: null,
-        description: null,
-      },
-      "display-language": {
-        title: null,
-        description: null,
-      },
-      logo: {
-        title: null,
-        description: null,
-        add: null,
-        recommended: null,
-        remove: null,
-        replace: null,
-      },
-      "welcome-messages": {
-        title: null,
-        description: null,
-        new: null,
-        system: null,
-        user: null,
-        message: null,
-        assistant: null,
-        "double-click": null,
-        save: null,
-      },
-      "browser-appearance": {
-        title: null,
-        description: null,
-        tab: {
-          title: null,
-          description: null,
-        },
-        favicon: {
-          title: null,
-          description: null,
-        },
-      },
-      "sidebar-footer": {
-        title: null,
-        description: null,
-        icon: null,
-        link: null,
-      },
-    },
-  },
-  "main-page": {
-    noWorkspaceError: null,
-    checklist: {
-      title: null,
-      tasksLeft: null,
-      completed: null,
-      dismiss: null,
-      tasks: {
-        create_workspace: {
-          title: null,
-          description: null,
-          action: null,
-        },
-        send_chat: {
-          title: null,
-          description: null,
-          action: null,
-        },
-        embed_document: {
-          title: null,
-          description: null,
-          action: null,
-        },
-        setup_system_prompt: {
-          title: null,
-          description: null,
-          action: null,
-        },
-        define_slash_command: {
-          title: null,
-          description: null,
-          action: null,
-        },
-        visit_community: {
-          title: null,
-          description: null,
-          action: null,
-        },
-      },
-    },
-    quickLinks: {
-      title: null,
-      sendChat: null,
-      embedDocument: null,
-      createWorkspace: null,
-    },
-    exploreMore: {
-      title: null,
-      features: {
-        customAgents: {
-          title: null,
-          description: null,
-          primaryAction: null,
-          secondaryAction: null,
-        },
-        slashCommands: {
-          title: null,
-          description: null,
-          primaryAction: null,
-          secondaryAction: null,
-        },
-        systemPrompts: {
-          title: null,
-          description: null,
-          primaryAction: null,
-          secondaryAction: null,
-        },
-      },
-    },
-    announcements: {
-      title: null,
-    },
-    resources: {
-      title: null,
-      links: {
-        docs: null,
-        star: null,
-      },
-      keyboardShortcuts: null,
-    },
-  },
+
   "keyboard-shortcuts": {
-    title: null,
+    title: "단축키 안내",
     shortcuts: {
-      settings: null,
-      workspaceSettings: null,
-      home: null,
-      workspaces: null,
-      apiKeys: null,
-      llmPreferences: null,
-      chatSettings: null,
-      help: null,
-      showLLMSelector: null,
+      settings: "설정 열기",
+      workspaceSettings: "현재 워크스페이스 설정 열기",
+      home: "홈으로 이동",
+      workspaces: "워크스페이스 관리",
+      apiKeys: "API 키 설정",
+      llmPreferences: "LLM 기본 설정",
+      chatSettings: "채팅 설정",
+      help: "단축키 도움말 보기",
+      showLLMSelector: "워크스페이스 LLM 선택기 열기",
     },
   },
+
   community_hub: {
     publish: {
       system_prompt: {
-        success_title: null,
-        success_description: null,
-        success_thank_you: null,
-        view_on_hub: null,
-        modal_title: null,
-        name_label: null,
-        name_description: null,
-        name_placeholder: null,
-        description_label: null,
-        description_description: null,
-        tags_label: null,
-        tags_description: null,
-        tags_placeholder: null,
-        visibility_label: null,
-        public_description: null,
-        private_description: null,
-        publish_button: null,
-        submitting: null,
-        submit: null,
-        prompt_label: null,
-        prompt_description: null,
-        prompt_placeholder: null,
+        success_title: "성공!",
+        success_description:
+          "시스템 프롬프트가 커뮤니티 허브에 성공적으로 게시되었습니다!",
+        success_thank_you: "커뮤니티에 공유해주셔서 감사합니다!",
+        view_on_hub: "커뮤니티 허브에서 보기",
+        modal_title: "시스템 프롬프트 게시",
+        name_label: "이름",
+        name_description: "시스템 프롬프트의 표시 이름입니다.",
+        name_placeholder: "나의 시스템 프롬프트",
+        description_label: "설명",
+        description_description:
+          "시스템 프롬프트의 목적이나 용도를 설명해 주세요.",
+        tags_label: "태그",
+        tags_description:
+          "태그를 추가하면 시스템 프롬프트를 더 쉽게 검색할 수 있습니다. 여러 개의 태그를 추가할 수 있습니다. 최대 5개, 태그당 20자 이내로 입력해 주세요.",
+        tags_placeholder: "태그 입력 후 Enter를 눌러 추가",
+        visibility_label: "공개 범위",
+        public_description: "공개 시스템 프롬프트는 모든 사용자에게 보입니다.",
+        private_description: "비공개 시스템 프롬프트는 본인만 볼 수 있습니다.",
+        publish_button: "커뮤니티 허브에 게시",
+        submitting: "게시 중...",
+        submit: "커뮤니티 허브에 게시",
+        prompt_label: "프롬프트",
+        prompt_description:
+          "실제로 LLM을 안내하는 데 사용될 시스템 프롬프트를 입력하세요.",
+        prompt_placeholder: "여기에 시스템 프롬프트를 입력하세요...",
       },
       agent_flow: {
-        public_description: null,
-        private_description: null,
-        success_title: null,
-        success_description: null,
-        success_thank_you: null,
-        view_on_hub: null,
-        modal_title: null,
-        name_label: null,
-        name_description: null,
-        name_placeholder: null,
-        description_label: null,
-        description_description: null,
-        tags_label: null,
-        tags_description: null,
-        tags_placeholder: null,
-        visibility_label: null,
-        publish_button: null,
-        submitting: null,
-        submit: null,
-        privacy_note: null,
+        public_description:
+          "공개 에이전트 플로우는 모든 사용자에게 표시됩니다.",
+        private_description: "비공개 에이전트 플로우는 본인만 볼 수 있습니다.",
+        success_title: "성공!",
+        success_description:
+          "에이전트 플로우가 커뮤니티 허브에 성공적으로 게시되었습니다!",
+        success_thank_you: "커뮤니티에 공유해주셔서 감사합니다!",
+        view_on_hub: "커뮤니티 허브에서 보기",
+        modal_title: "에이전트 플로우 게시",
+        name_label: "이름",
+        name_description: "에이전트 플로우의 표시 이름입니다.",
+        name_placeholder: "나의 에이전트 플로우",
+        description_label: "설명",
+        description_description:
+          "에이전트 플로우의 목적이나 용도를 설명해 주세요.",
+        tags_label: "태그",
+        tags_description:
+          "태그를 추가하면 에이전트 플로우를 더 쉽게 검색할 수 있습니다. 여러 개의 태그를 추가할 수 있습니다. 최대 5개, 태그당 20자 이내로 입력해 주세요.",
+        tags_placeholder: "태그 입력 후 Enter를 눌러 추가",
+        visibility_label: "공개 범위",
+        publish_button: "커뮤니티 허브에 게시",
+        submitting: "게시 중...",
+        submit: "커뮤니티 허브에 게시",
+        privacy_note:
+          "에이전트 플로우는 민감한 데이터를 보호하기 위해 항상 비공개로 업로드됩니다. 게시 후 커뮤니티 허브에서 공개 범위를 변경할 수 있습니다. 게시 전에 플로우에 민감하거나 개인 정보가 포함되어 있지 않은지 꼭 확인해 주세요.",
+      },
+      slash_command: {
+        success_title: "성공!",
+        success_description:
+          "슬래시 커맨드가 커뮤니티 허브에 성공적으로 게시되었습니다!",
+        success_thank_you: "커뮤니티에 공유해주셔서 감사합니다!",
+        view_on_hub: "커뮤니티 허브에서 보기",
+        modal_title: "슬래시 커맨드 게시",
+        name_label: "이름",
+        name_description: "슬래시 커맨드의 표시 이름입니다.",
+        name_placeholder: "나의 슬래시 커맨드",
+        description_label: "설명",
+        description_description:
+          "슬래시 커맨드의 목적이나 용도를 설명해 주세요.",
+        command_label: "커맨드",
+        command_description:
+          "사용자가 이 프리셋을 실행할 때 입력할 슬래시 커맨드입니다.",
+        command_placeholder: "my-command",
+        tags_label: "태그",
+        tags_description:
+          "태그를 추가하면 슬래시 커맨드를 더 쉽게 검색할 수 있습니다. 여러 개의 태그를 추가할 수 있습니다. 최대 5개, 태그당 20자 이내로 입력해 주세요.",
+        tags_placeholder: "태그 입력 후 Enter를 눌러 추가",
+        visibility_label: "공개 범위",
+        public_description: "공개 슬래시 커맨드는 모든 사용자에게 보입니다.",
+        private_description: "비공개 슬래시 커맨드는 본인만 볼 수 있습니다.",
+        publish_button: "커뮤니티 허브에 게시",
+        submitting: "게시 중...",
+        prompt_label: "프롬프트",
+        prompt_description: "슬래시 커맨드가 실행될 때 사용될 프롬프트입니다.",
+        prompt_placeholder: "여기에 프롬프트를 입력하세요...",
       },
       generic: {
         unauthenticated: {
-          title: null,
-          description: null,
-          button: null,
+          title: "인증 필요",
+          description:
+            "항목을 게시하려면 AnythingLLM 커뮤니티 허브에 인증해야 합니다.",
+          button: "커뮤니티 허브에 연결",
         },
-      },
-      slash_command: {
-        success_title: null,
-        success_description: null,
-        success_thank_you: null,
-        view_on_hub: null,
-        modal_title: null,
-        name_label: null,
-        name_description: null,
-        name_placeholder: null,
-        description_label: null,
-        description_description: null,
-        command_label: null,
-        command_description: null,
-        command_placeholder: null,
-        tags_label: null,
-        tags_description: null,
-        tags_placeholder: null,
-        visibility_label: null,
-        public_description: null,
-        private_description: null,
-        publish_button: null,
-        submitting: null,
-        prompt_label: null,
-        prompt_description: null,
-        prompt_placeholder: null,
       },
     },
   },

--- a/frontend/src/locales/ko/common.js
+++ b/frontend/src/locales/ko/common.js
@@ -1,3 +1,4 @@
+// Anything with "null" requires a translation. Contribute to translation via a PR!
 const TRANSLATIONS = {
   onboarding: {
     home: {
@@ -37,7 +38,6 @@ const TRANSLATIONS = {
       title: "AnythingLLM에 오신 것을 환영합니다",
       description:
         "여러분의 필요에 맞는 AnythingLLM을 만들 수 있도록 도와주세요. (선택 사항)",
-
       email: "이메일을 입력해 주세요",
       useCase: "AnythingLLM을 어떤 용도로 사용하실 예정인가요?",
       useCaseWork: "업무용",
@@ -69,8 +69,6 @@ const TRANSLATIONS = {
     yes: "예",
     no: "아니오",
   },
-
-  // Setting Sidebar menu items.
   settings: {
     title: "인스턴스 설정",
     system: "일반 설정",
@@ -103,8 +101,6 @@ const TRANSLATIONS = {
     branding: "브랜딩 및 화이트라벨링",
     chat: "채팅",
   },
-
-  // Page Definitions
   login: {
     "multi-user": {
       welcome: "웰컴!",
@@ -127,7 +123,6 @@ const TRANSLATIONS = {
       "back-to-login": "로그인으로 돌아가기",
     },
   },
-
   welcomeMessage: {
     part1:
       "AnythingLLM에 오신 것을 환영합니다! AnythingLLM은 Mintplex Labs에서 개발한 오픈소스 AI 도구로, 어떤 것이든 학습된 챗봇으로 만들어 대화하고 질문할 수 있습니다. AnythingLLM은 BYOK(키 직접 제공) 방식의 소프트웨어로, 사용자가 원하는 외부 서비스 이용료 외에는 별도의 구독이나 비용이 없습니다.",
@@ -148,7 +143,6 @@ const TRANSLATIONS = {
     starOnGitHub: "GitHub에 스타 누르기",
     contact: "Mintplex Labs에 문의하기",
   },
-
   "main-page": {
     noWorkspaceError: "채팅을 시작하기 전에 워크스페이스를 먼저 만들어주세요.",
     checklist: {
@@ -232,13 +226,10 @@ const TRANSLATIONS = {
       keyboardShortcuts: "단축키 안내",
     },
   },
-
   "new-workspace": {
     title: "새 워크스페이스",
     placeholder: "내 워크스페이스",
   },
-
-  // Workspace Settings menu items
   "workspaces—settings": {
     general: "일반 설정",
     chat: "채팅 설정",
@@ -246,8 +237,6 @@ const TRANSLATIONS = {
     members: "구성원",
     agent: "에이전트 구성",
   },
-
-  // General Appearance
   general: {
     vector: {
       title: "벡터 수",
@@ -281,8 +270,6 @@ const TRANSLATIONS = {
         "워크스페이스 전체를 삭제합니다. 이 작업은 벡터 데이터베이스에 있는 모든 벡터 임베딩을 제거합니다.\n\n원본 소스 파일은 그대로 유지됩니다. 이 작업은 되돌릴 수 없습니다.",
     },
   },
-
-  // Chat Settings
   chat: {
     llm: {
       title: "워크스페이스 LLM 제공자",
@@ -352,8 +339,6 @@ const TRANSLATIONS = {
       hint: "대부분의 LLM은 유효한 값의 다양한 허용 범위를 가지고 있습니다. 해당 정보는 LLM 제공자에게 문의하세요.",
     },
   },
-
-  // Vector Database
   "vector-workspace": {
     identifier: "벡터 데이터베이스 식별자",
     snippets: {
@@ -380,8 +365,6 @@ const TRANSLATIONS = {
       success: "워크스페이스 벡터 데이터베이스가 재설정되었습니다!",
     },
   },
-
-  // Agent Configuration
   agent: {
     "performance-warning":
       "도구 호출을 명시적으로 지원하지 않는 LLM의 성능은 모델의 기능과 정확도에 크게 좌우됩니다. 일부 기능은 제한되거나 작동하지 않을 수 있습니다.",
@@ -439,8 +422,6 @@ const TRANSLATIONS = {
       },
     },
   },
-
-  // Workspace Chats
   recorded: {
     title: "워크스페이스 채팅",
     description:
@@ -455,7 +436,6 @@ const TRANSLATIONS = {
       at: "보낸 시각",
     },
   },
-
   customization: {
     interface: {
       title: "UI 환경 설정",
@@ -553,7 +533,6 @@ const TRANSLATIONS = {
       },
     },
   },
-
   api: {
     title: "API 키",
     description:
@@ -566,7 +545,6 @@ const TRANSLATIONS = {
       created: "생성일",
     },
   },
-
   llm: {
     title: "LLM 기본 설정",
     description:
@@ -584,7 +562,6 @@ const TRANSLATIONS = {
       },
     },
   },
-
   transcription: {
     title: "텍스트 변환 모델 기본 설정",
     description:
@@ -595,7 +572,6 @@ const TRANSLATIONS = {
     "warn-recommend": "최소 2GB RAM과 10Mb 보다 작은 파일 업로드를 권장합니다.",
     "warn-end": "내장된 모델은 첫 번째 사용 시 자동으로 다운로드됩니다.",
   },
-
   embedding: {
     title: "임베딩 기본 설정",
     "desc-start":
@@ -608,7 +584,6 @@ const TRANSLATIONS = {
         "AnythingLLM의 기본 임베딩 엔진을 사용할 때는 설정이 필요하지 않습니다.",
     },
   },
-
   text: {
     title: "텍스트 분할 및 청킹 기본 설정",
     "desc-start":
@@ -623,14 +598,12 @@ const TRANSLATIONS = {
       description: "단일 벡터에 들어갈 수 있는 최대 문자 길이입니다.",
       recommend: "임베드 모델 최대 길이는",
     },
-
     overlap: {
       title: "텍스트 청크 겹침",
       description:
         "청킹 동안 두 인접 텍스트 청크 간에 겹칠 수 있는 최대 문자 수입니다.",
     },
   },
-
   vector: {
     title: "벡터 데이터베이스",
     description:
@@ -640,8 +613,6 @@ const TRANSLATIONS = {
       description: "LanceDB를 선택하면 설정이 필요 없습니다.",
     },
   },
-
-  // Embeddable Chat Widgets
   embeddable: {
     title: "임베드 가능한 채팅 위젯",
     description:
@@ -654,7 +625,6 @@ const TRANSLATIONS = {
       created: "생성일",
     },
   },
-
   "embed-chats": {
     title: "임베드 채팅",
     export: "내보내기",
@@ -667,7 +637,6 @@ const TRANSLATIONS = {
       at: "보낸 시각",
     },
   },
-
   multi: {
     title: "다중 사용자 모드",
     description:
@@ -692,8 +661,6 @@ const TRANSLATIONS = {
       password: "인스턴스 비밀번호",
     },
   },
-
-  // Event Logs
   event: {
     title: "이벤트 로그",
     description:
@@ -705,8 +672,6 @@ const TRANSLATIONS = {
       occurred: "발생 시각",
     },
   },
-
-  // Privacy & Data-Handling
   privacy: {
     title: "개인정보와 데이터 처리",
     description:
@@ -716,7 +681,6 @@ const TRANSLATIONS = {
     vector: "벡터 데이터베이스",
     anonymous: "익명 원격 분석 활성화",
   },
-
   connectors: {
     "search-placeholder": "데이터 커넥터 검색",
     "no-connectors": "데이터 커넥터를 찾을 수 없습니다.",
@@ -847,7 +811,6 @@ const TRANSLATIONS = {
       task_explained:
         "가져오기가 완료되면 페이지 내용이 문서 선택기에서 워크스페이스에 임베딩할 수 있도록 제공됩니다.",
     },
-
     manage: {
       documents: "문서 관리",
       "data-connectors": "데이터 커넥터",
@@ -913,7 +876,6 @@ const TRANSLATIONS = {
       accept: "확인했습니다",
     },
   },
-
   chat_window: {
     welcome: "새 워크스페이스에 오신 것을 환영합니다.",
     get_started: "시작하려면",
@@ -972,7 +934,6 @@ const TRANSLATIONS = {
       missing_credentials_description: "클릭하여 인증 정보를 설정하세요",
     },
   },
-
   profile_settings: {
     edit_account: "계정 정보 수정",
     profile_picture: "프로필 사진",
@@ -995,7 +956,6 @@ const TRANSLATIONS = {
     support: "지원",
     signout: "로그아웃",
   },
-
   "keyboard-shortcuts": {
     title: "단축키 안내",
     shortcuts: {
@@ -1010,7 +970,6 @@ const TRANSLATIONS = {
       showLLMSelector: "워크스페이스 LLM 선택기 열기",
     },
   },
-
   community_hub: {
     publish: {
       system_prompt: {


### PR DESCRIPTION
- Add comprehensive Korean translations for UI elements
- Include main page features, workspace settings, and chat components
- Support Korean localization for common user interactions


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

N/A - Adding Korean localization support


### What is in this change?

This PR adds comprehensive Korean (ko) translations to AnythingLLM's frontend localization system.

**Changes made:**
- Add complete Korean translations for `frontend/src/locales/ko/common.js`
- Include main page features, workspace settings, and chat components
- Support Korean localization for common user interactions
- Translate UI elements including:
  - Main page explore features section (custom agents, slash commands, system prompts)
  - Workspace settings and configuration options
  - Chat functionality and modes
  - Common navigation and error messages
  - Onboarding flow and welcome messages

This enables Korean-speaking users to use AnythingLLM in their native language, improving accessibility and user experience for the Korean community.

### Additional Information

- All translations follow the existing translation structure and key naming conventions
- Korean translations are culturally appropriate and maintain technical accuracy
- No breaking changes to existing functionality
- Ready for production use

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
