### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-and-push-image-semver.yaml
+++ b/.github/workflows/build-and-push-image-semver.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if DockerHub build needed
         shell: bash

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if DockerHub build needed
         shell: bash

--- a/.github/workflows/check-package-versions.yaml
+++ b/.github/workflows/check-package-versions.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 

--- a/.github/workflows/check-translations.yaml
+++ b/.github/workflows/check-translations.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 

--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if DockerHub build needed
         shell: bash

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 
       - name: Cache root dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-yarn-root-
 
       - name: Cache server dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             server/node_modules
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-yarn-server-
 
       - name: Cache collector dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             collector/node_modules

--- a/.github/workflows/sponsors.yaml
+++ b/.github/workflows/sponsors.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Generate All Sponsors README
         id: generate-all-sponsors
@@ -24,14 +24,14 @@ jobs:
           marker: 'all-sponsors'
 
       - name: Commit and Push 🚀
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         id: auto-commit-action
         with:
           commit_message: 'Update Sponsors README'
           file_pattern: 'README.md'
 
       - name: Generate PR if changes detected
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         if: steps.auto-commit-action.outputs.files_changed == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/run-tests.yaml`
- Updated `stefanzweifel/git-auto-commit-action` from `v5` to `v7` in `.github/workflows/sponsors.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/check-package-versions.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/sponsors.yaml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/check-translations.yaml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/check-package-versions.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/dev-build.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/build-and-push-image.yaml`
- Updated `actions/cache` from `v3` to `v5` in `.github/workflows/run-tests.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/build-and-push-image-semver.yaml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/check-translations.yaml`
- Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/sponsors.yaml`
- Updated `actions/setup-node` from `v3` to `v6` in `.github/workflows/run-tests.yaml`
