### PR TITLE
Validation of PG Vector Connection on Message Sent

### DIFF
--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -66,7 +66,7 @@ async function streamChatWithWorkspace(
         type: "textResponse",
         sources: [],
         close: true,
-        error: `Postgres::${heartbeat.error}. Failed to connect to the PostgreSQL database. Please verify your connection string and confirm the database server is running.`,
+        error: `Postgres::${heartbeat.error}. Failed to connect to the PostgreSQL database. Please verify that your connection string is correct and confirm the database server is running.`,
       });
       vectorDatabaseIsAlive = false;
     }

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -59,7 +59,6 @@ async function streamChatWithWorkspace(
   let vectorDatabaseIsAlive = true;
   // If the vector database is PostgreSQL, we need to check if it is alive. The reason for this explicit heartbeat check is because Postgres will hang on connection if the database is not running without any error.
   if (VectorDb.name === "PGVector") {
-    console.log("Checking if PostgreSQL is alive...");
     const heartbeat = await VectorDb.heartbeat();
     if (heartbeat.error) {
       writeResponseChunk(response, {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4431 


### What is in this change?


<!-- Describe the changes in this PR that are impactful to the repo. -->

This PR introduces an explicit heartbeat check when PGVector is selected as the user’s vector database. The check runs whenever a chat message is sent. If the heartbeat takes longer than 3 seconds, it triggers a timeout and returns a clear chat error to the user, indicating a PostgreSQL connection issue.

This check is non-blocking, once the error is returned, the process continues with the rest of the streaming workflow, allowing the LLM to respond to the prompt while skipping the similarity search step.


## Previous Behavior

The connection to Postgres would timeout after a couple minutes with no indication of this connection problem to the user. LLM responds at 2:35.

https://github.com/user-attachments/assets/4b5bb956-e554-42c3-ada7-1d21de425a75


## Current Behavior

The connection times out after 3 seconds, sending a chat error to the user notifying them of the connection issue and then proceeding with the LLM response.

https://github.com/user-attachments/assets/30437c4c-8319-49ac-9ff0-28520b7d1465

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
