### PR TITLE
Add support for `SIMPLE_SSO_NO_LOGIN_REDIRECT` config setting

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -354,6 +354,7 @@ GID='1000'
 # See https://docs.anythingllm.com/configuration#simple-sso-passthrough for more information.
 # SIMPLE_SSO_ENABLED=1
 # SIMPLE_SSO_NO_LOGIN=1
+# SIMPLE_SSO_NO_LOGIN_REDIRECT=https://your-custom-login-url.com (optional)
 
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.

--- a/frontend/src/hooks/useSimpleSSO.js
+++ b/frontend/src/hooks/useSimpleSSO.js
@@ -3,13 +3,14 @@ import System from "@/models/system";
 
 /**
  * Checks if Simple SSO is enabled and if the user should be redirected to the SSO login page.
- * @returns {{loading: boolean, ssoConfig: {enabled: boolean, noLogin: boolean}}}
+ * @returns {{loading: boolean, ssoConfig: {enabled: boolean, noLogin: boolean, noLoginRedirect: string | null}}}
  */
 export default function useSimpleSSO() {
   const [loading, setLoading] = useState(true);
   const [ssoConfig, setSsoConfig] = useState({
     enabled: false,
     noLogin: false,
+    noLoginRedirect: null,
   });
 
   useEffect(() => {
@@ -19,6 +20,7 @@ export default function useSimpleSSO() {
         setSsoConfig({
           enabled: settings?.SimpleSSOEnabled,
           noLogin: settings?.SimpleSSONoLogin,
+          noLoginRedirect: settings?.SimpleSSONoLoginRedirect,
         });
       } catch (e) {
         console.error(e);

--- a/frontend/src/pages/Login/SSO/simple.jsx
+++ b/frontend/src/pages/Login/SSO/simple.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { FullScreenLoader } from "@/components/Preloader";
+import { Link } from "react-router-dom";
 import paths from "@/utils/paths";
 import useQuery from "@/hooks/useQuery";
 import System from "@/models/system";
@@ -8,44 +9,76 @@ import { AUTH_TIMESTAMP, AUTH_TOKEN, AUTH_USER } from "@/utils/constants";
 export default function SimpleSSOPassthrough() {
   const query = useQuery();
   const redirectPath = query.get("redirectTo") || paths.home();
+  const noLoginRedirect = query.get("nlr") || null;
   const [ready, setReady] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    try {
-      if (!query.get("token")) throw new Error("No token provided.");
+    async function validateSimpleSSOLoginToken() {
+      try {
+        if (!query.get("token")) {
+          if (!!noLoginRedirect) {
+            debugger;
+            // If a noLoginRedirect is provided, redirect to that webpage when no token is provided.
+            return window.location.replace(noLoginRedirect);
+          } else {
+            // Otherwise, show no token error
+            throw new Error("No token provided.");
+          }
+        }
 
-      // Clear any existing auth data
-      window.localStorage.removeItem(AUTH_USER);
-      window.localStorage.removeItem(AUTH_TOKEN);
-      window.localStorage.removeItem(AUTH_TIMESTAMP);
+        // Clear any existing auth data
+        window.localStorage.removeItem(AUTH_USER);
+        window.localStorage.removeItem(AUTH_TOKEN);
+        window.localStorage.removeItem(AUTH_TIMESTAMP);
 
-      System.simpleSSOLogin(query.get("token"))
-        .then((res) => {
-          if (!res.valid) throw new Error(res.message);
+        // Validate the token since it's provided. If the token is invalid, show an error
+        System.simpleSSOLogin(query.get("token"))
+          .then((res) => {
+            if (!res.valid) throw new Error(res.message);
 
-          window.localStorage.setItem(AUTH_USER, JSON.stringify(res.user));
-          window.localStorage.setItem(AUTH_TOKEN, res.token);
-          window.localStorage.setItem(AUTH_TIMESTAMP, Number(new Date()));
-          setReady(res.valid);
-        })
-        .catch((e) => {
-          setError(e.message);
-        });
-    } catch (e) {
-      setError(e.message);
+            window.localStorage.setItem(AUTH_USER, JSON.stringify(res.user));
+            window.localStorage.setItem(AUTH_TOKEN, res.token);
+            window.localStorage.setItem(AUTH_TIMESTAMP, Number(new Date()));
+            setReady(res.valid);
+          })
+          .catch((e) => {
+            setError(e.message);
+          });
+      } catch (e) {
+        setError(e.message);
+      }
     }
+    validateSimpleSSOLoginToken();
   }, []);
 
-  if (error)
+  if (error) {
+    if (!!noLoginRedirect)
+      setTimeout(() => {
+        window.location.replace(noLoginRedirect);
+      }, 8_000);
     return (
       <div className="w-screen h-screen overflow-hidden bg-theme-bg-primary flex items-center justify-center flex-col gap-4">
         <p className="text-theme-text-primary font-mono text-lg">{error}</p>
         <p className="text-theme-text-secondary font-mono text-sm">
           Please contact the system administrator about this error.
         </p>
+        {!!noLoginRedirect && (
+          <p className="text-theme-text-secondary font-mono text-sm">
+            You will be redirected to{" "}
+            <Link
+              className="text-theme-text-primary font-mono text-sm hover:underline"
+              to={noLoginRedirect}
+            >
+              {noLoginRedirect}
+            </Link>{" "}
+            shortly...
+          </p>
+        )}
       </div>
     );
+  }
+
   if (ready) return window.location.replace(redirectPath);
 
   // Loading state by default

--- a/frontend/src/pages/Login/index.jsx
+++ b/frontend/src/pages/Login/index.jsx
@@ -21,7 +21,7 @@ export default function Login() {
 
   if (loading || ssoLoading) return <FullScreenLoader />;
   if (ssoConfig.enabled && ssoConfig.noLogin)
-    return <Navigate to={paths.sso.login()} />;
+    return <Navigate to={paths.sso.login(ssoConfig.noLoginRedirect)} />;
   if (requiresAuth === false) return <Navigate to={paths.home()} />;
 
   return <PasswordModal mode={mode} />;

--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -19,8 +19,10 @@ export default {
     return `/login${noTry ? "?nt=1" : ""}`;
   },
   sso: {
-    login: () => {
-      return "/sso/simple";
+    login: (noLoginRedirect = null) => {
+      return applyOptions(`/sso/simple`, {
+        search: noLoginRedirect ? `nlr=${noLoginRedirect}` : "",
+      });
     },
   },
   onboarding: {

--- a/server/.env.example
+++ b/server/.env.example
@@ -352,6 +352,7 @@ TTS_PROVIDER="native"
 # See https://docs.anythingllm.com/configuration#simple-sso-passthrough for more information.
 # SIMPLE_SSO_ENABLED=1
 # SIMPLE_SSO_NO_LOGIN=1
+# SIMPLE_SSO_NO_LOGIN_REDIRECT=https://your-custom-login-url.com (optional)
 
 # Allow scraping of any IP address in collector - must be string "true" to be enabled
 # See https://docs.anythingllm.com/configuration#local-ip-address-scraping for more information.

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -297,6 +297,7 @@ const SystemSettings = {
       // --------------------------------------------------------
       SimpleSSOEnabled: "SIMPLE_SSO_ENABLED" in process.env || false,
       SimpleSSONoLogin: "SIMPLE_SSO_NO_LOGIN" in process.env || false,
+      SimpleSSONoLoginRedirect: this.simpleSSO.noLoginRedirect(),
     };
   },
 
@@ -653,6 +654,29 @@ const SystemSettings = {
       console.error(error.message);
       return { connectionKey: null };
     }
+  },
+
+  simpleSSO: {
+    /**
+     * Gets the no login redirect URL. If the conditions below are not met, this will return null.
+     * - If simple SSO is not enabled.
+     * - If simple SSO login page is not disabled.
+     * - If the no login redirect is not a valid URL or is not set.
+     * @returns {string | null}
+     */
+    noLoginRedirect: () => {
+      if (!("SIMPLE_SSO_ENABLED" in process.env)) return null; // if simple SSO is not enabled, return null
+      if (!("SIMPLE_SSO_NO_LOGIN" in process.env)) return null; // if the no login config is not set, return null
+      if (!("SIMPLE_SSO_NO_LOGIN_REDIRECT" in process.env)) return null; // if the no login redirect is not set, return null
+
+      try {
+        let url = new URL(process.env.SIMPLE_SSO_NO_LOGIN_REDIRECT);
+        return url.toString();
+      } catch {}
+
+      // if the no login redirect is not a valid URL or is not set, return null
+      return null;
+    },
   },
 };
 

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1152,6 +1152,7 @@ function dumpENV() {
     // Simple SSO
     "SIMPLE_SSO_ENABLED",
     "SIMPLE_SSO_NO_LOGIN",
+    "SIMPLE_SSO_NO_LOGIN_REDIRECT",
     // Community Hub
     "COMMUNITY_HUB_BUNDLE_DOWNLOADS_ENABLED",
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4277
closes #4283


### What is in this change?
- Allow user to set `SIMPLE_SSO_NO_LOGIN_REDIRECT` which will redirect users to a defined URL, typically a login page for SIMPLE_SSO to provision a token.
- This allows the user to not be stuck on the AnythingLLM instance homepage with an "Invalid token" error.
- This does not impact the error rendering pages and will only fire when visting the `/` URL while unauthenticated.

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
