### PR TITLE
chore: Remove unused variables in frontend

### DIFF
--- a/frontend/src/components/ChatBubble/index.jsx
+++ b/frontend/src/components/ChatBubble/index.jsx
@@ -4,7 +4,7 @@ import { userFromStorage } from "@/utils/request";
 import renderMarkdown from "@/utils/chat/markdown";
 import DOMPurify from "@/utils/chat/purify";
 
-export default function ChatBubble({ message, type, popMsg }) {
+export default function ChatBubble({ message, type }) {
   const isUser = type === "user";
 
   return (

--- a/frontend/src/components/LLMSelection/DPAISOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/DPAISOptions/index.jsx
@@ -5,10 +5,7 @@ import PreLoader from "@/components/Preloader";
 import { DPAIS_COMMON_URLS } from "@/utils/constants";
 import useProviderEndpointAutoDiscovery from "@/hooks/useProviderEndpointAutoDiscovery";
 
-export default function DellProAIStudioOptions({
-  settings,
-  showAlert = false,
-}) {
+export default function DellProAIStudioOptions({ settings }) {
   const {
     autoDetecting: loading,
     basePath,

--- a/frontend/src/components/LLMSelection/NvidiaNimOptions/managed.jsx
+++ b/frontend/src/components/LLMSelection/NvidiaNimOptions/managed.jsx
@@ -2,6 +2,6 @@
  * This component is used to select, start, and manage NVIDIA NIM
  * containers and images via docker management tools.
  */
-export default function ManagedNvidiaNimOptions({ settings }) {
+export default function ManagedNvidiaNimOptions({ settings: _settings }) {
   return null;
 }

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
@@ -256,7 +256,7 @@ const WatchForChanges = memo(({ workspace, docPath, item }) => {
   );
 });
 
-const RemoveItemFromWorkspace = ({ item, onClick }) => {
+const RemoveItemFromWorkspace = ({ item: _item, onClick }) => {
   return (
     <div>
       <ArrowUUpLeft

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Chartable/CustomCell.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Chartable/CustomCell.jsx
@@ -1,17 +1,5 @@
 export default function CustomCell({ ...props }) {
-  const {
-    root,
-    depth,
-    x,
-    y,
-    width,
-    height,
-    index,
-    payload,
-    colors,
-    rank,
-    name,
-  } = props;
+  const { root, depth, x, y, width, height, index, colors, name } = props;
   return (
     <g>
       <rect

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -17,7 +17,6 @@ const PromptReply = ({
   error,
   workspace,
   sources = [],
-  closed = true,
 }) => {
   const assistantBackgroundColor = "bg-theme-bg-chat";
 

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/utils.js
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/utils.js
@@ -38,7 +38,7 @@ export function validatedModelSelection(model) {
 
     // If the model is in the dropdown, return the model as is
     return model;
-  } catch (error) {
+  } catch {
     return null; // If the dropdown was empty or something else went wrong, return null to abort the save
   }
 }

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -247,7 +247,7 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
           setLoadingResponse(true);
           try {
             handleSocketResponse(socket, event, setChatHistory);
-          } catch (e) {
+          } catch {
             console.error("Failed to parse data");
             window.dispatchEvent(new CustomEvent(AGENT_SESSION_END));
             socket.close();

--- a/frontend/src/hooks/useProviderEndpointAutoDiscovery.js
+++ b/frontend/src/hooks/useProviderEndpointAutoDiscovery.js
@@ -17,7 +17,7 @@ export default function useProviderEndpointAutoDiscovery({
   const [autoDetectAttempted, setAutoDetectAttempted] = useState(false);
   const [showAdvancedControls, setShowAdvancedControls] = useState(true);
 
-  async function autoDetect(isInitialAttempt = false) {
+  async function autoDetect() {
     setLoading(true);
     setAutoDetectAttempted(true);
     const possibleEndpoints = [];

--- a/frontend/src/locales/normalizeEn.mjs
+++ b/frontend/src/locales/normalizeEn.mjs
@@ -75,7 +75,7 @@ function compareStructures(lang, a, b, subdir = null) {
   }
 }
 
-function normalizeTranslations(lang, source, target, subdir = null) {
+function normalizeTranslations(lang, source, target, _subdir = null) {
   // Handle primitives - if target exists, keep it, otherwise set null
   if (!source || typeof source !== "object") {
     return target ?? null;

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -431,12 +431,11 @@ const System = {
         throw new Error("Failed to fetch pfp.");
       })
       .then((blob) => (blob ? URL.createObjectURL(blob) : null))
-      .catch((e) => {
-        // console.log(e);
+      .catch(() => {
         return null;
       });
   },
-  removePfp: async function (id) {
+  removePfp: async function () {
     return await fetch(`${API_BASE}/system/remove-pfp`, {
       method: "DELETE",
       headers: baseHeaders(),

--- a/frontend/src/models/workspace.js
+++ b/frontend/src/models/workspace.js
@@ -348,7 +348,7 @@ const Workspace = {
         throw new Error("Failed to fetch TTS.");
       })
       .then((blob) => (blob ? URL.createObjectURL(blob) : null))
-      .catch((e) => {
+      .catch(() => {
         return null;
       });
   },
@@ -379,8 +379,7 @@ const Workspace = {
         throw new Error("Failed to fetch pfp.");
       })
       .then((blob) => (blob ? URL.createObjectURL(blob) : null))
-      .catch((e) => {
-        // console.log(e);
+      .catch(() => {
         return null;
       });
   },

--- a/frontend/src/models/workspaceThread.js
+++ b/frontend/src/models/workspaceThread.js
@@ -14,7 +14,7 @@ const WorkspaceThread = {
       }
     )
       .then((res) => res.json())
-      .catch((e) => {
+      .catch(() => {
         return { threads: [] };
       });
 

--- a/frontend/src/pages/Admin/AgentBuilder/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/index.jsx
@@ -48,9 +48,7 @@ export default function AgentBuilder() {
   const [blocks, setBlocks] = useState(DEFAULT_BLOCKS);
   const [selectedBlock, setSelectedBlock] = useState("start");
   const [showBlockMenu, setShowBlockMenu] = useState(false);
-  const [showLoadMenu, setShowLoadMenu] = useState(false);
   const [availableFlows, setAvailableFlows] = useState([]);
-  const [selectedFlowForDetails, setSelectedFlowForDetails] = useState(null);
   const nameRef = useRef(null);
   const descriptionRef = useRef(null);
   const [showPublishModal, setShowPublishModal] = useState(false);
@@ -122,7 +120,6 @@ export default function AgentBuilder() {
       setActive(flow.config.active ?? true);
       setCurrentFlowUuid(flow.uuid);
       setBlocks(flowBlocks);
-      setShowLoadMenu(false);
     } catch (error) {
       console.error(error);
       showToast("Failed to load flow", "error", { clear: true });

--- a/frontend/src/pages/Admin/Agents/Badges/default.jsx
+++ b/frontend/src/pages/Admin/Agents/Badges/default.jsx
@@ -1,4 +1,4 @@
-export function DefaultBadge({ title }) {
+export function DefaultBadge({ title: _title }) {
   return (
     <>
       <span

--- a/frontend/src/pages/Admin/Agents/SQLConnectorSelection/index.jsx
+++ b/frontend/src/pages/Admin/Agents/SQLConnectorSelection/index.jsx
@@ -8,7 +8,6 @@ import Admin from "@/models/admin";
 
 export default function AgentSQLConnectorSelection({
   skill,
-  settings, // unused.
   toggleSkill,
   enabled = false,
   setHasChanges,

--- a/frontend/src/pages/Admin/Workspaces/WorkspaceRow/index.jsx
+++ b/frontend/src/pages/Admin/Workspaces/WorkspaceRow/index.jsx
@@ -3,7 +3,7 @@ import Admin from "@/models/admin";
 import paths from "@/utils/paths";
 import { LinkSimple, Trash } from "@phosphor-icons/react";
 
-export default function WorkspaceRow({ workspace, users }) {
+export default function WorkspaceRow({ workspace, users: _users }) {
   const rowRef = useRef(null);
   const handleDelete = async () => {
     if (

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedChats/MarkdownRenderer.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedChats/MarkdownRenderer.jsx
@@ -12,7 +12,7 @@ const md = new MarkdownIt({
     if (lang && hljs.getLanguage(lang)) {
       try {
         return hljs.highlight(str, { language: lang }).value;
-      } catch (__) {}
+      } catch {}
     }
     return ""; // use external default escaping
   },

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/index.jsx
@@ -2,12 +2,10 @@ import { useState } from "react";
 import Sidebar from "@/components/SettingsSidebar";
 import { isMobile } from "react-device-detect";
 import { CaretLeft, CaretRight } from "@phosphor-icons/react";
-import { useTranslation } from "react-i18next";
 import EmbedConfigsView from "./EmbedConfigs";
 import EmbedChatsView from "./EmbedChats";
 
 export default function ChatEmbedWidgets() {
-  const { t } = useTranslation();
   const [selectedView, setSelectedView] = useState("configs");
   const [showViewModal, setShowViewModal] = useState(false);
 

--- a/frontend/src/pages/GeneralSettings/Chats/MarkdownRenderer.jsx
+++ b/frontend/src/pages/GeneralSettings/Chats/MarkdownRenderer.jsx
@@ -12,7 +12,7 @@ const md = new MarkdownIt({
     if (lang && hljs.getLanguage(lang)) {
       try {
         return hljs.highlight(str, { language: lang }).value;
-      } catch (__) {}
+      } catch {}
     }
     return ""; // use external default escaping
   },

--- a/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
@@ -63,7 +63,7 @@ export default function EmbeddingTextSplitterPreference() {
       setHasChanges(false);
       closeModal();
       showToast("Text chunking strategy settings saved.", "success");
-    } catch (error) {
+    } catch {
       showToast("Failed to save text chunking strategy settings.", "error");
     } finally {
       setSaving(false);

--- a/frontend/src/utils/chat/markdown.js
+++ b/frontend/src/utils/chat/markdown.js
@@ -38,7 +38,7 @@ const markdown = markdownIt({
           hljs.highlight(code, { language: lang, ignoreIllegals: true }).value +
           "</pre></div>"
         );
-      } catch (__) {}
+      } catch {}
     }
 
     return (

--- a/frontend/src/utils/chat/plugins/markdown-katex.js
+++ b/frontend/src/utils/chat/plugins/markdown-katex.js
@@ -33,7 +33,7 @@ function isValidDelim(state, pos) {
 }
 
 function math_inline(state, silent) {
-  var start, match, token, res, pos, esc_count;
+  var start, match, token, res, pos;
 
   // Only process $ and \( delimiters for inline math
   if (

--- a/frontend/src/utils/directories.js
+++ b/frontend/src/utils/directories.js
@@ -13,7 +13,7 @@ export function formatDateTimeAsMoment(dateString, format = "LLL") {
   if (!dateString) return moment().format(format);
   try {
     return moment(dateString).format(format);
-  } catch (error) {
+  } catch {
     return moment().format(format);
   }
 }


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Base PR: #4923 

### What is in this change?

Removes unused variables and parameters across the frontend codebase to satisfy the new ESLint rules:

- **Removed unused function parameters** (e.g., `popMsg`, `showAlert`, `closed`, `settings`, `id`)
- **Prefixed intentionally unused params with `_`** to indicate they're required by an interface but not used (e.g., `settings: _settings`, `item: _item`, `users: _users`)
- **Removed unused caught error variables** in catch blocks (`catch (e)` → `catch`)
- **Removed unused imports** (e.g., `useTranslation` from ChatEmbedWidgets)
- **Removed unused state variables** (e.g., `showLoadMenu`, `selectedFlowForDetails` from AgentBuilder)
- **Cleaned up unused destructured props** (e.g., `payload`, `rank` from CustomCell)

### Additional Information

This is a child PR of the ESLint refactor branch. The `_` prefix pattern follows JavaScript conventions for intentionally unused variables.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally