### PR TITLE
docs(zh-TW): correct traditional Chinese translations in home section

### DIFF
--- a/frontend/src/locales/zh_TW/common.js
+++ b/frontend/src/locales/zh_TW/common.js
@@ -1003,9 +1003,9 @@ const TRANSLATIONS = {
   },
   home: {
     welcome: "歡迎",
-    chooseWorkspace: "选择一个工作区开始聊天！",
+    chooseWorkspace: "選擇一個工作區開始聊天！",
     notAssigned:
-      "你目前还没有分配到任何工作区。\n请联系你的管理员请求访问一个工作区。",
+      "你目前還沒有分配到任何工作區。\n請聯繫你的管理員請求訪問一個工作區。",
     goToWorkspace: '前往 "{{workspace}}"',
   },
 };


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

These two original sentences are actually Simplified Chinese instead of Traditional Chinese, this PR modifies the translation of these two sentences so that they become Traditional Chinese.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
