### PR TITLE
Implement full chat and `@agent` chat `user` indentificiation for OpenRouter

### DIFF
--- a/server/utils/AiProviders/openRouter/index.js
+++ b/server/utils/AiProviders/openRouter/index.js
@@ -238,7 +238,7 @@ class OpenRouterLLM {
     ];
   }
 
-  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+  async getChatCompletion(messages = null, { temperature = 0.7, user = null }) {
     if (!(await this.isValidChatCompletionModel(this.model)))
       throw new Error(
         `OpenRouter chat: ${this.model} is not valid for chat completion!`
@@ -253,6 +253,7 @@ class OpenRouterLLM {
           // This is an OpenRouter specific option that allows us to get the reasoning text
           // before the token text.
           include_reasoning: true,
+          user: user?.id ? `user_${user.id}` : "",
         })
         .catch((e) => {
           throw new Error(e.message);
@@ -279,7 +280,10 @@ class OpenRouterLLM {
     };
   }
 
-  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+  async streamGetChatCompletion(
+    messages = null,
+    { temperature = 0.7, user = null }
+  ) {
     if (!(await this.isValidChatCompletionModel(this.model)))
       throw new Error(
         `OpenRouter chat: ${this.model} is not valid for chat completion!`
@@ -294,6 +298,7 @@ class OpenRouterLLM {
         // This is an OpenRouter specific option that allows us to get the reasoning text
         // before the token text.
         include_reasoning: true,
+        user: user?.id ? `user_${user.id}` : "",
       }),
       messages
       // We have to manually count the tokens

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -474,6 +474,8 @@ class AIbitat {
       ...this.defaultProvider,
       ...channelConfig,
     });
+    provider.attachHandlerProps(this.handlerProps);
+
     const history = this.getHistory({ to: channel });
 
     // build the messages to send to the provider
@@ -594,6 +596,7 @@ ${this.getHistory({ to: route.to })
       ...this.defaultProvider,
       ...fromConfig,
     });
+    provider.attachHandlerProps(this.handlerProps);
 
     let content;
     if (provider.supportsAgentStreaming) {
@@ -911,11 +914,10 @@ ${this.getHistory({ to: route.to })
    * If the provider is a string, it will return the default provider for that string.
    *
    * @param config The provider configuration.
+   * @returns {Providers.OpenAIProvider} The provider instance.
    */
   getProviderForConfig(config) {
-    if (typeof config.provider === "object") {
-      return config.provider;
-    }
+    if (typeof config.provider === "object") return config.provider;
 
     switch (config.provider) {
       case "openai":

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -28,6 +28,22 @@ const DEFAULT_WORKSPACE_PROMPT =
 
 class Provider {
   _client;
+
+  /**
+   * The invocation object containing the user ID and other invocation details.
+   * @type {import("@prisma/client").workspace_agent_invocations}
+   */
+  invocation = {};
+
+  /**
+   * The user ID for the chat completion to send to the LLM provider for user tracking.
+   * In order for this to be set, the handler props must be attached to the provider after instantiation.
+   * ex: this.attachHandlerProps({ ..., invocation: { ..., user_id: 123 } });
+   * eg: `user_123`
+   * @type {string}
+   */
+  executingUserId = "";
+
   constructor(client) {
     if (this.constructor == Provider) {
       return;
@@ -40,6 +56,19 @@ class Provider {
       `\x1b[36m[AgentLLM${this?.model ? ` - ${this.model}` : ""}]\x1b[0m ${text}`,
       ...args
     );
+  }
+
+  /**
+   * Attaches handler props to the provider for reuse in the provider.
+   * - Explicitly sets the invocation object.
+   * - Explicitly sets the executing user ID from the invocation object.
+   * @param {Object} handlerProps - The handler props to attach to the provider.
+   */
+  attachHandlerProps(handlerProps = {}) {
+    this.invocation = handlerProps?.invocation || {};
+    this.executingUserId = this.invocation?.user_id
+      ? `user_${this.invocation.user_id}`
+      : "";
   }
 
   get client() {

--- a/server/utils/agents/aibitat/providers/openrouter.js
+++ b/server/utils/agents/aibitat/providers/openrouter.js
@@ -5,6 +5,8 @@ const UnTooled = require("./helpers/untooled.js");
 
 /**
  * The agent provider for the OpenRouter provider.
+ * @extends {Provider}
+ * @extends {UnTooled}
  */
 class OpenRouterProvider extends InheritMultiple([Provider, UnTooled]) {
   model;
@@ -40,6 +42,7 @@ class OpenRouterProvider extends InheritMultiple([Provider, UnTooled]) {
       .create({
         model: this.model,
         messages,
+        user: this.executingUserId,
       })
       .then((result) => {
         if (!result.hasOwnProperty("choices"))
@@ -58,6 +61,7 @@ class OpenRouterProvider extends InheritMultiple([Provider, UnTooled]) {
       model: this.model,
       stream: true,
       messages,
+      user: this.executingUserId,
     });
   }
 

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -307,6 +307,7 @@ async function chatSync({
   const { textResponse, metrics: performanceMetrics } =
     await LLMConnector.getChatCompletion(messages, {
       temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
+      user: user,
     });
 
   if (!textResponse) {
@@ -649,6 +650,7 @@ async function streamChat({
     const { textResponse, metrics: performanceMetrics } =
       await LLMConnector.getChatCompletion(messages, {
         temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
+        user: user,
       });
     completeText = textResponse;
     metrics = performanceMetrics;
@@ -664,6 +666,7 @@ async function streamChat({
   } else {
     const stream = await LLMConnector.streamGetChatCompletion(messages, {
       temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
+      user: user,
     });
     completeText = await LLMConnector.handleStream(response, stream, { uuid });
     metrics = stream.metrics;

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -248,6 +248,7 @@ async function streamChatWithWorkspace(
     const { textResponse, metrics: performanceMetrics } =
       await LLMConnector.getChatCompletion(messages, {
         temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
+        user: user,
       });
 
     completeText = textResponse;
@@ -264,6 +265,7 @@ async function streamChatWithWorkspace(
   } else {
     const stream = await LLMConnector.streamGetChatCompletion(messages, {
       temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
+      user: user,
     });
     completeText = await LLMConnector.handleStream(response, stream, {
       uuid,

--- a/server/utils/helpers/index.js
+++ b/server/utils/helpers/index.js
@@ -24,6 +24,7 @@
  *
  * @typedef {Object} ChatCompletionOptions
  * @property {number} temperature - The sampling temperature for the LLM response
+ * @property {import("@prisma/client").users} user - The user object for the chat completion to send to the LLM provider for user tracking (optional)
  *
  * @typedef {function(Array<ChatMessage>, ChatCompletionOptions): Promise<ChatCompletionResponse>} getChatCompletionFunction
  *


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4453
closes #4482

### What is in this change?
- Adds an optional `user` record in `getChatCompletion` and `streamCompletion` in chat that can be used in any provider, but this PR only adds it for OpenRouter currently.

- Also adds context and tracking for user and general `invocation` on the Aibitat `Provider` so that we can easily get references to the calling record and user at any time

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

- Since all of this is optional, this should have no impact on existing providers.
- No tracking was added to `LLMInstruction` calls from agent flows or `EphemeralAgent` API based calls - since they may not have a user associated.

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality

> Tested normal chats, agent chats, and API chats w/&w/o agents for workspace & thread sync and stream with multiple providers in addition to OR.

- [x] Docker build succeeds locally
