### PR TITLE
Change incorrect notation of Weaviate to PG Vector in env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -228,7 +228,7 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # Enable all below if you are using vector database: LanceDB.
 VECTOR_DB="lancedb"
 
-# Enable all below if you are using vector database: Weaviate.
+# Enable all below if you are using vector database: PG Vector.
 # VECTOR_DB="pgvector"
 # PGVECTOR_CONNECTION_STRING="postgresql://dbuser:dbuserpass@localhost:5432/yourdb"
 # PGVECTOR_TABLE_NAME="anythingllm_vectors" # optional, but can be defined


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4437 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

This PR corrects a notation error in `/server/env.example`, clarifying that the listed environment variables are for PG Vector, not Weaviate.


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
