### PR TITLE
fix(devcontainer): forward ports 3000/3001

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,9 @@
   // "containerUser": "anythingllm",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18-bookworm",
+
+  "forwardPorts": [3001, 3000],
+
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     // Docker very useful linter


### PR DESCRIPTION
### Pull Request Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] style
- [ ] chore
- [ ] docs

### Relevant Issues

resolves #4778

### What is in this change?

- Adds explicit forwardPorts for 3001 (server) and 3000 (frontend) in the dev container configuration to make Codespaces port forwarding consistent.

### Additional Information

- N/A

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally