### PR TITLE
Fix LM Studio race condition bug

### DIFF
--- a/server/__tests__/utils/AiProviders/lmStudio/index.test.js
+++ b/server/__tests__/utils/AiProviders/lmStudio/index.test.js
@@ -1,0 +1,152 @@
+const { LMStudioLLM } = require("../../../../utils/AiProviders/lmStudio");
+
+jest.mock("../../../../utils/EmbeddingEngines/native");
+jest.mock("openai");
+
+global.fetch = jest.fn();
+
+describe("LMStudioLLM", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    LMStudioLLM.modelContextWindows = {};
+    LMStudioLLM._cachePromise = null;
+    process.env.LMSTUDIO_BASE_PATH = "http://localhost:1234";
+  });
+
+  afterEach(() => {
+    delete process.env.LMSTUDIO_BASE_PATH;
+  });
+
+  describe("Constructor initialization", () => {
+    it("initializes limits immediately to prevent race conditions", () => {
+      const llm = new LMStudioLLM();
+
+      expect(llm.limits).toBeDefined();
+      expect(llm.limits.user).toBe(4096 * 0.7);
+      expect(llm.limits.system).toBe(4096 * 0.15);
+      expect(llm.limits.history).toBe(4096 * 0.15);
+    });
+
+    it("sets model from preference or defaults to fallback", () => {
+      const llm1 = new LMStudioLLM(null, "custom-model");
+      expect(llm1.model).toBe("custom-model");
+
+      const llm2 = new LMStudioLLM();
+      expect(llm2.model).toBe("Loaded from Chat UI");
+    });
+  });
+
+  describe("cacheContextWindows", () => {
+    it("caches context windows for all chat models", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: "model-1", type: "chat", max_context_length: 8192 },
+            { id: "embedding-model", type: "embeddings", max_context_length: 2048 },
+          ],
+        }),
+      });
+
+      await LMStudioLLM.cacheContextWindows(true);
+
+      expect(LMStudioLLM.modelContextWindows["model-1"]).toBe(8192);
+      expect(LMStudioLLM.modelContextWindows["embedding-model"]).toBeUndefined();
+    });
+
+    it("handles concurrent cache requests without duplicate fetches", async () => {
+      global.fetch.mockImplementation(() =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({
+            ok: true,
+            json: async () => ({ data: [{ id: "model-1", type: "chat", max_context_length: 8192 }] }),
+          }), 100)
+        )
+      );
+
+      const promise1 = LMStudioLLM.cacheContextWindows(true);
+      const promise2 = LMStudioLLM.cacheContextWindows(false);
+
+      await Promise.all([promise1, promise2]);
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("ensureModelCached", () => {
+    it("returns immediately if model is already cached", async () => {
+      LMStudioLLM.modelContextWindows["model-1"] = 8192;
+
+      await LMStudioLLM.ensureModelCached("model-1");
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("refreshes cache when model is not found", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: "new-model", type: "chat", max_context_length: 4096 }],
+        }),
+      });
+
+      await LMStudioLLM.ensureModelCached("new-model");
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(LMStudioLLM.modelContextWindows["new-model"]).toBe(4096);
+    });
+  });
+
+  describe("getChatCompletion", () => {
+    it("ensures model is cached before making request", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: "test-model", type: "chat", max_context_length: 8192 }],
+        }),
+      });
+
+      const llm = new LMStudioLLM(null, "test-model");
+      const mockCreate = jest.fn().mockResolvedValue({
+        choices: [{ message: { content: "Response" } }],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      });
+
+      llm.lmstudio = {
+        chat: {
+          completions: { create: mockCreate },
+        },
+      };
+
+      await llm.getChatCompletion([{ role: "user", content: "Hello" }], { temperature: 0.7 });
+
+      expect(LMStudioLLM.modelContextWindows["test-model"]).toBe(8192);
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+
+  describe("streamGetChatCompletion", () => {
+    it("ensures model is cached before streaming", async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: "test-model", type: "chat", max_context_length: 8192 }],
+        }),
+      });
+
+      const llm = new LMStudioLLM(null, "test-model");
+      const mockCreate = jest.fn().mockResolvedValue({ [Symbol.asyncIterator]: jest.fn() });
+
+      llm.lmstudio = {
+        chat: {
+          completions: { create: mockCreate },
+        },
+      };
+
+      await llm.streamGetChatCompletion([{ role: "user", content: "Hello" }], { temperature: 0.7 });
+
+      expect(LMStudioLLM.modelContextWindows["test-model"]).toBe(8192);
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/__tests__/utils/agents/aibitat/providers/lmstudio.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/lmstudio.test.js
@@ -1,0 +1,85 @@
+const LMStudioProvider = require("../../../../../utils/agents/aibitat/providers/lmstudio");
+const { LMStudioLLM } = require("../../../../../utils/AiProviders/lmStudio");
+
+jest.mock("openai");
+jest.mock("../../../../../utils/AiProviders/lmStudio", () => ({
+  LMStudioLLM: {
+    ensureModelCached: jest.fn(),
+    cacheContextWindows: jest.fn(),
+  },
+  parseLMStudioBasePath: jest.fn((path) => path),
+}));
+
+describe("LMStudioProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.LMSTUDIO_BASE_PATH = "http://localhost:1234";
+  });
+
+  afterEach(() => {
+    delete process.env.LMSTUDIO_BASE_PATH;
+    delete process.env.LMSTUDIO_MODEL_PREF;
+  });
+
+  describe("Initialization", () => {
+    it("initializes with provided model or defaults", () => {
+      const provider1 = new LMStudioProvider({ model: "custom-model" });
+      expect(provider1.model).toBe("custom-model");
+
+      const provider2 = new LMStudioProvider();
+      expect(provider2.model).toBe("Loaded from Chat UI");
+    });
+
+    it("supports agent streaming", () => {
+      const provider = new LMStudioProvider();
+      expect(provider.supportsAgentStreaming).toBe(true);
+    });
+  });
+
+  describe("Chat completion", () => {
+    it("ensures model is cached before completing", async () => {
+      const provider = new LMStudioProvider({ model: "test-model" });
+      const mockCreate = jest.fn().mockResolvedValue({
+        choices: [{ message: { content: "Response" } }],
+      });
+
+      provider._client = {
+        chat: {
+          completions: { create: mockCreate },
+        },
+      };
+
+      await provider.complete([{ role: "user", content: "Hello" }]);
+
+      expect(LMStudioLLM.ensureModelCached).toHaveBeenCalledWith("test-model");
+      expect(mockCreate).toHaveBeenCalled();
+    });
+
+    it("ensures model is cached before streaming", async () => {
+      const provider = new LMStudioProvider({ model: "test-model" });
+      const mockCreate = jest.fn().mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield { choices: [{ delta: { content: "Hello" } }] };
+        },
+      });
+
+      provider._client = {
+        chat: {
+          completions: { create: mockCreate },
+        },
+      };
+
+      await provider.stream([{ role: "user", content: "Hello" }], [], null);
+
+      expect(LMStudioLLM.ensureModelCached).toHaveBeenCalledWith("test-model");
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+
+  describe("Cost calculation", () => {
+    it("returns zero cost for LMStudio", () => {
+      const provider = new LMStudioProvider();
+      expect(provider.getCost({})).toBe(0);
+    });
+  });
+});

