### PR TITLE
fix: Show clear message for users without workspace access

### DIFF
--- a/frontend/src/components/NoWorkspaceAccess/index.jsx
+++ b/frontend/src/components/NoWorkspaceAccess/index.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { User, EnvelopeSimple } from "@phosphor-icons/react";
+import { userFromStorage } from "@/utils/request";
+import paths from "@/utils/paths";
+
+export default function NoWorkspaceAccess() {
+  const { t } = useTranslation();
+  const user = userFromStorage();
+
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-theme-bg-container">
+      <div className="max-w-md mx-auto text-center p-8">
+        <div className="mb-6">
+          <div className="w-16 h-16 mx-auto mb-4 bg-theme-button-primary rounded-full flex items-center justify-center">
+            <User className="w-8 h-8 text-white" />
+          </div>
+          <h1 className="text-2xl font-semibold text-theme-text-primary mb-2">
+            {t("noWorkspaceAccess.title")}
+          </h1>
+          <p className="text-theme-text-secondary mb-6">
+            {t("noWorkspaceAccess.description")}
+          </p>
+        </div>
+
+        <div className="bg-theme-bg-secondary rounded-lg p-4 mb-6">
+          <p className="text-sm text-theme-text-secondary mb-3">
+            {t("noWorkspaceAccess.nextSteps")}
+          </p>
+          <div className="flex flex-col gap-2 text-sm">
+            <div className="flex items-center gap-2 text-theme-text-primary">
+              <span className="w-2 h-2 bg-theme-button-primary rounded-full"></span>
+              {t("noWorkspaceAccess.step1")}
+            </div>
+            <div className="flex items-center gap-2 text-theme-text-primary">
+              <span className="w-2 h-2 bg-theme-button-primary rounded-full"></span>
+              {t("noWorkspaceAccess.step2")}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <a
+            href={paths.mailToMintplex()}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-theme-button-primary text-white rounded-lg hover:bg-theme-button-primary-hover transition-colors"
+          >
+            <EnvelopeSimple className="w-4 h-4" />
+            {t("noWorkspaceAccess.contactSupport")}
+          </a>
+          
+          {user?.role === "default" && (
+            <p className="text-xs text-theme-text-secondary">
+              {t("noWorkspaceAccess.userRole", { username: user.username })}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useWorkspaceAccess.js
+++ b/frontend/src/hooks/useWorkspaceAccess.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+import Workspace from "@/models/workspace";
+import useUser from "@/hooks/useUser";
+
+export default function useWorkspaceAccess() {
+  const [hasAccess, setHasAccess] = useState(null);
+  const [workspaces, setWorkspaces] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const { user } = useUser();
+
+  useEffect(() => {
+    async function checkWorkspaceAccess() {
+      try {
+        setLoading(true);
+        const userWorkspaces = await Workspace.all();
+        setWorkspaces(userWorkspaces);
+        setHasAccess(userWorkspaces.length > 0);
+      } catch (error) {
+        console.error("Error checking workspace access:", error);
+        setHasAccess(false);
+        setWorkspaces([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    checkWorkspaceAccess();
+  }, [user]);
+
+  return {
+    hasAccess,
+    workspaces,
+    loading,
+  };
+}

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1127,6 +1127,16 @@ const TRANSLATIONS = {
       },
     },
   },
+
+  noWorkspaceAccess: {
+    title: "No Workspace Access",
+    description: "You are not currently added to any workspaces. Please contact your administrator or manager to be granted access.",
+    nextSteps: "What you can do:",
+    step1: "Contact your administrator or manager to request workspace access",
+    step2: "Wait for them to add you to the appropriate workspaces",
+    contactSupport: "Contact Support",
+    userRole: "You are logged in as: {{username}} (Default User)",
+  },
 };
 
 export default TRANSLATIONS;

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -3,22 +3,48 @@ import PasswordModal, { usePasswordModal } from "@/components/Modals/Password";
 import { FullScreenLoader } from "@/components/Preloader";
 import Home from "./Home";
 import DefaultChatContainer from "@/components/DefaultChat";
+import NoWorkspaceAccess from "@/components/NoWorkspaceAccess";
 import { isMobile } from "react-device-detect";
 import Sidebar, { SidebarMobileHeader } from "@/components/Sidebar";
 import { userFromStorage } from "@/utils/request";
+import useWorkspaceAccess from "@/hooks/useWorkspaceAccess";
 
 export default function Main() {
   const { loading, requiresAuth, mode } = usePasswordModal();
+  const { hasAccess, loading: workspaceLoading } = useWorkspaceAccess();
 
-  if (loading) return <FullScreenLoader />;
+  if (loading || workspaceLoading) return <FullScreenLoader />;
   if (requiresAuth !== false)
     return <>{requiresAuth !== null && <PasswordModal mode={mode} />}</>;
 
   const user = userFromStorage();
+  
+  const getMainComponent = () => {
+    if (user?.role === "admin") {
+      return <Home />;
+    }
+    
+    if (user?.role === "default") {
+      if (hasAccess === false) {
+        return <NoWorkspaceAccess />;
+      }
+      return <DefaultChatContainer />;
+    }
+    
+    if (user?.role === "manager") {
+      if (hasAccess === false) {
+        return <Home />;
+      }
+      return <DefaultChatContainer />;
+    }
+    
+    return <DefaultChatContainer />;
+  };
+
   return (
     <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
       {!isMobile ? <Sidebar /> : <SidebarMobileHeader />}
-      {!!user && user?.role !== "admin" ? <DefaultChatContainer /> : <Home />}
+      {getMainComponent()}
     </div>
   );
 }


### PR DESCRIPTION
- when default users log in but aren't added to any workspaces, they previously saw confusing onboarding text. 
- This PR adds a dedicated component that clearly explains they need workspace access and provides guidance on contacting their admin/manager.

fixes: #4491

**Changes:**
- New `NoWorkspaceAccess` component with helpful messaging
- `useWorkspaceAccess` hook to check user permissions  
- Updated Main component routing logic
- Added translation keys for the new messages

**Impact:** Reduces user confusion and support requests by providing clear guidance instead of misleading onboarding text.