### PR TITLE
Fix pagination bug in paperless-ngx data connector

### DIFF
--- a/collector/utils/extensions/PaperlessNgx/PaperlessNgxLoader/index.js
+++ b/collector/utils/extensions/PaperlessNgx/PaperlessNgxLoader/index.js
@@ -50,6 +50,8 @@ class PaperlessNgxLoader {
           if (!validResults.length) break;
 
           documents.push(...validResults);
+
+          if (data.next === nextUrl) break;
           nextUrl = data.next || null;
           page++;
         } catch (error) {


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4753


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Fixes a bug where importing documents via the paperless-ngx data connector would only import up to 25 documents (1 page of data)
- Fixed by using the `next` url that is returned by the paperless-ngx API to fetch next page of data until it is `null` indicating there are no more pages to iterate over

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
