### PR TITLE
- feat: make a workspace is agentic as default

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -59,6 +59,8 @@ const TRANSLATIONS = {
   },
   common: {
     "workspaces-name": "Workspaces Name",
+    workspaces_is_agentic: "Is agentic",
+    workspaces_is_agentic_is_agentic_description: "Use all chats as agents",
     error: "error",
     success: "success",
     user: "User",

--- a/frontend/src/pages/WorkspaceSettings/GeneralAppearance/WorkspaceIsAgentic/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/GeneralAppearance/WorkspaceIsAgentic/index.jsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+export default function WorkspaceIsAgentic({ workspace, setHasChanges }) {
+  const [isAgentic, setIsAgentic] = useState(false);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (workspace?.agentic !== undefined) {
+      setIsAgentic(Boolean(workspace.agentic));
+    }
+  }, [workspace?.agentic]);
+
+  const handleChange = (e) => {
+    const newValue = e.target.checked;
+    setIsAgentic(newValue);
+    setHasChanges(true);
+  };
+
+  return (
+    <div className="flex flex-col gap-y-0.5 my-4">
+      <p className="text-sm leading-6 font-semibold text-white">
+        {t("common.workspaces_is_agentic")}
+      </p>
+      <p className="text-xs text-white/60">
+        {t("common.workspaces_is_agentic_is_agentic_description")}
+      </p>
+      <div className="flex items-center gap-x-4">
+        <label className="relative inline-flex cursor-pointer items-center">
+          <input
+            id="agentic"
+            type="checkbox"
+            name="agentic"
+            value="yes"
+            checked={isAgentic}
+            onChange={handleChange}
+            className="peer sr-only"
+          />
+          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-white after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspaceSettings/GeneralAppearance/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/GeneralAppearance/index.jsx
@@ -3,6 +3,7 @@ import { castToType } from "@/utils/types";
 import showToast from "@/utils/toast";
 import { useEffect, useRef, useState } from "react";
 import WorkspaceName from "./WorkspaceName";
+import WorkspaceIsAgentic from "./WorkspaceIsAgentic";
 import SuggestedChatMessages from "./SuggestedChatMessages";
 import DeleteWorkspace from "./DeleteWorkspace";
 import WorkspacePfp from "./WorkspacePfp";
@@ -59,6 +60,11 @@ export default function GeneralInfo({ slug }) {
           </div>
         )}
         <WorkspaceName
+          key={workspace.slug}
+          workspace={workspace}
+          setHasChanges={setHasChanges}
+        />
+        <WorkspaceIsAgentic
           key={workspace.slug}
           workspace={workspace}
           setHasChanges={setHasChanges}

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -55,6 +55,7 @@ const Workspace = {
     "agentModel",
     "queryRefusalResponse",
     "vectorSearchMode",
+    "agentic",
   ],
 
   validations: {
@@ -128,6 +129,16 @@ const Workspace = {
       )
         return "default";
       return value;
+    },
+    agentic: (value) => {
+      if (value === null || value === undefined) return false;
+      if (typeof value === "boolean") return value;
+      if (typeof value === "string") {
+        const lowerValue = value.toLowerCase();
+        return lowerValue === "true" || lowerValue === "yes" || lowerValue === "1";
+      }
+      if (typeof value === "number") return Boolean(value);
+      return Boolean(value);
     },
   },
 

--- a/server/prisma/migrations/20250826125714_init/migration.sql
+++ b/server/prisma/migrations/20250826125714_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN "agentic" BOOLEAN DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -2,14 +2,6 @@ generator client {
   provider = "prisma-client-js"
 }
 
