### PR TITLE
fix: Use eval_duration for output TPS calculations in Ollama LLM provider

### DIFF
--- a/server/utils/AiProviders/ollama/index.js
+++ b/server/utils/AiProviders/ollama/index.js
@@ -263,7 +263,6 @@ class OllamaAILLM {
               prompt_tokens: res.prompt_eval_count,
               completion_tokens: res.eval_count,
               total_tokens: res.prompt_eval_count + res.eval_count,
-              // Override duration with Ollama's eval_duration for more accurate outputTps
               duration: res.eval_duration / 1e9,
             },
           };
@@ -352,7 +351,6 @@ class OllamaAILLM {
           if (chunk.done) {
             usage.prompt_tokens = chunk.prompt_eval_count;
             usage.completion_tokens = chunk.eval_count;
-            // Override duration with Ollama's eval_duration for more accurate outputTps
             usage.duration = chunk.eval_duration / 1e9;
             writeResponseChunk(response, {
               uuid,


### PR DESCRIPTION
 ### Pull Request Type
- [x] 🐛 fix

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4567


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

## What is in this change?

- Updated `LLMPerformanceMonitor` to support provider duration timing for more accurate output TPS calculations
- `measureAsyncFunction` accepts `duration` from `output.usage.duration`
- Modified `measureStream` to accept `duration` from `reportedUsage.duration` if provided by the LLM provider  
- Updated Ollama provider to use `eval_duration` for more accurate TPS calculation

This is a generic enhancement that any provider can leverage to supply more accurate timing information, while maintaining backward compatibility with providers that don't supply duration metrics.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
