### PR TITLE
refactor: change naming - contextwarpper to authprovider #4510

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense } from "react";
 import { Routes, Route } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
-import { ContextWrapper } from "@/AuthContext";
+import { AuthProvider } from "@/AuthContext";
 import PrivateRoute, {
   AdminRoute,
   ManagerRoute,
@@ -97,7 +97,7 @@ export default function App() {
   return (
     <ThemeProvider>
       <Suspense fallback={<FullScreenLoader />}>
-        <ContextWrapper>
+        <AuthProvider>
           <LogoProvider>
             <PfpProvider>
               <I18nextProvider i18n={i18n}>
@@ -278,7 +278,7 @@ export default function App() {
               </I18nextProvider>
             </PfpProvider>
           </LogoProvider>
-        </ContextWrapper>
+        </AuthProvider>
       </Suspense>
     </ThemeProvider>
   );

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -2,7 +2,7 @@ import React, { useState, createContext } from "react";
 import { AUTH_TIMESTAMP, AUTH_TOKEN, AUTH_USER } from "@/utils/constants";
 
 export const AuthContext = createContext(null);
-export function ContextWrapper(props) {
+export function AuthProvider(props) {
   const localUser = localStorage.getItem(AUTH_USER);
   const localAuthToken = localStorage.getItem(AUTH_TOKEN);
   const [store, setStore] = useState({


### PR DESCRIPTION
 ### Pull Request Type
 
- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4510


### What is in this change?

the name contextwrapper seems too generic, instead now using AuthProvider


- [ x] I ran `yarn lint` from the root of the repo & committed changes
- [ x] Relevant documentation has been updated
- [ x] I have tested my code functionality
- [ x] Docker build succeeds locally
