### PR TITLE
Refactor WorkspaceFileRow component

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
@@ -190,8 +190,9 @@ const WatchForChanges = memo(({ workspace, docPath, item }) => {
   const [watched, setWatched] = useState(item?.watched || false);
   const watchEvent = new CustomEvent("watch_document_for_changes");
 
-  const updateWatchStatus = async () => {
+  const updateWatchStatus = async (e) => {
     try {
+      e.stopPropagation();
       if (!watched) window.dispatchEvent(watchEvent);
       const success =
         await System.experimentalFeatures.liveSync.setWatchStatusForDocument(
@@ -236,30 +237,21 @@ const WatchForChanges = memo(({ workspace, docPath, item }) => {
       className="group flex gap-x-2 items-center hover:bg-theme-file-picker-hover p-[2px] rounded ml-2 cursor-pointer"
       onClick={updateWatchStatus}
       data-tooltip-id="watch-changes"
+      data-active={watched}
       data-tooltip-content={
         watched ? "Stop watching for changes" : "Watch document for changes"
       }
     >
-      {watched ? (
-        <Eye
-          size={16}
-          weight="fill"
-          className="outline-none text-base font-bold flex-shrink-0"
-        />
-      ) : (
-        <>
-          <Eye
-            size={16}
-            weight="regular"
-            className="outline-none text-base font-bold flex-shrink-0 group-hover:hidden"
-          />
-          <Eye
-            size={16}
-            weight="fill"
-            className="outline-none text-base font-bold flex-shrink-0 hidden group-hover:block"
-          />
-        </>
-      )}
+      <Eye
+        size={16}
+        weight="regular"
+        className="outline-none text-base font-bold flex-shrink-0 group-hover:hidden group-data-[active=true]:hidden"
+      />
+      <Eye
+        size={16}
+        weight="fill"
+        className="outline-none text-base font-bold flex-shrink-0 hidden group-hover:block group-data-[active=true]:block"
+      />
     </div>
   );
 });


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4739 


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Refactors the WorkspaceFileRow subcomponent by removing 2 event listeners (onMouseEnter and onMouseLeave) and 1 useState per row rendered for managing hover state
- Uses CSS to conditionally hide/show on group hover
- Significantly improves performance in frontend for users that have many files embedded in a workspace
- No change in UI/UX

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

- Previously 10 embedded files would have 20 event listeners and 10 unnecessary useStates just for managing hover state

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
