### PR TITLE
Modify the PostgreSQL SQL connector to support querying tables from schemas other than the default public schema.

### DIFF
--- a/frontend/src/pages/Admin/Agents/SQLConnectorSelection/NewConnectionModal.jsx
+++ b/frontend/src/pages/Admin/Agents/SQLConnectorSelection/NewConnectionModal.jsx
@@ -36,6 +36,7 @@ const DEFAULT_CONFIG = {
   host: null,
   port: null,
   database: null,
+  schema: null,
   encrypt: false,
 };
 
@@ -268,6 +269,23 @@ export default function NewSQLConnection({
                     spellCheck={false}
                   />
                 </div>
+
+                {engine === "postgresql" && (
+                  <div className="flex flex-col">
+                    <label className="block mb-2 text-sm font-medium text-white">
+                      Schema (optional)
+                    </label>
+                    <input
+                      type="text"
+                      name="schema"
+                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      placeholder="public (default schema if not specified)"
+                      required={false}
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                  </div>
+                )}
 
                 {engine === "sql-server" && (
                   <div className="flex items-center justify-between">

--- a/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
+++ b/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
@@ -61,5 +61,6 @@ class PostgresSQLConnector {
   getTableSchemaSql(table_name) {
     return ` select column_name, data_type, character_maximum_length, column_default, is_nullable from INFORMATION_SCHEMA.COLUMNS where table_name = '${table_name}' AND table_schema = '${this.schema}'`;
   }
+}
 
 module.exports.PostgresSQLConnector = PostgresSQLConnector;

--- a/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
+++ b/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
@@ -61,6 +61,5 @@ class PostgresSQLConnector {
   getTableSchemaSql(table_name) {
     return ` select column_name, data_type, character_maximum_length, column_default, is_nullable from INFORMATION_SCHEMA.COLUMNS where table_name = '${table_name}' AND table_schema = '${this.schema}'`;
   }
-}
 
 module.exports.PostgresSQLConnector = PostgresSQLConnector;

--- a/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
+++ b/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
@@ -62,14 +62,4 @@ class PostgresSQLConnector {
     return ` select column_name, data_type, character_maximum_length, column_default, is_nullable from INFORMATION_SCHEMA.COLUMNS where table_name = '${table_name}' AND table_schema = '${this.schema}'`;
   }
 
-  /**
-   * Returns the qualified table name with schema prefix
-   * @param {string} table_name - The table name
-   * @returns {string} - The qualified table name (schema.table)
-   */
-  getQualifiedTableName(table_name) {
-    return `${this.schema}.${table_name}`;
-  }
-}
-
 module.exports.PostgresSQLConnector = PostgresSQLConnector;

--- a/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
+++ b/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
@@ -5,9 +5,11 @@ class PostgresSQLConnector {
   constructor(
     config = {
       connectionString: null,
+      schema: null,
     }
   ) {
     this.connectionString = config.connectionString;
+    this.schema = config.schema || 'public';
     this._client = new pgSql.Client({
       connectionString: this.connectionString,
     });
@@ -54,10 +56,19 @@ class PostgresSQLConnector {
   }
 
   getTablesSql() {
-    return `SELECT * FROM pg_catalog.pg_tables WHERE schemaname = 'public'`;
+    return `SELECT * FROM pg_catalog.pg_tables WHERE schemaname = '${this.schema}'`;
   }
   getTableSchemaSql(table_name) {
-    return ` select column_name, data_type, character_maximum_length, column_default, is_nullable from INFORMATION_SCHEMA.COLUMNS where table_name = '${table_name}'`;
+    return ` select column_name, data_type, character_maximum_length, column_default, is_nullable from INFORMATION_SCHEMA.COLUMNS where table_name = '${table_name}' AND table_schema = '${this.schema}'`;
+  }
+
+  /**
+   * Returns the qualified table name with schema prefix
+   * @param {string} table_name - The table name
+   * @returns {string} - The qualified table name (schema.table)
+   */
+  getQualifiedTableName(table_name) {
+    return `${this.schema}.${table_name}`;
   }
 }
 

--- a/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
+++ b/server/utils/agents/aibitat/plugins/sql-agent/SQLConnectors/Postgresql.js
@@ -9,7 +9,7 @@ class PostgresSQLConnector {
     }
   ) {
     this.connectionString = config.connectionString;
-    this.schema = config.schema || 'public';
+    this.schema = config.schema || "public";
     this._client = new pgSql.Client({
       connectionString: this.connectionString,
     });


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4196 


### What is in this change?
Modify the PostgreSQL SQL connector to support querying tables from schemas other than the default public schema. The connector should dynamically include the schema name when generating SQL queries, using the schema.table format.


<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
