### PR TITLE
 fix: API export-chats endpoint function import error

### DIFF
--- a/server/endpoints/api/system/index.js
+++ b/server/endpoints/api/system/index.js
@@ -2,10 +2,7 @@ const { EventLogs } = require("../../../models/eventLogs");
 const { SystemSettings } = require("../../../models/systemSettings");
 const { purgeDocument } = require("../../../utils/files/purgeDocument");
 const { getVectorDbClass } = require("../../../utils/helpers");
-const {
-  prepareWorkspaceChatsForExport,
-  exportChatsAsType,
-} = require("../../../utils/helpers/chat/convertTo");
+const { exportChatsAsType } = require("../../../utils/helpers/chat/convertTo");
 const { dumpENV, updateENV } = require("../../../utils/helpers/updateENV");
 const { reqBody } = require("../../../utils/http");
 const { validApiKey } = require("../../../utils/middleware/validApiKey");
@@ -192,8 +189,10 @@ function apiSystemEndpoints(app) {
     */
       try {
         const { type = "jsonl" } = request.query;
-        const chats = await prepareWorkspaceChatsForExport(type);
-        const { contentType, data } = await exportChatsAsType(chats, type);
+        const { contentType, data } = await exportChatsAsType(
+          type,
+          "workspace"
+        );
         await EventLogs.logEvent("exported_chats", {
           type,
         });


### PR DESCRIPTION
- [x] 🐛 fix

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4215

### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

Fixed API export-chats endpoint error by correcting function import and call. Changed from non-existent `prepareWorkspaceChatsForExport` to correct `exportChatsAsType` function.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

The bug was causing "prepareWorkspaceChatsForExport is not a function" error when exporting chat logs via API. Web UI export was working fine as it uses different endpoints.