### PR TITLE
Upgrade MCP SDK to Latest (1.24.3)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
     "@langchain/textsplitters": "0.0.0",
     "@mintplex-labs/bree": "^9.2.5",
     "@mintplex-labs/express-ws": "^5.0.7",
-    "@modelcontextprotocol/sdk": "^1.11.0",
+    "@modelcontextprotocol/sdk": "^1.24.3",
     "@pinecone-database/pinecone": "^2.0.1",
     "@prisma/client": "5.3.1",
     "@qdrant/js-client-rest": "^1.9.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2044,7 +2044,7 @@
   dependencies:
     ws "^7.5.10"
 
-"@modelcontextprotocol/sdk@^1.11.0":
+"@modelcontextprotocol/sdk@^1.24.3":
   version "1.24.3"
   resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz#81a3fcc919cb4ce8630e2bcecf59759176eb331a"
   integrity sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

This PR upgrades the MCP SDK (`@modelcontextprotocol/sdk`) in `/server` subrepo to `1.23.3`.

Just to clarify, you might notice the version remains the same in `package.json`, it's using the semver range syntax (`^`) specifying that anything between 1.11.0 and 2.0.0 is compatible, but the **exact** version we're using is pinned in the `yarn.lock`.

After running `yarn` to update your packages, you can run

```
cat node_modules/@modelcontextprotocol/sdk/package.json | grep '"version"'
``` 
To verify what version is in your `node_modules`

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
