### PR TITLE
Adding AnythingLLM Helm Chart

### DIFF
--- a/cloud-deployments/helm/charts/anythingllm/.helmignore
+++ b/cloud-deployments/helm/charts/anythingllm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/cloud-deployments/helm/charts/anythingllm/Chart.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: anythingllm
+description: The all-in-one Desktop & Docker AI application with built-in RAG, AI agents, No-code agent builder, MCP compatibility, and more.
+type: application
+version: 1.0.0
+appVersion: "1.85.0"
+icon: https://raw.githubusercontent.com/Mintplex-Labs/anything-llm/refs/heads/master/frontend/public/favicon.png

--- a/cloud-deployments/helm/charts/anythingllm/README.md
+++ b/cloud-deployments/helm/charts/anythingllm/README.md
@@ -1,0 +1,149 @@
+# anythingllm
+
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.85.0](https://img.shields.io/badge/AppVersion-1.85.0-informational?style=flat-square)
+
+![AnythingLLM](https://raw.githubusercontent.com/Mintplex-Labs/anything-llm/master/images/wordmark.png)
+
+[AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)
+
+The all-in-one Desktop & Docker AI application with built-in RAG, AI agents, No-code agent builder, MCP compatibility, and more.
+
+**Configuration & Usage**
+
+- **Config vs Secrets:** This chart exposes application configuration via two mechanisms:
+  - `config` (in `values.yaml`) — rendered into a `ConfigMap` and injected using `envFrom` in the pod. Do NOT place sensitive values (API keys, secrets) in `config` because `ConfigMap`s are not encrypted.
+  - `env` / `envFrom` — the preferred way to inject secrets. Use Kubernetes `Secret` objects and reference them from `env` (with `valueFrom.secretKeyRef`) or `envFrom.secretRef`.
+
+- **Storage & STORAGE_DIR mapping:** The chart creates (or mounts) a `PersistentVolumeClaim` using the `persistentVolume.*` settings. The container mount path is set from `persistentVolume.mountPath`. Ensure the container `STORAGE_DIR` config key matches that path (defaults are set in `values.yaml`).
+
+**Providing API keys & secrets (recommended)**
+
+Use Kubernetes Secrets. Below are example workflows and `values.yaml` snippets.
+
+1) Create a Kubernetes Secret with API keys:
+
+```
+kubectl create secret generic openai-secret --from-literal=OPENAI_KEY="sk-..."
+# or from a file
+# kubectl create secret generic openai-secret --from-file=OPENAI_KEY=/path/to/keyfile
+```
+
+2) Reference the Secret from `values.yaml` using `envFrom` (recommended when your secret contains multiple env keys):
+
+```yaml
+envFrom:
+  - secretRef:
+      name: openai-secret
+```
+
+This will inject all key/value pairs from the `openai-secret` Secret as environment variables in the container.
+
+3) Or reference a single secret key via `env` (explicit mapping):
+
+```yaml
+env:
+  - name: OPENAI_KEY
+    valueFrom:
+      secretKeyRef:
+        name: openai-secret
+        key: OPENAI_KEY
+```
+
+Notes:
+- Avoid placing secret values into `config:` (the chart's `ConfigMap`) — `ConfigMap`s are visible to anyone who can read the namespace. Use `Secret` objects for any credentials/tokens.
+- If you use a GitOps workflow, consider integrating an external secret operator (ExternalSecrets, SealedSecrets, etc.) so you don't store raw secrets in Git.
+
+**Example `values-secret.yaml` to pass during `helm install`**
+
+```yaml
+image:
+  repository: mintplexlabs/anythingllm
+  tag: "1.8.5"
+
+service:
+  type: ClusterIP
+  port: 3001
+
+# Reference secret containing API keys
+envFrom:
+  - secretRef:
+      name: openai-secret
+
+# Optionally override other values
+persistentVolume:
+  size: 16Gi
+  mountPath: /storage
+```
+
+Install with:
+
+```
+helm install my-anythingllm ./anythingllm -f values-secret.yaml
+```
+
+**Best practices & tips**
+
+- Use `envFrom` for convenience when many environment variables are stored in a single `Secret` and use `env`/`valueFrom` for explicit single-key mappings.
+- Use `kubectl create secret generic` or your secrets management solution. If you need to reference multiple different provider keys (OpenAI, Anthropic, etc.), create a single `Secret` with multiple keys or multiple Secrets and add multiple `envFrom` entries.
+- Keep probe paths and `service.port` aligned. If your probes fail after deployment, check that the probe `port` matches the container port (or named port `http`) and that the `path` is valid.
+- For storage, if you have a pre-existing PVC set `persistentVolume.existingClaim` to the PVC name; the chart will mount that claim (and will not attempt to create a new PVC).
+- For production, provide resource `requests` and `limits` in `values.yaml` to prevent scheduler starvation and to control cost.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| config.DISABLE_TELEMETRY | string | `"true"` |  |
+| config.GID | string | `"1000"` |  |
+| config.NODE_ENV | string | `"production"` |  |
+| config.STORAGE_DIR | string | `"/storage"` |  |
+| config.UID | string | `"1000"` |  |
+| env | object | `{}` |  |
+| envFrom | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"mintplexlabs/anythingllm"` |  |
+| image.tag | string | `"1.8.5"` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| initContainers | list | `[]` |  |
+| livenessProbe.failureThreshold | int | `3` |  |
+| livenessProbe.httpGet.path | string | `"/v1/api/health"` |  |
+| livenessProbe.httpGet.port | int | `8888` |  |
+| livenessProbe.initialDelaySeconds | int | `15` |  |
+| livenessProbe.periodSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| persistentVolume.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| persistentVolume.annotations | object | `{}` |  |
+| persistentVolume.existingClaim | string | `""` |  |
+| persistentVolume.labels | object | `{}` |  |
+| persistentVolume.mountPath | string | `"/storage"` |  |
+| persistentVolume.size | string | `"8Gi"` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `1000` |  |
+| readinessProbe.httpGet.path | string | `"/v1/api/health"` |  |
+| readinessProbe.httpGet.port | int | `8888` |  |
+| readinessProbe.initialDelaySeconds | int | `15` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `2` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| service.port | int | `3001` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |

--- a/cloud-deployments/helm/charts/anythingllm/README.md.gotmpl
+++ b/cloud-deployments/helm/charts/anythingllm/README.md.gotmpl
@@ -1,0 +1,103 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+![AnythingLLM](https://raw.githubusercontent.com/Mintplex-Labs/anything-llm/master/images/wordmark.png)
+
+[AnythingLLM](https://github.com/Mintplex-Labs/anything-llm)
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+**Configuration & Usage**
+
+- **Config vs Secrets:** This chart exposes application configuration via two mechanisms:
+  - `config` (in `values.yaml`) — rendered into a `ConfigMap` and injected using `envFrom` in the pod. Do NOT place sensitive values (API keys, secrets) in `config` because `ConfigMap`s are not encrypted.
+  - `env` / `envFrom` — the preferred way to inject secrets. Use Kubernetes `Secret` objects and reference them from `env` (with `valueFrom.secretKeyRef`) or `envFrom.secretRef`.
+
+- **Storage & STORAGE_DIR mapping:** The chart creates (or mounts) a `PersistentVolumeClaim` using the `persistentVolume.*` settings. The container mount path is set from `persistentVolume.mountPath`. Ensure the container `STORAGE_DIR` config key matches that path (defaults are set in `values.yaml`).
+
+
+**Providing API keys & secrets (recommended)**
+
+Use Kubernetes Secrets. Below are example workflows and `values.yaml` snippets.
+
+1) Create a Kubernetes Secret with API keys:
+
+```
+kubectl create secret generic openai-secret --from-literal=OPENAI_KEY="sk-..." 
+# or from a file
+# kubectl create secret generic openai-secret --from-file=OPENAI_KEY=/path/to/keyfile
+```
+
+2) Reference the Secret from `values.yaml` using `envFrom` (recommended when your secret contains multiple env keys):
+
+```yaml
+envFrom:
+  - secretRef:
+      name: openai-secret
+```
+
+This will inject all key/value pairs from the `openai-secret` Secret as environment variables in the container.
+
+3) Or reference a single secret key via `env` (explicit mapping):
+
+```yaml
+env:
+  - name: OPENAI_KEY
+    valueFrom:
+      secretKeyRef:
+        name: openai-secret
+        key: OPENAI_KEY
+```
+
+Notes:
+- Avoid placing secret values into `config:` (the chart's `ConfigMap`) — `ConfigMap`s are visible to anyone who can read the namespace. Use `Secret` objects for any credentials/tokens.
+- If you use a GitOps workflow, consider integrating an external secret operator (ExternalSecrets, SealedSecrets, etc.) so you don't store raw secrets in Git.
+
+
+**Example `values-secret.yaml` to pass during `helm install`**
+
+```yaml
+image:
+  repository: mintplexlabs/anythingllm
+  tag: "1.8.5"
+
+service:
+  type: ClusterIP
+  port: 3001
+
+# Reference secret containing API keys
+envFrom:
+  - secretRef:
+      name: openai-secret
+
+# Optionally override other values
+persistentVolume:
+  size: 16Gi
+  mountPath: /storage
+```
+
+Install with:
+
+```
+helm install my-anythingllm ./anythingllm -f values-secret.yaml
+```
+
+**Best practices & tips**
+
+- Use `envFrom` for convenience when many environment variables are stored in a single `Secret` and use `env`/`valueFrom` for explicit single-key mappings.
+- Use `kubectl create secret generic` or your secrets management solution. If you need to reference multiple different provider keys (OpenAI, Anthropic, etc.), create a single `Secret` with multiple keys or multiple Secrets and add multiple `envFrom` entries.
+- Keep probe paths and `service.port` aligned. If your probes fail after deployment, check that the probe `port` matches the container port (or named port `http`) and that the `path` is valid.
+- For storage, if you have a pre-existing PVC set `persistentVolume.existingClaim` to the PVC name; the chart will mount that claim (and will not attempt to create a new PVC).
+- For production, provide resource `requests` and `limits` in `values.yaml` to prevent scheduler starvation and to control cost.
+
+{{ template "chart.valuesSection" . }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/NOTES.txt
+++ b/cloud-deployments/helm/charts/anythingllm/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Get the application URL by running these commands:
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "anythingllm.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "anythingllm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "anythingllm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "anythingllm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "To access locally, run:"
+  echo "  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT"
+  echo "Then visit http://127.0.0.1:8080"
+
+{{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/_helpers.tpl
+++ b/cloud-deployments/helm/charts/anythingllm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "anythingllm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "anythingllm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "anythingllm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "anythingllm.labels" -}}
+helm.sh/chart: {{ include "anythingllm.chart" . }}
+{{ include "anythingllm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "anythingllm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "anythingllm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "anythingllm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "anythingllm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/configmap.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+  name: {{ include "anythingllm.fullname" . }}-config
+data:
+{{- range $key, $value := .Values.config }}
+  {{ $key }}: "{{ $value }}"
+{{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/deployment.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "anythingllm.fullname" . }}
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "anythingllm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "anythingllm.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "anythingllm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.strategy }}
+      strategy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "anythingllm.fullname" . }}-config
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: {{ .Values.persistentVolume.mountPath }}
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ include "anythingllm.fullname" . }}-storage-claim
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/extra-objects.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/ingress.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "anythingllm.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/pvc.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/pvc.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{- if .Values.persistentVolume.annotations }}
+  annotations:
+{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+    {{- with .Values.persistentVolume.labels }}
+       {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "anythingllm.fullname" . }}-storage-claim
+spec:
+  accessModes:
+    {{- toYaml .Values.persistentVolume.accessModes | nindent 4 }}
+{{- if .Values.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolume.size }}
+{{- if .Values.persistentVolume.volumeName }}
+  volumeName: "{{ .Values.persistentVolume.volumeName }}"
+{{- end -}}
+  {{- with .Values.persistentVolume.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/service.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "anythingllm.fullname" . }}
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "anythingllm.selectorLabels" . | nindent 4 }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/serviceaccount.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "anythingllm.serviceAccountName" . }}
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/cloud-deployments/helm/charts/anythingllm/templates/tests/test-connection.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "anythingllm.fullname" . }}-test-connection"
+  labels:
+    {{- include "anythingllm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: healthcheck
+      image: curlimages/curl:8.1.2
+      command: ["sh", "-c"]
+      args:
+        - "curl -fsS -o /dev/null http://{{ include "anythingllm.fullname" . }}:{{ .Values.service.port }}|| exit 1"
+  restartPolicy: Never

--- a/cloud-deployments/helm/charts/anythingllm/values.yaml
+++ b/cloud-deployments/helm/charts/anythingllm/values.yaml
@@ -1,0 +1,231 @@
+replicaCount: 1
+
+initContainers: []
+  # - name: init-myservice
+  #   image: busybox
+  #   command: ['sh', '-c', 'chown -R 1000:1000 /storage']
+
+image:
+  repository: mintplexlabs/anythingllm
+  pullPolicy: IfNotPresent
+  tag: "1.8.5"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+persistentVolume:
+  # AnythingLLM storage data Persistent Volume access modes
+  # Must match those of existing PV or dynamic provisioner
+  # Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  #
+  accessModes:
+    - ReadWriteOnce
+
+  # AnythingLLM storage data Persistent Volume labels
+  #
+  labels: {}
+
+  # AnythingLLM storage data Persistent Volume annotations
+  #
+  annotations: {}
+
+  # AnythingLLM storage data Persistent Volume  existing claim name
+  # If defined, PVC must be created manually before volume will be bound
+  #
+  existingClaim: ""
+
+  # AnythingLLM storage data Persistent Volume size
+  #
+  size: 8Gi
+
+  # AnythingLLM storage data Persistent Volume mount path
+  # Must match the STORAGE_DIR config value
+  #
+  mountPath: /app/server/storage
+
+  # AnythingLLM storage data Persistent Volume Storage Class
+  # If defined, storageClassName: <storageClass>
+  # If set to "-", storageClassName: "", which disables dynamic provisioning
+  # If undefined (the default) or set to null, no storageClassName spec is
+  #   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  #   GKE, AWS & OpenStack)
+  #
+  storageClass: ""
+
+  # AnythingLLM storage data Persistent Volume Claim Selector
+  # Useful if Persistent Volumes have been provisioned in advance
+  # Ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
+  #
+  selector: {}
+  # selector:
+  #  matchLabels:
+  #    release: "stable"
+  #  matchExpressions:
+  #    - { key: environment, operator: In, values: [ dev ] }
+  
+  # AnythingLLM storage data Persistent Volume Name
+  # Useful if Persistent Volumes have been provisioned in advance and you want to use a specific one
+  #
+  volumeName: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# The Anything LLM application  deployment strategy
+# This is set to "Recreate" by default as AnythingLLM support is not yet
+# production ready.  Once it is, this can be changed to "RollingUpdate"
+# Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+#
+strategy:
+  # Type of deployment. Can be "Recreate" or "RollingUpdate". Default is "Recreate"
+  type: Recreate
+  # If type is "RollingUpdate", the following values can be set:
+  # rollingUpdate:
+  #   maxUnavailable: 1
+  #   maxSurge: 1
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  # fsGroup needs to be set as the same as the uid/gid used to run the application
+  # in order to have the right permissions on mounted volumes
+  fsGroup: 1000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# AnythingLLM configuration options, these are stored in a ConfigMap and passed
+# to the container as environment variables.
+# See https://github.com/Mintplex-Labs/anything-llm/blob/render/docker/.env.example
+# for all available environment variables to use as configuration options
+#
+config:
+  DISABLE_TELEMETRY: "true"
+  NODE_ENV: production
+  STORAGE_DIR: /app/server/storage
+  UID: "1000"
+  GID: "1000"
+
+# The preferred method for setting secret environment variables
+# Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret
+#
+env: {}
+# - name: OPEN_AI_KEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: openai-secret
+#       key: openai_key
+
+# Typically used to reference a pre existing Secret containing multiple environment variables
+# Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-a-container-environment-variable-with-data-from-a-single-secret
+#
+envFrom: {}
+  # - secretRef:
+  #     name: mysecret
+
+service:
+  type: ClusterIP
+  port: 3001
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+readinessProbe:
+  httpGet:
+    path: /v1/api/health
+    port: 8888
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  successThreshold: 2
+livenessProbe:
+  httpGet:
+    path: /v1/api/health
+    port: 8888
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  failureThreshold: 3
+
+# Additional volumes on the output Deployment definition.
+#
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+#
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+## Array of extra manifests/obhects to create
+#
+extraObjects: []
+# - apiVersion: external-secrets.io/v1beta1
+#   kind: ExternalSecret
+#   metadata:
+#     name: open-ai-api-key-external-secret
+#     namespace: default
+#   spec:
+#     refreshInterval: 1h
+#     secretStoreRef:
+#       name: vault
+#       kind: ClusterSecretStore
+#     target:
+#       name: open-ai-api-key-secret
+#       template:
+#         type: Opaque
+#     data:
+#       - secretKey: open_ai_key
+#         remoteRef:
+#           key: secret/data/anything-llm
+#           property: open_ai_key
+


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

N/A

### What is in this change?

This pull request introduces an official Helm chart for deploying AnythingLLM on Kubernetes. It provides all the necessary templates and documentation for a production-ready deployment, including configuration guidance, secret management, persistent storage, and service exposure. The chart is designed for flexibility, security, and ease of use, enabling users to deploy AnythingLLM with best practices for Kubernetes environments.

**Documentation and usability enhancements:**

* Included a comprehensive `README.md` with usage instructions, a configuration values table, and deployment tips.


### Additional Information

Ideally, a Helm Repository should be set up in this repository so users can install the Helm chart using standard tooling without needing to download and run it locally. This requires some additional changes that are not in scope for this change and would require setting up GitHub Pages. I am planning to submit a new PR with the changes necessary + details.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
