### PR TITLE
fix(frontend): fix event listener memory leak in useIsDisabled hook

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -360,20 +360,15 @@ function useIsDisabled() {
    */
   useEffect(() => {
     if (!window) return;
-    window.addEventListener(ATTACHMENTS_PROCESSING_EVENT, () =>
-      setIsDisabled(true)
-    );
-    window.addEventListener(ATTACHMENTS_PROCESSED_EVENT, () =>
-      setIsDisabled(false)
-    );
+    const onProcessing = () => setIsDisabled(true);
+    const onProcessed = () => setIsDisabled(false);
+
+    window.addEventListener(ATTACHMENTS_PROCESSING_EVENT, onProcessing);
+    window.addEventListener(ATTACHMENTS_PROCESSED_EVENT, onProcessed);
 
     return () => {
-      window?.removeEventListener(ATTACHMENTS_PROCESSING_EVENT, () =>
-        setIsDisabled(true)
-      );
-      window?.removeEventListener(ATTACHMENTS_PROCESSED_EVENT, () =>
-        setIsDisabled(false)
-      );
+      window.removeEventListener(ATTACHMENTS_PROCESSING_EVENT, onProcessing);
+      window.removeEventListener(ATTACHMENTS_PROCESSED_EVENT, onProcessed);
     };
   }, []);
 


### PR DESCRIPTION
## Description

Fixes a subtle but real event listener memory leak in the [useIsDisabled](cci:1://file:///c:/Users/hp/Documents/Work/git%20forked/anything-llm/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx:348:0-375:1) 
hook inside [PromptInput](cci:1://file:///c:/Users/hp/Documents/Work/git%20forked/anything-llm/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx:32:0-346:1).

## Problem
useIsDisabled registers two event listeners (`ATTACHMENTS_PROCESSING_EVENT` 
and `ATTACHMENTS_PROCESSED_EVENT`) on `window` inside a `useEffect`. The 
cleanup function in the `return` of the effect was calling 
`removeEventListener` with **new inline arrow functions** — not the same 
function references that were originally passed to `addEventListener`.

Since `removeEventListener` identifies handlers by reference equality, 
passing a different function instance means the cleanup **is a no-op** — 
the original listeners are never removed.

```js
// Before — broken cleanup (new arrow functions ≠ original handlers)
window.addEventListener(ATTACHMENTS_PROCESSING_EVENT, () => setIsDisabled(true));
return () => {
  window.removeEventListener(ATTACHMENTS_PROCESSING_EVENT, () => setIsDisabled(true)); // ❌
};

// After — correct cleanup
const onProcessing = () => setIsDisabled(true);
const onProcessed = () => setIsDisabled(false);

window.addEventListener(ATTACHMENTS_PROCESSING_EVENT, onProcessing);
window.addEventListener(ATTACHMENTS_PROCESSED_EVENT, onProcessed);

return () => {
  window.removeEventListener(ATTACHMENTS_PROCESSING_EVENT, onProcessing); // ✅
  window.removeEventListener(ATTACHMENTS_PROCESSED_EVENT, onProcessed);   // ✅
};