### PR TITLE
chore: remove unused imports

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef } from "react";
 import { Microphone } from "@phosphor-icons/react";
 import { Tooltip } from "react-tooltip";
-import _regeneratorRuntime from "regenerator-runtime";
+import "regenerator-runtime"; //required polyfill for speech recognition;
 import SpeechRecognition, {
   useSpeechRecognition,
 } from "react-speech-recognition";

--- a/frontend/src/pages/Admin/ExperimentalFeatures/features.js
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/features.js
@@ -1,5 +1,4 @@
 import LiveSyncToggle from "./Features/LiveSync/toggle";
-import paths from "@/utils/paths";
 
 export const configurableFeatures = {
   experimental_live_file_sync: {

--- a/frontend/src/pages/GeneralSettings/AudioPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/AudioPreference/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import { isMobile } from "react-device-detect";
 import Sidebar from "@/components/SettingsSidebar";
 import System from "@/models/system";

--- a/frontend/src/pages/GeneralSettings/Settings/components/SpellCheck/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/SpellCheck/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Appearance from "@/models/appearance";
 import { useTranslation } from "react-i18next";
 


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Base PR: #4923 

### What is in this change?

Removes unused imports flagged by the ESLint `unused-imports` plugin enabled in the parent branch:

- **SpeechToText/index.jsx**: Changed `_regeneratorRuntime` named import to a side-effect import (polyfill only needs to be loaded, not referenced)
- **features.js**: Removed unused `paths` import
- **AudioPreference/index.jsx**: Removed unused `useRef` from React imports
- **SpellCheck/index.jsx**: Removed unused `useEffect` from React imports

### Additional Information

Part of the frontend ESLint cleanup series for #4917.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally