### PR TITLE
Bug Fix: File Parsing Fails for URLs Without Explicit File Extensions

### DIFF
--- a/collector/processLink/index.js
+++ b/collector/processLink/index.js
@@ -12,7 +12,8 @@ const { validateURL } = require("../utils/url");
  */
 async function processLink(link, scraperHeaders = {}, metadata = {}) {
   const validatedLink = validateURL(link);
-  if (!validURL(validatedLink)) return { success: false, reason: "Not a valid URL." };
+  if (!validURL(validatedLink))
+    return { success: false, reason: "Not a valid URL." };
   return await scrapeGenericUrl({
     link: validatedLink,
     captureAs: "text",
@@ -31,7 +32,8 @@ async function processLink(link, scraperHeaders = {}, metadata = {}) {
  */
 async function getLinkText(link, captureAs = "text") {
   const validatedLink = validateURL(link);
-  if (!validURL(validatedLink)) return { success: false, reason: "Not a valid URL." };
+  if (!validURL(validatedLink))
+    return { success: false, reason: "Not a valid URL." };
   return await scrapeGenericUrl({
     link: validatedLink,
     captureAs,

--- a/collector/utils/downloadURIToFile/index.js
+++ b/collector/utils/downloadURIToFile/index.js
@@ -17,7 +17,7 @@ function getExtensionFromContentType(contentType) {
       return extensions[0];
     }
   }
-  
+
   return "";
 }
 
@@ -30,10 +30,13 @@ function getExtensionFromContentType(contentType) {
 function generateSafeFilename(url, contentType) {
   const urlPath = new URL(url).pathname;
   const basename = path.basename(urlPath);
-  
+
   const currentExt = path.extname(basename).toLowerCase();
   const extensionFromContentType = getExtensionFromContentType(contentType);
-  if (extensionFromContentType && (!currentExt || !Object.values(ACCEPTED_MIMES).flat().includes(currentExt))) {
+  if (
+    extensionFromContentType &&
+    (!currentExt || !Object.values(ACCEPTED_MIMES).flat().includes(currentExt))
+  ) {
     const nameWithoutExt = path.basename(basename, currentExt);
     return `${nameWithoutExt}${extensionFromContentType}`;
   }


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues
resolves #4513


### Root Cause
The `downloadURIToFile` function was using `path.basename(url)` to determine filenames, which didn't account for HTTP Content-Type headers that indicate the actual file type.

### Solution
Enhanced the file download logic to:
- Extract Content-Type from HTTP response headers
- Map Content-Type to appropriate file extension using existing `ACCEPTED_MIMES` configuration
- Generate proper filenames with correct extensions

### Changes
- Added `getExtensionFromContentType()` function to map MIME types to extensions
- Added `generateSafeFilename()` function for Content-Type aware filename generation
- Modified download logic to use Content-Type headers for proper file extension assignment


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