--- a/server/utils/agents/aibitat/providers/lmstudio.js
+++ b/server/utils/agents/aibitat/providers/lmstudio.js
@@ -41,7 +41,10 @@ class LMStudioProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async #handleFunctionCallChat({ messages = [] }) {
-    await LMStudioLLM.cacheContextWindows();
+    // Ensure context window is cached before proceeding
+    // Prevents race conditions and handles newly downloaded models
+    await LMStudioLLM.ensureModelCached(this.model);
+
     return await this.client.chat.completions
       .create({
         model: this.model,
@@ -60,7 +63,10 @@ class LMStudioProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async #handleFunctionCallStream({ messages = [] }) {
-    await LMStudioLLM.cacheContextWindows();
+    // Ensure context window is cached before proceeding
+    // Prevents race conditions and handles newly downloaded models
+    await LMStudioLLM.ensureModelCached(this.model);
+
     return await this.client.chat.completions.create({
       model: this.model,
       stream: true,


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4572 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Patches LM Studio race condition bug
- Bug occurs in the constructor when we begin fetching the context windows in the background (using `.then` in constructor does not wait for completion before instantiating the class) and there is no check to ensure `this.limits` was initialized before a chat can be sent
- This race condition bug happens when a user has lots of models in LM Studio and the API has a delay in returning the context windows causing the chat to be sent before we can get a response back from the context window LM Studio API endpoint (`this.limits` is not initialized)
- Adds awaited `ensureModelCached` guard function to all chat methods and agent provider chat methods to block a chat from happening until we either get a response back from the LM Studio API with correct context window OR fallback to 4096 as default context window size (ensures `this.limits` is initialized properly)
- Adds checks for models that may have been downloaded from LM Studio AFTER the backend server was started and fetches context windows again from the LM Studio API if the model is not already cached instead of just defaulting back to 4096 immediately when the selected model doesn't exist in cache
- Adds test cases for both LM Studio LLM and agent providers

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
