### PR TITLE
fix: resolve react-hooks ESLint errors

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Citation/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Citation/index.jsx
@@ -43,11 +43,12 @@ function combineLikeSources(sources) {
 }
 
 export default function Citations({ sources = [] }) {
-  if (sources.length === 0) return null;
   const [open, setOpen] = useState(false);
   const [selectedSource, setSelectedSource] = useState(null);
   const { t } = useTranslation();
   const { textSizeClass } = useTextSize();
+
+  if (sources.length === 0) return null;
 
   return (
     <div className="flex flex-col mt-4 justify-left">

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/index.jsx
@@ -128,8 +128,8 @@ function CopyMessage({ message }) {
 }
 
 function RegenerateMessage({ regenerateMessage, chatId }) {
-  if (!chatId) return null;
   const { t } = useTranslation();
+  if (!chatId) return null;
   return (
     <div className="mt-3 relative">
       <button

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/refs */
 import { memo, useRef, useEffect } from "react";
 import { Warning } from "@phosphor-icons/react";
 import UserIcon from "../../../../UserIcon";

--- a/frontend/src/components/lib/ModelTable/index.jsx
+++ b/frontend/src/components/lib/ModelTable/index.jsx
@@ -104,28 +104,28 @@ export default function ModelTable({
   );
 }
 
+function DeviceTypeTagWrapper({ text, bgClass, textClass }) {
+  return (
+    <div
+      className={
+        bgClass + " px-1.5 py-1 rounded-full flex items-center gap-x-1 w-fit"
+      }
+    >
+      <Cpu size={14} weight="bold" className={textClass} />
+      <p className={textClass + " text-xs"}>{text}</p>
+    </div>
+  );
+}
+
 /**
  * @param {{deviceType: ModelDefinition["deviceType"]}} deviceType
  * @returns {React.ReactNode}
  */
 function DeviceTypeTag({ deviceType }) {
-  const Wrapper = ({ text, bgClass, textClass }) => {
-    return (
-      <div
-        className={
-          bgClass + " px-1.5 py-1 rounded-full flex items-center gap-x-1 w-fit"
-        }
-      >
-        <Cpu size={14} weight="bold" className={textClass} />
-        <p className={textClass + " text-xs"}>{text}</p>
-      </div>
-    );
-  };
-
   switch (deviceType?.toLowerCase()) {
     case "cpu":
       return (
-        <Wrapper
+        <DeviceTypeTagWrapper
           text="CPU"
           bgClass="bg-zinc-800 light:bg-zinc-200"
           textClass="text-theme-text-primary"
@@ -133,7 +133,7 @@ function DeviceTypeTag({ deviceType }) {
       );
     case "gpu":
       return (
-        <Wrapper
+        <DeviceTypeTagWrapper
           text="GPU"
           bgClass="bg-green-800 light:bg-green-200"
           textClass="text-theme-text-primary"
@@ -141,7 +141,7 @@ function DeviceTypeTag({ deviceType }) {
       );
     case "npu":
       return (
-        <Wrapper
+        <DeviceTypeTagWrapper
           text="NPU"
           bgClass="bg-indigo-800 light:bg-indigo-200"
           textClass="text-theme-text-primary"
@@ -149,7 +149,7 @@ function DeviceTypeTag({ deviceType }) {
       );
     default:
       return (
-        <Wrapper
+        <DeviceTypeTagWrapper
           text="CPU"
           bgClass="bg-zinc-800 light:bg-zinc-200"
           textClass="text-theme-text-primary"

--- a/frontend/src/components/lib/MonoProviderIcon/index.jsx
+++ b/frontend/src/components/lib/MonoProviderIcon/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/static-components */
 // https://lobehub.com/icons for all the icons
 import OpenAI from "@lobehub/icons/es/OpenAI/components/Mono";
 import Anthropic from "@lobehub/icons/es/Anthropic/components/Mono";

--- a/frontend/src/pages/Admin/AgentBuilder/HeaderMenu/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/HeaderMenu/index.jsx
@@ -93,9 +93,9 @@ export default function HeaderMenu({
                 <div className="absolute top-full left-0 mt-1 w-full min-w-[200px] max-w-[350px] bg-theme-settings-input-bg border border-white/10 rounded-md shadow-lg z-50 animate-fadeUpIn">
                   {availableFlows
                     .filter((flow) => flow.uuid !== flowId)
-                    .map((flow) => (
+                    .map((flow, index) => (
                       <button
-                        key={flow?.uuid || Math.random()}
+                        key={flow?.uuid || `flow-${index}`}
                         onClick={() => {
                           navigate(paths.agents.editAgent(flow.uuid));
                           setShowDropdown(false);

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/ApiCallNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/ApiCallNode/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/refs */
 import React, { useRef, useState } from "react";
 import { Plus, X, CaretDown } from "@phosphor-icons/react";
 

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/FlowInfoNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/FlowInfoNode/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/refs */
 import React, { forwardRef } from "react";
 
 const FlowInfoNode = forwardRef(({ config, onConfigChange }, refs) => {


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

Base PR: #4923 

### What is in this change?

This PR fixes ESLint `react-hooks` rule violations in the frontend:

**Hooks called conditionally (rules of hooks violation):**
- `Citation/index.jsx` - Moved early return after all hooks are called
- `HistoricalMessage/Actions/index.jsx` - Moved early return after `useTranslation()` hook

**Component defined inside component:**
- `ModelTable/index.jsx` - Extracted `Wrapper` component out of `DeviceTypeTag` as `DeviceTypeTagWrapper` to avoid recreating the component on each render

**Unstable key usage:**
- `HeaderMenu/index.jsx` - Replaced `Math.random()` fallback key with index-based fallback (`flow-${index}`)

**ESLint disable directives for valid patterns:**
- `PromptReply/index.jsx` - Disabled `react-hooks/refs` for valid ref usage
- `ApiCallNode/index.jsx` - Disabled `react-hooks/refs` for valid ref usage  
- `FlowInfoNode/index.jsx` - Disabled `react-hooks/refs` for forwardRef pattern
- `MonoProviderIcon/index.jsx` - Disabled `react-hooks/static-components` for static icon mapping

### Additional Information

These changes are part of the frontend ESLint cleanup effort to enable stricter linting rules.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally