### PR TITLE
fix: add password character validation to onboarding single-user setup

### DIFF
--- a/frontend/src/pages/GeneralSettings/Security/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Security/index.jsx
@@ -199,7 +199,7 @@ function MultiUserMode() {
   );
 }
 
-const PW_REGEX = new RegExp(/^[a-zA-Z0-9_\-!@$%^&*();]+$/);
+export const PW_REGEX = new RegExp(/^[a-zA-Z0-9_\-!@$%^&*();]+$/);
 function PasswordProtection() {
   const [saving, setSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);

--- a/frontend/src/pages/OnboardingFlow/Steps/UserSetup/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/UserSetup/index.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { AUTH_TIMESTAMP, AUTH_TOKEN, AUTH_USER } from "@/utils/constants";
 import { useTranslation } from "react-i18next";
 import { USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH } from "@/utils/username";
+import { PW_REGEX } from "@/pages/GeneralSettings/Security";
 
 export default function UserSetup({ setHeader, setForwardBtn, setBackBtn }) {
   const { t } = useTranslation();
@@ -118,7 +119,6 @@ const JustMe = ({
   const { t } = useTranslation();
   const [itemSelected, setItemSelected] = useState(false);
   const [password, setPassword] = useState("");
-  const PW_REGEX = /^[a-zA-Z0-9_\-!@$%^&*();]+$/;
   const handleSubmit = async (e) => {
     e.preventDefault();
     const form = e.target;


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5036

### Description

The onboarding single-user password form was missing the same character validation that exists on the Security settings page. Passwords containing `#` (and other restricted characters) were accepted during onboarding but silently truncated when written to the `.env` file by `sanitizeValue()`, since `#` denotes comments in `.env` files. After a server restart, the truncated `AUTH_TOKEN` is loaded and the user's original password no longer matches — leaving the instance fully exposed with no working authentication.

This adds the same `PW_REGEX` check (`/^[a-zA-Z0-9_\-!@$%^&*();]+$/`) already used in the Security settings page and the backend `noRestrictedChars()` validation to the onboarding password form, rejecting invalid characters with a toast error before submission.

### Additional Information

Steps to reproduce the original bug:
1. Go to onboarding
2. When it asks who the instance is for, choose "Just myself"
3. Choose to set up a password
4. Enter a password with a `#` character such as `Password123!@#`
5. Navigate to home
6. Go to Settings > Security
7. Notice password mode is disabled
8. Navigate home
9. Click avatar and logout — notice how it doesn't redirect you to login. The instance is fully exposed even though it looked like it was protected.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally