### PR TITLE
Fix pending chat indicator rerendering when typing in input

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -32,7 +32,6 @@ const MAX_EDIT_STACK_SIZE = 100;
 
 export default function PromptInput({
   submit,
-  onChange,
   isStreaming,
   sendCommand,
   attachments = [],
@@ -51,7 +50,6 @@ export default function PromptInput({
 
   // Synchronizes prompt input value with localStorage, scoped to the current thread.
   usePromptInputStorage({
-    onChange,
     promptInput,
     setPromptInput,
   });
@@ -228,7 +226,6 @@ export default function PromptInput({
         pasteText +
         promptInput.substring(end);
       setPromptInput(newPromptInput);
-      onChange({ target: { value: newPromptInput } });
 
       // Set the cursor position after the pasted text
       // we need to use setTimeout to prevent the cursor from being set to the end of the text
@@ -243,7 +240,6 @@ export default function PromptInput({
 
   function handleChange(e) {
     debouncedSaveState(-1);
-    onChange(e);
     watchForSlash(e);
     watchForAt(e);
     adjustTextArea(e);

--- a/frontend/src/hooks/usePromptInputStorage.js
+++ b/frontend/src/hooks/usePromptInputStorage.js
@@ -20,16 +20,11 @@ import { safeJsonParse } from "@/utils/request";
  * ```
  *
  * @param {Object} props
- * @param {Function} props.onChange - Callback invoked when restoring saved value, receives `{ target: { value: string } }`
  * @param {string} props.promptInput - Current prompt input value to sync
  * @param {Function} props.setPromptInput - State setter function for prompt input
  * @returns {void}
  */
-export default function usePromptInputStorage({
-  onChange,
-  promptInput,
-  setPromptInput,
-}) {
+export default function usePromptInputStorage({ promptInput, setPromptInput }) {
   const { threadSlug = null, slug: workspaceSlug } = useParams();
   useEffect(() => {
     const serializedPromptInputMap =
@@ -40,8 +35,6 @@ export default function usePromptInputStorage({
     const userPromptInputValue = promptInputMap[threadSlug ?? workspaceSlug];
     if (userPromptInputValue) {
       setPromptInput(userPromptInputValue);
-      // Notify parent component so message state is synchronized
-      onChange({ target: { value: userPromptInputValue } });
     }
   }, []);
 


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4938 

 - Fixes the pending chat indicator (3 dot animation) rerendering/flickering when typing in the input while waiting for a 
  response
- `message` state in ChatContainer was updating on every keystroke, causing unnecessary rerenders of the _entire chat history_ including the pending indicator (pending indicator was the only visible bug but the entire history was actually rerendering)
- Removed redundant `message` state sync since PromptInput already maintains its own local state and now reads from DOM on submit instead

### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

- [x] Sent regular chat and no longer rerenders 3 dot animation while message is pending
- [x] Test STT in both auto submit and append mode
- [x] Localstorage draft messages store properly
- [x] Slash commands pops up on `/` typed into chat input
- [x] Agent meny pops up on `@` typed into chat input
- [x] Pasted text pastes properly
- [x] Undo/redo works properly
- [x] Enter to submit chat, shift + enter creates new line

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
