### PR TITLE
patch folder name GET request response

### DIFF
--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -693,13 +693,11 @@ function apiDocumentEndpoints(app) {
       try {
         const { folderName } = request.params;
         const result = await getDocumentsByFolder(folderName);
-        response
-          .status(result.code)
-          .json({
-            folder: result.folder,
-            documents: result.documents,
-            error: result.error,
-          });
+        response.status(result.code).json({
+          folder: result.folder,
+          documents: result.documents,
+          error: result.error,
+        });
       } catch (e) {
         console.error(e.message, e);
         response.sendStatus(500).end();

--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -693,7 +693,13 @@ function apiDocumentEndpoints(app) {
       try {
         const { folderName } = request.params;
         const result = await getDocumentsByFolder(folderName);
-        response.status(200).json(result);
+        response
+          .status(result.code)
+          .json({
+            folder: result.folder,
+            documents: result.documents,
+            error: result.error,
+          });
       } catch (e) {
         console.error(e.message, e);
         response.sendStatus(500).end();

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -1287,7 +1287,6 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
@@ -1315,7 +1314,8 @@
                   }
                 }
               }
-            }
+            },
+            "description": "OK"
           },
           "403": {
             "description": "Forbidden",

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -95,15 +95,34 @@ async function viewLocalFiles() {
   return directory;
 }
 
+/**
+ * Gets the documents by folder name.
+ * @param {string} folderName - The name of the folder to get the documents from.
+ * @returns {Promise<{folder: string, documents: any[], code: number, error: string}>} - The documents by folder name.
+ */
 async function getDocumentsByFolder(folderName = "") {
-  if (!folderName) throw new Error("Folder name must be provided.");
+  if (!folderName) {
+    return {
+      folder: "custom-documents",
+      documents: [],
+      code: 400,
+      error: "Folder name must be provided.",
+    };
+  }
+
   const folderPath = path.resolve(documentsPath, normalizePath(folderName));
   if (
     !isWithin(documentsPath, folderPath) ||
     !fs.existsSync(folderPath) ||
     !fs.lstatSync(folderPath).isDirectory()
-  )
-    throw new Error(`Folder "${folderName}" does not exist.`);
+  ) {
+    return {
+      folder: "custom-documents",
+      documents: [],
+      code: 404,
+      error: `Folder "${folderName}" does not exist.`,
+    };
+  }
 
   const documents = [];
   const filenames = {};
@@ -136,7 +155,7 @@ async function getDocumentsByFolder(folderName = "") {
     );
   }
 
-  return { folder: folderName, documents };
+  return { folder: folderName, documents, code: 200, error: null };
 }
 
 /**

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -103,7 +103,7 @@ async function viewLocalFiles() {
 async function getDocumentsByFolder(folderName = "") {
   if (!folderName) {
     return {
-      folder: "custom-documents",
+      folder: folderName,
       documents: [],
       code: 400,
       error: "Folder name must be provided.",
@@ -117,7 +117,7 @@ async function getDocumentsByFolder(folderName = "") {
     !fs.lstatSync(folderPath).isDirectory()
   ) {
     return {
-      folder: "custom-documents",
+      folder: folderName,
       documents: [],
       code: 404,
       error: `Folder "${folderName}" does not exist.`,


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4334


### What is in this change?
- Fixes the response of the `/v1/documents/folder/:folderName` endpoint so that `getDocumentsByFolder` does not throw a generic error `500` for the cases when the folder does not exist or not passed in.

- This also refactors `getDocumentsByFolder` to return an object with properties to return the proper response + valid status code and error message

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
