### PR TITLE
fix: add rel=noreferrer to target=_blank links

### DIFF
--- a/frontend/src/pages/Admin/Agents/AgentFlows/index.jsx
+++ b/frontend/src/pages/Admin/Agents/AgentFlows/index.jsx
@@ -14,6 +14,7 @@ export default function AgentFlowsList({
           href="https://docs.anythingllm.com/agent-flows/getting-started"
           target="_blank"
           className="text-theme-text-secondary underline hover:text-cta-button"
+          rel="noreferrer"
         >
           Learn more about Agent Flows.
         </a>

--- a/frontend/src/pages/Admin/Agents/Imported/SkillList/index.jsx
+++ b/frontend/src/pages/Admin/Agents/Imported/SkillList/index.jsx
@@ -16,6 +16,7 @@ export default function ImportedSkillList({
             href="https://docs.anythingllm.com/agent/custom/developer-guide"
             target="_blank"
             className="text-theme-text-secondary underline hover:text-cta-button"
+            rel="noreferrer"
           >
             AnythingLLM Agent Docs
           </a>

--- a/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/toggle.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/toggle.jsx
@@ -69,6 +69,7 @@ export default function LiveSyncToggle({ enabled = false, onToggle }) {
               href="https://docs.anythingllm.com/beta-preview/active-features/live-document-sync"
               target="_blank"
               className="text-sm text-blue-400 light:text-blue-500 hover:underline flex items-center gap-x-1"
+              rel="noreferrer"
             >
               <ArrowSquareOut size={14} />
               <span>Feature Documentation and Warnings</span>

--- a/frontend/src/pages/GeneralSettings/PrivacyAndData/index.jsx
+++ b/frontend/src/pages/GeneralSettings/PrivacyAndData/index.jsx
@@ -105,6 +105,7 @@ function TelemetryLogs({ settings }) {
               href="https://github.com/search?q=repo%3AMintplex-Labs%2Fanything-llm%20.sendTelemetry(&type=code"
               className="underline text-blue-400"
               target="_blank"
+              rel="noreferrer"
             >
               GitHub here
             </a>
@@ -120,6 +121,7 @@ function TelemetryLogs({ settings }) {
               href="mailto:team@mintplexlabs.com"
               className="underline text-blue-400"
               target="_blank"
+              rel="noreferrer"
             >
               team@mintplexlabs.com
             </a>


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Base PR: #4923 

### What is in this change?

This PR fixes ESLint `react/jsx-no-target-blank` violations by adding `rel="noreferrer"` to external links that use `target="_blank"`:

- `src/pages/Admin/Agents/AgentFlows/index.jsx` - Agent Flows documentation link
- `src/pages/Admin/Agents/Imported/SkillList/index.jsx` - Agent Docs link
- `src/pages/Admin/ExperimentalFeatures/Features/LiveSync/toggle.jsx` - Feature documentation link
- `src/pages/GeneralSettings/PrivacyAndData/index.jsx` - GitHub and email links

This prevents a potential security vulnerability where the new page could access `window.opener`.

### Additional Information

These changes are part of the frontend ESLint cleanup effort to enable stricter linting rules.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally