### PR TITLE
feat: add system theme + rename default to dark

### DIFF
--- a/frontend/src/LogoContext.jsx
+++ b/frontend/src/LogoContext.jsx
@@ -4,6 +4,7 @@ import AnythingLLMDark from "./media/logo/anything-llm-dark.png";
 import DefaultLoginLogoLight from "./media/illustrations/login-logo.svg";
 import DefaultLoginLogoDark from "./media/illustrations/login-logo-light.svg";
 import System from "./models/system";
+import { getResolvedThemeFromStorage } from "./utils/theme";
 
 export const REFETCH_LOGO_EVENT = "refetch-logo";
 export const LogoContext = createContext();
@@ -12,12 +13,12 @@ export function LogoProvider({ children }) {
   const [logo, setLogo] = useState("");
   const [loginLogo, setLoginLogo] = useState("");
   const [isCustomLogo, setIsCustomLogo] = useState(false);
-  const DefaultLoginLogo =
-    localStorage.getItem("theme") !== "default"
-      ? DefaultLoginLogoDark
-      : DefaultLoginLogoLight;
 
   async function fetchInstanceLogo() {
+    const resolvedTheme = getResolvedThemeFromStorage();
+    const DefaultLoginLogo =
+      resolvedTheme !== "light" ? DefaultLoginLogoDark : DefaultLoginLogoLight;
+
     try {
       const { isCustomLogo, logoURL } = await System.fetchLogo();
       if (logoURL) {
@@ -25,14 +26,14 @@ export function LogoProvider({ children }) {
         setLoginLogo(isCustomLogo ? logoURL : DefaultLoginLogo);
         setIsCustomLogo(isCustomLogo);
       } else {
-        localStorage.getItem("theme") !== "default"
+        resolvedTheme !== "light"
           ? setLogo(AnythingLLMDark)
           : setLogo(AnythingLLM);
         setLoginLogo(DefaultLoginLogo);
         setIsCustomLogo(false);
       }
     } catch (err) {
-      localStorage.getItem("theme") !== "default"
+      resolvedTheme !== "light"
         ? setLogo(AnythingLLMDark)
         : setLogo(AnythingLLM);
       setLoginLogo(DefaultLoginLogo);

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -1,5 +1,6 @@
 import { API_BASE, AUTH_TIMESTAMP, fullApiUrl } from "@/utils/constants";
 import { baseHeaders, safeJsonParse } from "@/utils/request";
+import { getResolvedThemeFromStorage } from "@/utils/theme";
 import DataConnector from "./dataConnector";
 import LiveDocumentSync from "./experimental/liveSync";
 import AgentPlugins from "./experimental/agentPlugins";
@@ -423,10 +424,7 @@ const System = {
   },
   fetchLogo: async function () {
     const url = new URL(`${fullApiUrl()}/system/logo`);
-    url.searchParams.append(
-      "theme",
-      localStorage.getItem("theme") || "default"
-    );
+    url.searchParams.append("theme", getResolvedThemeFromStorage());
 
     return await fetch(url, {
       method: "GET",

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/CodeSnippetModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/CodeSnippetModal/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { CheckCircle, CopySimple, X } from "@phosphor-icons/react";
 import showToast from "@/utils/toast";
+import { getResolvedThemeFromStorage } from "@/utils/theme";
 import hljs from "highlight.js";
 import "@/utils/chat/themes/github-dark.css";
 import "@/utils/chat/themes/github.css";
@@ -68,7 +69,7 @@ const ScriptTag = ({ embed }) => {
     : window.location.origin;
   const snippet = createScriptTagSnippet(embed, scriptHost, serverHost);
   const theme =
-    window.localStorage.getItem("theme") === "light" ? "github" : "github-dark";
+    getResolvedThemeFromStorage() === "light" ? "github" : "github-dark";
 
   const handleClick = () => {
     window.navigator.clipboard.writeText(snippet);

--- a/frontend/src/utils/chat/markdown.js
+++ b/frontend/src/utils/chat/markdown.js
@@ -6,6 +6,7 @@ import hljs from "highlight.js";
 import "./themes/github-dark.css";
 import "./themes/github.css";
 import { v4 } from "uuid";
+import { getResolvedThemeFromStorage } from "@/utils/theme";
 
 // Register custom lanaguages
 import hljsDefineSvelte from "./hljs-libraries/svelte";
@@ -17,9 +18,7 @@ const markdown = markdownIt({
   highlight: function (code, lang) {
     const uuid = v4();
     const theme =
-      window.localStorage.getItem("theme") === "light"
-        ? "github"
-        : "github-dark";
+      getResolvedThemeFromStorage() === "light" ? "github" : "github-dark";
 
     if (lang && hljs.getLanguage(lang)) {
       try {

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -1,0 +1,38 @@
+const THEME_STORAGE_KEY = "theme";
+
+export const THEME_OPTIONS = Object.freeze({
+  system: "System",
+  dark: "Dark",
+  light: "Light",
+});
+
+export function normalizeThemeSetting(value) {
+  if (value === "default") return "dark"; 
+  if (value === "system" || value === "dark" || value === "light") return value;
+  return "system";
+}
+
+export function getSystemTheme() {
+  if (!window?.matchMedia) return "dark";
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+export function resolveTheme(themeSetting) {
+  const normalized = normalizeThemeSetting(themeSetting);
+  return normalized === "system" ? getSystemTheme() : normalized;
+}
+
+export function getStoredThemeSetting() {
+  try {
+    return normalizeThemeSetting(window?.localStorage?.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return "system";
+  }
+}
+
+export function getResolvedThemeFromStorage() {
+  return resolveTheme(getStoredThemeSetting());
+}
+

--- a/frontend/src/utils/toast.js
+++ b/frontend/src/utils/toast.js
@@ -1,10 +1,11 @@
 import { toast } from "react-toastify";
+import { getResolvedThemeFromStorage } from "@/utils/theme";
 
 // Additional Configs (opts)
 // You can also pass valid ReactToast params to override the defaults.
 // clear: false, // Will dismiss all visible toasts before rendering next toast
 const showToast = (message, type = "default", opts = {}) => {
-  const theme = localStorage?.getItem("theme") || "default";
+  const resolvedTheme = getResolvedThemeFromStorage();
   const options = {
     position: "bottom-center",
     autoClose: 5000,
@@ -12,7 +13,7 @@ const showToast = (message, type = "default", opts = {}) => {
     closeOnClick: true,
     pauseOnHover: true,
     draggable: true,
-    theme: theme === "default" ? "dark" : "light",
+    theme: resolvedTheme === "light" ? "light" : "dark",
     ...opts,
   };
 

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -656,8 +656,8 @@ function systemEndpoints(app) {
 
   app.get("/system/logo", async function (request, response) {
     try {
-      const darkMode =
-        !request?.query?.theme || request?.query?.theme === "default";
+      const theme = request?.query?.theme;
+      const darkMode = !theme || theme === "default" || theme === "dark";
       const defaultFilename = getDefaultFilename(darkMode);
       const logoPath = await determineLogoFilepath(defaultFilename);
       const { found, buffer, size, mime } = fetchLogo(logoPath);


### PR DESCRIPTION
### Pull Request Type
[x] ✨ feat

### Relevant Issues

resolves : #4945

### What is in this change?

- Adds a System (auto) theme option that follows the OS color scheme and updates live on OS theme changes.
- Renames the Default theme to Dark, keeping backward compatibility for previously saved "default" theme values.
- Updates theme-dependent UI behaviors (logo selection, toast styling, code highlighting) to use the resolved light/dark theme when System is selected.

### Additional Information
- None

### Developer Validations

[ ] I ran yarn lint from the root of the repo & committed changes
[ ] Relevant documentation has been updated
[ ] I have tested my code functionality
[ ] Docker build succeeds locally