### PR TITLE
Allow user to specify args for chromium process so they dont need SYS_ADMIN on container.

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: ['upload-ui-ux'] # put your current branch to create a build. Core team only.
+    branches: ['3999-chromium-flags'] # put your current branch to create a build. Core team only.
     paths-ignore:
       - '**.md'
       - 'cloud-deployments/*'

--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -24,10 +24,6 @@ async function scrapeGenericUrl({
   scraperHeaders = {},
   metadata = {},
 }) {
-  const runtimeSettings = new RuntimeSettings();
-  const launchArgs = runtimeSettings.get("browserLaunchArgs");
-  console.log("launchArgs", launchArgs);
-
   console.log(`-- Working URL ${link} => (${captureAs}) --`);
   const content = await getPageContent({
     link,
@@ -110,11 +106,16 @@ function validatedHeaders(headers = {}) {
  */
 async function getPageContent({ link, captureAs = "text", headers = {} }) {
   try {
+    const runtimeSettings = new RuntimeSettings();
+    const launchArgs = runtimeSettings.get("browserLaunchArgs");
+    console.log("launchArgs", launchArgs);
+
     let pageContents = [];
     const loader = new PuppeteerWebBaseLoader(link, {
       launchOptions: {
         headless: "new",
         ignoreHTTPSErrors: true,
+        args: launchArgs,
       },
       gotoOptions: {
         waitUntil: "networkidle2",

--- a/collector/processLink/convert/generic.js
+++ b/collector/processLink/convert/generic.js
@@ -5,6 +5,7 @@ const {
 const { writeToServerDocuments } = require("../../utils/files");
 const { tokenizeString } = require("../../utils/tokenizer");
 const { default: slugify } = require("slugify");
+const RuntimeSettings = require("../../utils/runtimeSettings");
 
 /**
  * Scrape a generic URL and return the content in the specified format
@@ -23,6 +24,10 @@ async function scrapeGenericUrl({
   scraperHeaders = {},
   metadata = {},
 }) {
+  const runtimeSettings = new RuntimeSettings();
+  const launchArgs = runtimeSettings.get("browserLaunchArgs");
+  console.log("launchArgs", launchArgs);
+
   console.log(`-- Working URL ${link} => (${captureAs}) --`);
   const content = await getPageContent({
     link,

--- a/collector/utils/runtimeSettings/index.js
+++ b/collector/utils/runtimeSettings/index.js
@@ -27,6 +27,16 @@ class RuntimeSettings {
       // Value must be explicitly "true" or "false" as a string
       validate: (value) => String(value) === "true",
     },
+    browserLaunchArgs: {
+      default: [],
+      validate: (value) => {
+        let args = [];
+        if (Array.isArray(value)) args = value.map((arg) => String(arg.trim()));
+        if (typeof value === "string")
+          args = value.split(",").map((arg) => arg.trim());
+        return args;
+      },
+    },
   };
 
   constructor() {

--- a/server/utils/collectorApi/index.js
+++ b/server/utils/collectorApi/index.js
@@ -38,6 +38,7 @@ class CollectorApi {
       },
       runtimeSettings: {
         allowAnyIp: process.env.COLLECTOR_ALLOW_ANY_IP ?? "false",
+        browserLaunchArgs: process.env.ANYTHINGLLM_CHROMIUM_ARGS ?? [],
       },
     };
   }

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1167,6 +1167,9 @@ function dumpENV() {
 
     // Allow disabling of streaming for generic openai
     "GENERIC_OPENAI_STREAMING_DISABLED",
+
+    // Specify Chromium args for collector
+    "ANYTHINGLLM_CHROMIUM_ARGS",
   ];
 
   // Simple sanitization of each value to prevent ENV injection via newline or quote escaping.


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3999 


### What is in this change?
- Adds support for configurable `ANYTHINGLLM_CHROMIUM_ARGS` in ENV to allow the user to pass flags directly to the Puppeteer browser process that runs in a container.

This should allow the user to no longer need the `SYS_ADMIN` flag _if they want to omit that and use args_ like `--no-sandbox` and `--disable-setuid-sandbox`

<!-- Describe the changes in this PR that are impactful to the repo. -->

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
