### PR TITLE
Fix: missing edit icon for prompts

### DIFF
--- a/frontend/src/utils/chat/index.js
+++ b/frontend/src/utils/chat/index.js
@@ -103,8 +103,11 @@ export default function handleChat(
           chatId,
           metrics,
         };
-        setLoadingResponse(false);
+
+        _chatHistory[chatIdx - 1] = { ..._chatHistory[chatIdx - 1], chatId }; // update prompt with chatID
+
         emitAssistantMessageCompleteEvent(chatId);
+        setLoadingResponse(false);
       } else {
         updatedHistory = {
           ...existingHistory,
@@ -136,15 +139,6 @@ export default function handleChat(
     setChatHistory([..._chatHistory]);
   } else if (type === "agentInitWebsocketConnection") {
     setWebsocket(chatResult.websocketUUID);
-  } else if (type === "finalizeResponseStream") {
-    const chatIdx = _chatHistory.findIndex((chat) => chat.uuid === uuid);
-    if (chatIdx !== -1) {
-      _chatHistory[chatIdx - 1] = { ..._chatHistory[chatIdx - 1], chatId }; // update prompt with chatID
-      _chatHistory[chatIdx] = { ..._chatHistory[chatIdx], chatId }; // update response with chatID
-    }
-
-    setChatHistory([..._chatHistory]);
-    setLoadingResponse(false);
   } else if (type === "stopGeneration") {
     const chatIdx = _chatHistory.length - 1;
     const existingHistory = { ..._chatHistory[chatIdx] };


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->
resolves #4332

### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->
Assignment of chatIds was done in an unreachable branch (due to redundant conditional check). This was moved to the first finalizeResponseStream handler check.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->
The edit icon for prompts will be hidden until the assignment of the chatId (ie when the response stream finishes) ensuring editing is only possible when a chat has a valid chatId. 

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
