### PR TITLE
Fix Sidebar Clipping When Closed

### DIFF
--- a/frontend/src/components/Sidebar/SidebarToggle/index.jsx
+++ b/frontend/src/components/Sidebar/SidebarToggle/index.jsx
@@ -75,7 +75,7 @@ export function ToggleSidebarButton({ showSidebar, setShowSidebar }) {
     <>
       <button
         type="button"
-        className={`hidden md:block border-none bg-transparent outline-none ring-0 transition-left duration-500 ${showSidebar ? "left-[247px]" : "absolute top-[20px] left-[30px] z-10"}`}
+        className={`hidden md:block border-none bg-transparent outline-none ring-0 absolute transition-all duration-500 z-10 ${showSidebar ? "top-[18px] left-[248px]" : "top-[20px] left-[30px]"}`}
         onClick={() => setShowSidebar((prev) => !prev)}
         data-tooltip-id="sidebar-toggle"
         data-tooltip-content={

--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -34,39 +34,41 @@ export default function Sidebar() {
           width: showSidebar ? "292px" : "0px",
           paddingLeft: showSidebar ? "0px" : "16px",
         }}
-        className="transition-all duration-500"
+        className="relative transition-all duration-500"
       >
-        <div className="flex shrink-0 w-full justify-center my-[18px]">
-          <div className="flex justify-between w-[250px] min-w-[250px]">
-            <Link to={paths.home()} aria-label="Home">
-              <img
-                src={logo}
-                alt="Logo"
-                className={`rounded max-h-[24px] object-contain transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
-              />
-            </Link>
-            {canToggleSidebar && (
-              <ToggleSidebarButton
-                showSidebar={showSidebar}
-                setShowSidebar={setShowSidebar}
-              />
-            )}
+        {canToggleSidebar && (
+          <ToggleSidebarButton
+            showSidebar={showSidebar}
+            setShowSidebar={setShowSidebar}
+          />
+        )}
+        <div className="overflow-hidden h-full">
+          <div className="flex shrink-0 w-full justify-center my-[18px]">
+            <div className="flex w-[250px] min-w-[250px]">
+              <Link to={paths.home()} aria-label="Home">
+                <img
+                  src={logo}
+                  alt="Logo"
+                  className={`rounded max-h-[24px] object-contain transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
+                />
+              </Link>
+            </div>
           </div>
-        </div>
-        <div
-          ref={sidebarRef}
-          className="relative m-[16px] rounded-[16px] bg-theme-bg-sidebar border-[2px] border-theme-sidebar-border light:border-none min-w-[250px] p-[10px] h-[calc(100%-76px)]"
-        >
-          <div className="flex flex-col h-full overflow-hidden">
-            <div className="flex-grow flex flex-col min-w-[235px] min-h-0">
-              <div className="relative h-[calc(100%-60px)] flex flex-col w-full justify-between pt-[10px] overflow-y-scroll no-scroll">
-                <div className="flex flex-col gap-y-[14px]">
-                  <SearchBox user={user} showNewWsModal={showNewWsModal} />
-                  <ActiveWorkspaces />
+          <div
+            ref={sidebarRef}
+            className="relative m-[16px] rounded-[16px] bg-theme-bg-sidebar border-[2px] border-theme-sidebar-border light:border-none min-w-[250px] p-[10px] h-[calc(100%-76px)]"
+          >
+            <div className="flex flex-col h-full overflow-hidden">
+              <div className="flex-grow flex flex-col min-w-[235px] min-h-0">
+                <div className="relative h-[calc(100%-60px)] flex flex-col w-full justify-between pt-[10px] overflow-y-scroll no-scroll">
+                  <div className="flex flex-col gap-y-[14px]">
+                    <SearchBox user={user} showNewWsModal={showNewWsModal} />
+                    <ActiveWorkspaces />
+                  </div>
                 </div>
-              </div>
-              <div className="absolute bottom-0 left-0 right-0 pb-3 rounded-b-[16px] bg-theme-bg-sidebar bg-opacity-80 backdrop-filter backdrop-blur-md z-10">
-                <Footer />
+                <div className="absolute bottom-0 left-0 right-0 pb-3 rounded-b-[16px] bg-theme-bg-sidebar bg-opacity-80 backdrop-filter backdrop-blur-md z-10">
+                  <Footer />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4969 


### What is in this change?

### Before
https://github.com/user-attachments/assets/5f225906-dd7e-4c50-b731-cd577582160b


### After
https://github.com/user-attachments/assets/a5cfb43c-0e39-48eb-b885-0387080fdd46



<!-- Describe the changes in this PR that are impactful to the repo. -->
  Sidebar (index.jsx):
  - Added relative to the outer sidebar wrapper to serve as the positioning anchor for the toggle button
  - Wrapped the logo area and sidebar panel in a new overflow-hidden h-full inner div — this clips the sidebar content (including the
  absolutely-positioned footer) when the sidebar collapses to width: 0
  - Moved the ToggleSidebarButton outside the overflow container so it's never clipped during open/close transitions
  - Removed justify-between from the logo row since the toggle button is no longer a child of it

  SidebarToggle (SidebarToggle/index.jsx):
  - Toggle button is now always absolute positioned (previously only absolute when sidebar was closed)
  - Transitions smoothly between left-[248px] (open) and left-[30px] (closed) using transition-all

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