-// Uncomment the following lines and comment out the SQLite datasource block above to use PostgreSQL
-// Make sure to set the correct DATABASE_URL in your .env file
-// After swapping run `yarn prisma:setup` from the root directory to migrate the database
-//
-// datasource db {
-//   provider = "postgresql"
-//   url      = env("DATABASE_URL")
-// }
 datasource db {
   provider = "sqlite"
   url      = "file:../storage/anythingllm.db"
@@ -30,12 +22,12 @@ model workspace_documents {
   docpath              String
   workspaceId          Int
   metadata             String?
-  pinned               Boolean?              @default(false)
-  watched              Boolean?              @default(false)
   createdAt            DateTime              @default(now())
   lastUpdatedAt        DateTime              @default(now())
-  workspace            workspaces            @relation(fields: [workspaceId], references: [id])
+  pinned               Boolean?              @default(false)
+  watched              Boolean?              @default(false)
   document_sync_queues document_sync_queues?
+  workspace            workspaces            @relation(fields: [workspaceId], references: [id])
 }
 
 model invites {
@@ -43,10 +35,10 @@ model invites {
   code          String   @unique
   status        String   @default("pending")
   claimedBy     Int?
-  workspaceIds  String?
   createdAt     DateTime @default(now())
   createdBy     Int
   lastUpdatedAt DateTime @default(now())
+  workspaceIds  String?
 }
 
 model system_settings {
@@ -61,29 +53,29 @@ model users {
   id                          Int                           @id @default(autoincrement())
   username                    String?                       @unique
   password                    String
-  pfpFilename                 String?
   role                        String                        @default("default")
   suspended                   Int                           @default(0)
-  seen_recovery_codes         Boolean?                      @default(false)
   createdAt                   DateTime                      @default(now())
   lastUpdatedAt               DateTime                      @default(now())
+  pfpFilename                 String?
+  seen_recovery_codes         Boolean?                      @default(false)
   dailyMessageLimit           Int?
   bio                         String?                       @default("")
-  workspace_chats             workspace_chats[]
-  workspace_users             workspace_users[]
-  embed_configs               embed_configs[]
-  embed_chats                 embed_chats[]
-  threads                     workspace_threads[]
-  recovery_codes              recovery_codes[]
-  password_reset_tokens       password_reset_tokens[]
-  workspace_agent_invocations workspace_agent_invocations[]
-  slash_command_presets       slash_command_presets[]
   browser_extension_api_keys  browser_extension_api_keys[]
-  temporary_auth_tokens       temporary_auth_tokens[]
-  system_prompt_variables     system_prompt_variables[]
-  prompt_history              prompt_history[]
   desktop_mobile_devices      desktop_mobile_devices[]
+  embed_chats                 embed_chats[]
+  embed_configs               embed_configs[]
+  password_reset_tokens       password_reset_tokens[]
+  prompt_history              prompt_history[]
+  recovery_codes              recovery_codes[]
+  slash_command_presets       slash_command_presets[]
+  system_prompt_variables     system_prompt_variables[]
+  temporary_auth_tokens       temporary_auth_tokens[]
+  workspace_agent_invocations workspace_agent_invocations[]
+  workspace_chats             workspace_chats[]
   workspace_parsed_files      workspace_parsed_files[]
+  threads                     workspace_threads[]
+  workspace_users             workspace_users[]
 }
 
 model recovery_codes {
@@ -134,23 +126,24 @@ model workspaces {
   lastUpdatedAt                DateTime                       @default(now())
   openAiPrompt                 String?
   similarityThreshold          Float?                         @default(0.25)
-  chatProvider                 String?
   chatModel                    String?
   topN                         Int?                           @default(4)
   chatMode                     String?                        @default("chat")
   pfpFilename                  String?
-  agentProvider                String?
+  chatProvider                 String?
   agentModel                   String?
+  agentProvider                String?
   queryRefusalResponse         String?
   vectorSearchMode             String?                        @default("default")
-  workspace_users              workspace_users[]
-  documents                    workspace_documents[]
-  workspace_suggested_messages workspace_suggested_messages[]
+  agentic                      Boolean?                       @default(false)
   embed_configs                embed_configs[]
-  threads                      workspace_threads[]
-  workspace_agent_invocations  workspace_agent_invocations[]
   prompt_history               prompt_history[]
+  workspace_agent_invocations  workspace_agent_invocations[]
+  documents                    workspace_documents[]
   workspace_parsed_files       workspace_parsed_files[]
+  workspace_suggested_messages workspace_suggested_messages[]
+  threads                      workspace_threads[]
+  workspace_users              workspace_users[]
 }
 
 model workspace_threads {
@@ -161,9 +154,9 @@ model workspace_threads {
   user_id                Int?
   createdAt              DateTime                 @default(now())
   lastUpdatedAt          DateTime                 @default(now())
-  workspace              workspaces               @relation(fields: [workspace_id], references: [id], onDelete: Cascade)
-  user                   users?                   @relation(fields: [user_id], references: [id], onDelete: Cascade)
   workspace_parsed_files workspace_parsed_files[]
+  user                   users?                   @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  workspace              workspaces               @relation(fields: [workspace_id], references: [id], onDelete: Cascade)
 
   @@index([workspace_id])
   @@index([user_id])
@@ -188,26 +181,26 @@ model workspace_chats {
   response       String
   include        Boolean  @default(true)
   user_id        Int?
-  thread_id      Int? // No relation to prevent whole table migration
-  api_session_id String? // String identifier for only the dev API to partition chats in any mode.
   createdAt      DateTime @default(now())
   lastUpdatedAt  DateTime @default(now())
+  thread_id      Int?
   feedbackScore  Boolean?
-  users          users?   @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  api_session_id String?
+  users          users?   @relation(fields: [user_id], references: [id], onDelete: Cascade)
 }
 
 model workspace_agent_invocations {
   id            Int        @id @default(autoincrement())
   uuid          String     @unique
-  prompt        String // Contains agent invocation to parse + option additional text for seed.
+  prompt        String
   closed        Boolean    @default(false)
   user_id       Int?
-  thread_id     Int? // No relation to prevent whole table migration
+  thread_id     Int?
   workspace_id  Int
   createdAt     DateTime   @default(now())
   lastUpdatedAt DateTime   @default(now())
-  user          users?     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  workspace     workspaces @relation(fields: [workspace_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  workspace     workspaces @relation(fields: [workspace_id], references: [id], onDelete: Cascade)
+  user          users?     @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@index([uuid])
 }
@@ -218,8 +211,8 @@ model workspace_users {
   workspace_id  Int
   createdAt     DateTime   @default(now())
   lastUpdatedAt DateTime   @default(now())
-  workspaces    workspaces @relation(fields: [workspace_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  users         users      @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  users         users      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  workspaces    workspaces @relation(fields: [workspace_id], references: [id], onDelete: Cascade)
 }
 
 model cache_data {
@@ -244,14 +237,14 @@ model embed_configs {
   allow_prompt_override      Boolean       @default(false)
   max_chats_per_day          Int?
   max_chats_per_session      Int?
-  message_limit              Int?          @default(20)
   workspace_id               Int
   createdBy                  Int?
   usersId                    Int?
   createdAt                  DateTime      @default(now())
-  workspace                  workspaces    @relation(fields: [workspace_id], references: [id], onDelete: Cascade)
+  message_limit              Int?          @default(20)
   embed_chats                embed_chats[]
   users                      users?        @relation(fields: [usersId], references: [id])
+  workspace                  workspaces    @relation(fields: [workspace_id], references: [id], onDelete: Cascade)
 }
 
 model embed_chats {
@@ -264,8 +257,8 @@ model embed_chats {
   embed_id               Int
   usersId                Int?
   createdAt              DateTime      @default(now())
-  embed_config           embed_configs @relation(fields: [embed_id], references: [id], onDelete: Cascade)
   users                  users?        @relation(fields: [usersId], references: [id])
+  embed_config           embed_configs @relation(fields: [embed_id], references: [id], onDelete: Cascade)
 }
 
 model event_logs {
@@ -283,7 +276,7 @@ model slash_command_presets {
   command       String
   prompt        String
   description   String
-  uid           Int      @default(0) // 0 is null user
+  uid           Int      @default(0)
   userId        Int?
   createdAt     DateTime @default(now())
   lastUpdatedAt DateTime @default(now())
@@ -294,13 +287,13 @@ model slash_command_presets {
 
 model document_sync_queues {
   id             Int                        @id @default(autoincrement())
-  staleAfterMs   Int                        @default(604800000) // 7 days
+  staleAfterMs   Int                        @default(604800000)
   nextSyncAt     DateTime
   createdAt      DateTime                   @default(now())
   lastSyncedAt   DateTime                   @default(now())
   workspaceDocId Int                        @unique
-  workspaceDoc   workspace_documents?       @relation(fields: [workspaceDocId], references: [id], onDelete: Cascade)
   runs           document_sync_executions[]
+  workspaceDoc   workspace_documents        @relation(fields: [workspaceDocId], references: [id], onDelete: Cascade)
 }
 
 model document_sync_executions {
@@ -340,7 +333,7 @@ model system_prompt_variables {
   key         String   @unique
   value       String?
   description String?
-  type        String   @default("system") // system, user, dynamic
+  type        String   @default("system")
   userId      Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -351,17 +344,16 @@ model system_prompt_variables {
 
 model prompt_history {
   id          Int        @id @default(autoincrement())
-  workspace   workspaces @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   workspaceId Int
   prompt      String
   modifiedBy  Int?
   modifiedAt  DateTime   @default(now())
   user        users?     @relation(fields: [modifiedBy], references: [id])
+  workspace   workspaces @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
   @@index([workspaceId])
 }
 
-// Schema specific to mobile app <> Desktop app connection
 model desktop_mobile_devices {
   id         Int      @id @default(autoincrement())
   deviceOs   String
@@ -384,9 +376,9 @@ model workspace_parsed_files {
   metadata           String?
   tokenCountEstimate Int?               @default(0)
   createdAt          DateTime           @default(now())
-  workspace          workspaces         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  user               users?             @relation(fields: [userId], references: [id], onDelete: Cascade)
   thread             workspace_threads? @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  user               users?             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  workspace          workspaces         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
   @@index([workspaceId])
   @@index([userId])

--- a/server/utils/chats/agents.js
+++ b/server/utils/chats/agents.js
@@ -12,7 +12,11 @@ async function grepAgents({
   user = null,
   thread = null,
 }) {
-  const agentHandles = WorkspaceAgentInvocation.parseAgents(message);
+  let agentHandles = WorkspaceAgentInvocation.parseAgents(message);
+  if (agentHandles.length === 0) {
+    agentHandles = ["@agent"];
+  }
+
   if (agentHandles.length > 0) {
     const { invocation: newInvocation } = await WorkspaceAgentInvocation.new({
       prompt: message,

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -81,7 +81,10 @@ async function chatSync({
   const processedMessage = await grepAllSlashCommands(message);
   message = processedMessage;
 
-  if (EphemeralAgentHandler.isAgentInvocation({ message })) {
+  if (
+    workspace.agentic ||
+    EphemeralAgentHandler.isAgentInvocation({ message })
+  ) {
     await Telemetry.sendTelemetry("agent_chat_started");
 
     // Initialize the EphemeralAgentHandler to handle non-continuous
@@ -407,7 +410,10 @@ async function streamChat({
   const processedMessage = await grepAllSlashCommands(message);
   message = processedMessage;
 
-  if (EphemeralAgentHandler.isAgentInvocation({ message })) {
+  if (
+    workspace.agentic ||
+    EphemeralAgentHandler.isAgentInvocation({ message })
+  ) {
     await Telemetry.sendTelemetry("agent_chat_started");
 
     // Initialize the EphemeralAgentHandler to handle non-continuous


### PR DESCRIPTION
What is in this change?

This PR introduces the ability to set the Anything LLM workspace as agentic by default, so that users no longer need to type @agent every time.

Key changes include:

Defaulting the workspace to agentic mode;

Frontend adjustments for admin configuration and UI;

Backend updates to support default agentic workspace initialization and management.

Additional Information

These changes improve the user experience by reducing repetitive input and provide admins with better control over the default workspace behavior.