### PR TITLE
Make `OUTDIR` in Linux installer configurable by accepting an optional `ANYTHING_LLM_INSTALL_DIR` env var

### DIFF
--- a/linux_installer.sh
+++ b/linux_installer.sh
@@ -17,7 +17,7 @@ fi
 APPIMAGE_URL="https://cdn.anythingllm.com/latest/AnythingLLMDesktop.AppImage"
 APPIMAGE_FILE="AnythingLLMDesktop.AppImage"
 EXTRACTED_DIR="anythingllm-desktop"
-OUTDIR="$HOME/AnythingLLMDesktop"
+OUTDIR="${ANYTHING_LLM_INSTALL_DIR:-$HOME/AnythingLLMDesktop}"
 
 rm -rf $OUTDIR
 mkdir -p $OUTDIR


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

N/A


### What is in this change?

Added an optional env var `ANYTHING_LLM_INSTALL_DIR` (maybe someone could suggest a better name) to the Linux installer to be able to select the install path (I personally don't want an app to install itself into $HOME...)


### Additional Information

N/A

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated: https://github.com/Mintplex-Labs/anythingllm-docs/pull/210
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
