### PR TITLE
fix: only scroll active sidebar items into view when not already visible

### DIFF
--- a/frontend/src/hooks/useScrollActiveItemIntoView.js
+++ b/frontend/src/hooks/useScrollActiveItemIntoView.js
@@ -1,6 +1,19 @@
 import { useEffect, useRef } from "react";
 
 /**
+ * Walks up the DOM tree from `el` to find the nearest ancestor
+ * that is actually scrollable (i.e. its content overflows).
+ */
+function findScrollableParent(el) {
+  let node = el.parentElement;
+  while (node && node !== document.body) {
+    if (node.scrollHeight > node.clientHeight) return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
  * Hook that scrolls an element into view when it becomes active.
  * @param {Object} options - The options for the hook.
  * @param {boolean} options.isActive - Whether the element is currently active.
@@ -16,8 +29,25 @@ export default function useScrollActiveItemIntoView({
   const ref = useRef(null);
 
   useEffect(() => {
-    if (isActive) {
-      ref.current.scrollIntoView({
+    if (isActive && ref.current) {
+      const el = ref.current;
+
+      // Skip scrolling if the element is already fully visible within its
+      // scrollable container. This prevents the sidebar from jumping when
+      // the active item is already in view.
+      // Walk up the DOM to find the nearest ancestor that actually scrolls
+      // (scrollHeight > clientHeight), rather than matching by class name,
+      // so this works regardless of how the scroll container is styled.
+      const scrollParent = findScrollableParent(el);
+      if (scrollParent) {
+        const parentRect = scrollParent.getBoundingClientRect();
+        const elRect = el.getBoundingClientRect();
+        const isVisible =
+          elRect.top >= parentRect.top && elRect.bottom <= parentRect.bottom;
+        if (isVisible) return;
+      }
+
+      el.scrollIntoView({
         behavior,
         block,
       });


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #4992

### Description

Active sidebar items (workspace threads and settings menu options) would always scroll into center view on mount, causing jarring jumps even when the item was already visible in the scroll container.

This fix updates the `useScrollActiveItemIntoView` hook to check if the element is already fully visible within its nearest scrollable ancestor before calling `scrollIntoView`. It walks the DOM tree to find the actual scrollable parent (via `scrollHeight > clientHeight`) rather than matching by class name, making it work correctly across both the thread sidebar and settings sidebar (which has nested scroll containers).

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally