### PR TITLE
Embed chat widget ip security improvements

### DIFF
--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/EditEmbedModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/EditEmbedModal/index.jsx
@@ -93,7 +93,24 @@ export default function EditEmbedModal({ embed, closeModal }) {
                 hint="Allow setting of the system prompt to override the workspace default."
                 defaultValue={embed.allow_prompt_override}
               />
-
+              <BooleanInput
+                name="ip_session_binding"
+                title="Enable IP-Session Binding"
+                hint="Bind chat sessions to IP addresses to prevent session rotation abuse. When enabled, a session can only be used from the IP address that started it."
+                defaultValue={embed.ip_session_binding}
+              />
+              <NumberInput
+                name="max_chats_per_ip_per_day"
+                title="Max chats per IP per day"
+                hint="Limit the amount of chats from a single IP address in a 24 hour period. Zero is unlimited."
+                defaultValue={embed.max_chats_per_ip_per_day}
+              />
+              <NumberInput
+                name="max_chats_per_ip_per_session"
+                title="Max chats per IP per session"
+                hint="Limit the amount of chats from a single IP address per session in a 24 hour period. Zero is unlimited."
+                defaultValue={embed.max_chats_per_ip_per_session}
+              />
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
               <p className="text-white text-opacity-60 text-xs md:text-sm">
                 After creating an embed you will be provided a link that you can

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/NewEmbedModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/NewEmbedModal/index.jsx
@@ -20,6 +20,8 @@ export function enforceSubmissionSchema(form) {
     data.allow_temperature_override = false;
   if (!data.hasOwnProperty("allow_prompt_override"))
     data.allow_prompt_override = false;
+  if (!data.hasOwnProperty("ip_session_binding"))
+    data.ip_session_binding = false;
   if (!data.hasOwnProperty("message_limit")) data.message_limit = 20;
   return data;
 }
@@ -91,7 +93,21 @@ export default function NewEmbedModal({ closeModal }) {
                 title="Enable Prompt Override"
                 hint="Allow setting of the system prompt to override the workspace default."
               />
-
+              <BooleanInput
+                name="ip_session_binding"
+                title="Enable IP-Session Binding"
+                hint="Bind chat sessions to IP addresses to prevent session rotation abuse. When enabled, a session can only be used from the IP address that started it."
+              />
+              <NumberInput
+                name="max_chats_per_ip_per_day"
+                title="Max chats per IP per day"
+                hint="Limit the amount of chats from a single IP address in a 24 hour period. Zero is unlimited."
+              />
+              <NumberInput
+                name="max_chats_per_ip_per_session"
+                title="Max chats per IP per session"
+                hint="Limit the amount of chats from a single IP address per session in a 24 hour period. Zero is unlimited."
+              />
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
               <p className="text-white text-opacity-60 text-xs md:text-sm">
                 After creating an embed you will be provided a link that you can

--- a/server/models/embedConfig.js
+++ b/server/models/embedConfig.js
@@ -12,6 +12,9 @@ const EmbedConfig = {
     "allow_prompt_override",
     "max_chats_per_day",
     "max_chats_per_session",
+    "max_chats_per_ip_per_day",
+    "max_chats_per_ip_per_session",
+    "ip_session_binding",
     "chat_mode",
     "workspace_id",
     "message_limit",
@@ -52,6 +55,18 @@ const EmbedConfig = {
             data?.message_limit,
             "message_limit"
           ),
+          max_chats_per_ip_per_day: validatedCreationData(
+            data?.max_chats_per_ip_per_day,
+            "max_chats_per_ip_per_day"
+          ),
+          max_chats_per_ip_per_session: validatedCreationData(
+            data?.max_chats_per_ip_per_session,
+            "max_chats_per_ip_per_session"
+          ),
+          ip_session_binding: validatedCreationData(
+            data?.ip_session_binding,
+            "ip_session_binding"
+          ),
           createdBy: Number(creatorId) ?? null,
           workspace: {
             connect: { id: Number(data.workspace_id) },
@@ -71,7 +86,7 @@ const EmbedConfig = {
       this.writable.includes(key)
     );
     if (validKeys.length === 0)
-      return { embed: { id }, message: "No valid fields to update!" };
+      return { embed: { id: embedId }, message: "No valid fields to update!" };
 
     const updates = {};
     validKeys.map((key) => {
@@ -189,11 +204,14 @@ const BOOLEAN_KEYS = [
   "allow_temperature_override",
   "allow_prompt_override",
   "enabled",
+  "ip_session_binding",
 ];
 
 const NUMBER_KEYS = [
   "max_chats_per_day",
   "max_chats_per_session",
+  "max_chats_per_ip_per_day",
+  "max_chats_per_ip_per_session",
   "workspace_id",
   "message_limit",
 ];

--- a/server/prisma/migrations/20251223004106_init/migration.sql
+++ b/server/prisma/migrations/20251223004106_init/migration.sql
@@ -1,0 +1,30 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_embed_configs" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "uuid" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "chat_mode" TEXT NOT NULL DEFAULT 'query',
+    "allowlist_domains" TEXT,
+    "allow_model_override" BOOLEAN NOT NULL DEFAULT false,
+    "allow_temperature_override" BOOLEAN NOT NULL DEFAULT false,
+    "allow_prompt_override" BOOLEAN NOT NULL DEFAULT false,
+    "max_chats_per_day" INTEGER,
+    "max_chats_per_session" INTEGER,
+    "max_chats_per_ip_per_day" INTEGER,
+    "max_chats_per_ip_per_session" INTEGER,
+    "ip_session_binding" BOOLEAN NOT NULL DEFAULT false,
+    "message_limit" INTEGER DEFAULT 20,
+    "workspace_id" INTEGER NOT NULL,
+    "createdBy" INTEGER,
+    "usersId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "embed_configs_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "embed_configs_usersId_fkey" FOREIGN KEY ("usersId") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_embed_configs" ("allow_model_override", "allow_prompt_override", "allow_temperature_override", "allowlist_domains", "chat_mode", "createdAt", "createdBy", "enabled", "id", "max_chats_per_day", "max_chats_per_session", "message_limit", "usersId", "uuid", "workspace_id") SELECT "allow_model_override", "allow_prompt_override", "allow_temperature_override", "allowlist_domains", "chat_mode", "createdAt", "createdBy", "enabled", "id", "max_chats_per_day", "max_chats_per_session", "message_limit", "usersId", "uuid", "workspace_id" FROM "embed_configs";
+DROP TABLE "embed_configs";
+ALTER TABLE "new_embed_configs" RENAME TO "embed_configs";
+CREATE UNIQUE INDEX "embed_configs_uuid_key" ON "embed_configs"("uuid");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -245,6 +245,9 @@ model embed_configs {
   allow_prompt_override      Boolean       @default(false)
   max_chats_per_day          Int?
   max_chats_per_session      Int?
+  max_chats_per_ip_per_day   Int?
+  max_chats_per_ip_per_session Int?
+  ip_session_binding         Boolean       @default(false)
   message_limit              Int?          @default(20)
   workspace_id               Int
   createdBy                  Int?

--- a/server/utils/middleware/embedMiddleware.js
+++ b/server/utils/middleware/embedMiddleware.js
@@ -2,7 +2,7 @@ const { v4: uuidv4, validate } = require("uuid");
 const { VALID_CHAT_MODE } = require("../chats/stream");
 const { EmbedChats } = require("../../models/embedChats");
 const { EmbedConfig } = require("../../models/embedConfig");
-const { reqBody } = require("../http");
+const { reqBody, safeJsonParse } = require("../http");
 
 // Finds or Aborts request for a /:embedId/ url. This should always
 // be the first middleware and the :embedID should be in the URL.
@@ -104,6 +104,40 @@ async function canRespond(request, response, next) {
       return;
     }
 
+    const currentIp = response.locals.connection?.ip;
+    const oneDayAgo = new Date(new Date() - 24 * 60 * 60 * 1000);
+
+    // Verifies ip matches the first ip used with this session
+    if (embed.ip_session_binding === true) {
+      const previousChat = await EmbedChats.get(
+        {
+          embed_id: embed.id,
+          session_id: sessionId,
+        },
+        1,
+        { id: "asc" }
+      );
+
+      if (previousChat) {
+        const previousConnection = safeJsonParse(
+          previousChat.connection_information,
+          {}
+        );
+        if (previousConnection.ip && previousConnection.ip !== currentIp) {
+          response.status(429).json({
+            id: uuidv4(),
+            type: "abort",
+            textResponse: null,
+            sources: [],
+            close: true,
+            error: "Invalid request.",
+            errorMsg: "Invalid request.",
+          });
+          return;
+        }
+      }
+    }
+
     if (
       !isNaN(embed.max_chats_per_day) &&
       Number(embed.max_chats_per_day) > 0
@@ -111,7 +145,7 @@ async function canRespond(request, response, next) {
       const dailyChatCount = await EmbedChats.count({
         embed_id: embed.id,
         createdAt: {
-          gte: new Date(new Date() - 24 * 60 * 60 * 1000),
+          gte: oneDayAgo,
         },
       });
 
@@ -138,7 +172,7 @@ async function canRespond(request, response, next) {
         embed_id: embed.id,
         session_id: sessionId,
         createdAt: {
-          gte: new Date(new Date() - 24 * 60 * 60 * 1000),
+          gte: oneDayAgo,
         },
       });
 
@@ -150,6 +184,79 @@ async function canRespond(request, response, next) {
           sources: [],
           close: true,
           error:
+            "Your quota for this chat has been reached. Try again later or contact the site owner.",
+        });
+        return;
+      }
+    }
+
+    // Checks number of chats per ip per day across all sessions
+    if (
+      !isNaN(embed.max_chats_per_ip_per_day) &&
+      Number(embed.max_chats_per_ip_per_day) > 0
+    ) {
+      const recentChats = await EmbedChats.where(
+        {
+          embed_id: embed.id,
+          createdAt: {
+            gte: oneDayAgo,
+          },
+        },
+        null,
+        null
+      );
+
+      const ipChatCount = recentChats.filter((chat) => {
+        const connection = safeJsonParse(chat.connection_information, {});
+        return connection.ip === currentIp;
+      }).length;
+
+      if (ipChatCount >= Number(embed.max_chats_per_ip_per_day)) {
+        response.status(429).json({
+          id: uuidv4(),
+          type: "abort",
+          textResponse: null,
+          sources: [],
+          close: true,
+          error: "Rate limit exceeded for this IP address per day.",
+          errorMsg:
+            "Your quota for this chat has been reached. Try again later or contact the site owner.",
+        });
+        return;
+      }
+    }
+
+    // Checks number of chats per ip per session
+    if (
+      !isNaN(embed.max_chats_per_ip_per_session) &&
+      Number(embed.max_chats_per_ip_per_session) > 0
+    ) {
+      const recentSessionChats = await EmbedChats.where(
+        {
+          embed_id: embed.id,
+          session_id: sessionId,
+          createdAt: {
+            gte: oneDayAgo,
+          },
+        },
+        null,
+        null
+      );
+
+      const ipSessionChatCount = recentSessionChats.filter((chat) => {
+        const connection = safeJsonParse(chat.connection_information, {});
+        return connection.ip === currentIp;
+      }).length;
+
+      if (ipSessionChatCount >= Number(embed.max_chats_per_ip_per_session)) {
+        response.status(429).json({
+          id: uuidv4(),
+          type: "abort",
+          textResponse: null,
+          sources: [],
+          close: true,
+          error: "Rate limit exceeded for this IP address per session.",
+          errorMsg:
             "Your quota for this chat has been reached. Try again later or contact the site owner.",
         });
         return;


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #1382


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->

- Adds option for embed chat widget to allow session binding by ip address
- Adds option for embed chat widget to allow max chats per ip per day
- Adds option for embed chat widget to allow max chats per session per ip
- Improves security by allowing users that host the AnythingLLM embedded chat widget to add more limits to users based on ip address and can help prevent replay attacks

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
