### PR TITLE
feat: allow different logos per dark and light mode

### DIFF
--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -234,8 +234,13 @@ const System = {
         return { success: false, error: e.message };
       });
   },
-  uploadLogo: async function (formData) {
-    return await fetch(`${API_BASE}/system/upload-logo`, {
+  uploadLogo: async function (formData, theme = null) {
+    const url = new URL(`${API_BASE}/system/upload-logo`);
+    if (theme) {
+      // Append theme as query parameter or add to form data
+      formData.append('theme', theme);
+    }
+    return await fetch(url.toString(), {
       method: "POST",
       body: formData,
       headers: baseHeaders(),
@@ -402,8 +407,12 @@ const System = {
       });
   },
 
-  isDefaultLogo: async function () {
-    return await fetch(`${API_BASE}/system/is-default-logo`, {
+  isDefaultLogo: async function (theme = null) {
+    const url = new URL(`${API_BASE}/system/is-default-logo`);
+    if (theme) {
+      url.searchParams.append('theme', theme);
+    }
+    return await fetch(url.toString(), {
       method: "GET",
       cache: "no-cache",
     })
@@ -417,8 +426,12 @@ const System = {
         return null;
       });
   },
-  removeCustomLogo: async function () {
-    return await fetch(`${API_BASE}/system/remove-logo`, {
+  removeCustomLogo: async function (theme = null) {
+    const url = new URL(`${API_BASE}/system/remove-logo`);
+    if (theme) {
+      url.searchParams.append('theme', theme);
+    }
+    return await fetch(url.toString(), {
       headers: baseHeaders(),
     })
       .then((res) => {

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -36,6 +36,8 @@ const SystemSettings = {
   ],
   supportedFields: [
     "logo_filename",
+    "logo_filename_dark",
+    "logo_filename_light",
     "telemetry_id",
     "footer_data",
     "support_email",
@@ -397,8 +399,18 @@ const SystemSettings = {
     }
   },
 
-  currentLogoFilename: async function () {
+  currentLogoFilename: async function (theme = null) {
     try {
+      // If theme is specified, check for theme-specific logo first
+      if (theme === "dark") {
+        const darkSetting = await this.get({ label: "logo_filename_dark" });
+        if (darkSetting?.value) return darkSetting.value;
+      } else if (theme === "light") {
+        const lightSetting = await this.get({ label: "logo_filename_light" });
+        if (lightSetting?.value) return lightSetting.value;
+      }
+
+      // Fall back to the original logo_filename setting for backward compatibility
       const setting = await this.get({ label: "logo_filename" });
       return setting?.value || null;
     } catch (error) {

--- a/server/utils/files/logo.js
+++ b/server/utils/files/logo.js
@@ -30,15 +30,15 @@ function getDefaultFilename(darkMode = true) {
   return darkMode ? LOGO_FILENAME : LOGO_FILENAME_DARK;
 }
 
-async function determineLogoFilepath(defaultFilename = LOGO_FILENAME) {
-  const currentLogoFilename = await SystemSettings.currentLogoFilename();
+async function determineLogoFilepath(defaultFilename = LOGO_FILENAME, theme = null) {
+  const currentLogoFilename = await SystemSettings.currentLogoFilename(theme);
   const basePath = process.env.STORAGE_DIR
     ? path.join(process.env.STORAGE_DIR, "assets")
     : path.join(__dirname, "../../storage/assets");
   const defaultFilepath = path.join(basePath, defaultFilename);
 
   if (currentLogoFilename && validFilename(currentLogoFilename)) {
-    customLogoPath = path.join(basePath, normalizePath(currentLogoFilename));
+    const customLogoPath = path.join(basePath, normalizePath(currentLogoFilename));
     if (!isWithin(path.resolve(basePath), path.resolve(customLogoPath)))
       return defaultFilepath;
     return fs.existsSync(customLogoPath) ? customLogoPath : defaultFilepath;


### PR DESCRIPTION
- [x] ✨ feat

### Relevant Issues

resolves #4617

### What is in this change?

- Adds support for different logos per dark and light theme. Users can upload separate logos that automatically switch based on theme preference.

**Changes:**
- Backend: Theme-specific logo storage and API endpoints
- Frontend: Dual upload UI for dark/light theme logos  
- Automatic switching when theme changes
- Backward compatible with existing single-logo setups