### PR TITLE
Add CLAUDE.md with codebase guidance for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-AnythingLLM is an all-in-one AI application for chatting with documents using off-the-shelf LLMs. It's a monorepo with three main services that run independently but work together.
+AnythingLLM is an all-in-one AI application for chatting with documents using off-the-shelf LLMs. It's a monorepo with three services that run independently but work together: a React frontend, an Express backend, and a document processing collector.
 
 ## Commands
 
@@ -15,7 +15,7 @@ All commands run from the repo root using **Yarn**.
 yarn setup          # First-time setup: install deps, copy .env files, setup DB
 yarn dev:server     # Start backend (port 3001)
 yarn dev:frontend   # Start frontend (port 3000)
-yarn dev:collector  # Start document collector
+yarn dev:collector  # Start document collector (port 8888)
 yarn dev:all        # Start all three services concurrently
 ```
 
@@ -32,14 +32,13 @@ yarn lint           # Run Prettier across server, frontend, and collector
 
 ### Testing
 ```bash
-yarn test           # Run all Jest tests
-```
-Tests live in `server/__tests__/` and `collector/__tests__/`. Jest ignores `*.test.js` files in ESLint. To run a single test file:
-```bash
+yarn test           # Run all Jest tests (root)
+# Run a single test file:
 cd server && npx jest __tests__/utils/yourTest.test.js
 ```
+Test files live in `server/__tests__/` and `collector/__tests__/`. ESLint ignores `*.test.js` files.
 
-### Database (Prisma — run from repo root)
+### Database (Prisma)
 ```bash
 yarn prisma:setup     # generate + migrate + seed (first-time)
 yarn prisma:generate  # Regenerate Prisma client after schema changes
@@ -52,66 +51,195 @@ yarn prisma:reset     # Truncate DB and re-migrate
 
 ### Three Services
 
-| Service | Directory | Port | Role |
-|---------|-----------|------|------|
-| Server  | `server/` | 3001 | Express.js REST API + WebSocket backend |
-| Frontend | `frontend/` | 3000 | React + Vite UI |
-| Collector | `collector/` | — | Document ingestion & processing microservice |
+| Service   | Directory    | Port | Role |
+|-----------|--------------|------|------|
+| Server    | `server/`    | 3001 | Express.js REST API + WebSocket backend |
+| Frontend  | `frontend/`  | 3000 | React + Vite UI |
+| Collector | `collector/` | 8888 | Document ingestion & processing microservice |
 
-**Data flow**: Frontend → Server REST API → Collector (for document processing) → Vector DB + LLM providers.
+**Data flow:**
+```
+User → Frontend → Server REST API → Collector (document processing)
+                                  → LLM Provider (chat/embeddings)
+                                  → Vector DB (similarity search)
+```
 
-### Server (`server/`)
+---
 
-- **Framework**: Express.js (Node ≥18)
-- **Database**: Prisma ORM over SQLite (default). Schema at `server/prisma/schema.prisma`. DB file at `server/storage/anythingllm.db`.
-- **Key directories**:
-  - `endpoints/` — Route handlers (workspaces, chat, admin, API, embed, extensions, MCP, etc.)
-  - `models/` — Prisma-backed data models (workspace, user, vectors, documents, chats, etc.)
-  - `utils/AiProviders/` — LLM provider integrations (30+ providers)
-  - `utils/EmbeddingEngines/` — Embedding provider integrations
-  - `utils/vectorDbProviders/` — Vector database integrations (Pinecone, Chroma, LanceDB, Qdrant, Weaviate, Milvus, etc.)
-  - `utils/agents/` — AI agent framework
-  - `utils/MCP/` — Model Context Protocol (MCP) support
-  - `utils/TextSplitter/` — Document chunking
-  - `utils/chats/` — Chat session logic
-  - `jobs/` — Background jobs (Bree scheduler)
-- **Auth**: JWT tokens + bcryptjs password hashing
-- **Logging**: Winston
+## Server (`server/`)
 
-### Frontend (`frontend/`)
+**Framework:** Express.js (Node ≥18), Prisma ORM, SQLite by default.
 
-- **Framework**: React 18 + Vite
-- **Styling**: Tailwind CSS
-- **Key directories**:
-  - `src/components/` — Shared UI components
-  - `src/pages/` — Route-level page components
-  - `src/hooks/` — Custom React hooks
-  - `src/models/` — Frontend data/API models
-  - `src/utils/` — Utility functions
-  - `src/locales/` — i18n translation files (i18next)
-- **ESLint**: Uses `ft-flow` (Flow type annotations) and `hermes-eslint` parser
+**DB file:** `server/storage/anythingllm.db`
+**Processed documents:** `server/storage/documents/`
 
-### Collector (`collector/`)
+### Key directories
 
-- **Framework**: Express.js (Node ≥18)
-- **Role**: Handles file uploads and link scraping — converts documents to text chunks, then passes to server for embedding
-- **Supported formats**: PDF, DOCX, XLSX, EPUB, TXT, HTML, email (mbox), images (Tesseract OCR), audio, YouTube transcripts
-- **Web scraping**: Puppeteer + Cheerio
+| Path | Purpose |
+|------|---------|
+| `endpoints/` | Route handlers (workspaces, chat, admin, API, embed, MCP, etc.) |
+| `models/` | Prisma-backed data models |
+| `utils/AiProviders/` | 30+ LLM provider integrations |
+| `utils/EmbeddingEngines/` | Embedding provider integrations |
+| `utils/vectorDbProviders/` | Vector DB integrations (LanceDB default, Pinecone, Chroma, Qdrant, etc.) |
+| `utils/agents/` | AI agent framework |
+| `utils/MCP/` | Model Context Protocol support |
+| `utils/TextSplitter/` | Document chunking |
+| `utils/chats/` | Full chat pipeline (stream.js is the core) |
+| `utils/helpers/index.js` | Provider factory functions |
+| `jobs/` | Background jobs (Bree scheduler) |
+| `prisma/schema.prisma` | Database schema |
 
-## Environment Setup
+### Provider pattern
 
-Each service has its own `.env` file. On first run, `yarn setup` copies `.env.example` files:
-- `server/.env.development` (from `server/.env.example`) — LLM providers, vector DBs, auth keys
-- `frontend/.env` (from `frontend/.env.example`)
-- `collector/.env` (from `collector/.env.example`)
+LLM providers, embedding engines, and vector DBs all use a factory + class pattern:
 
-Node version: **18.18.0** (see `.nvmrc`).
+```js
+// Select provider
+const LLMConnector = getLLMProvider(workspace?.chatProvider);
+const VectorDb = getVectorDbClass();
+const Embedder = getEmbeddingEngineSelection();
+```
 
-## Key Patterns
+Each LLM provider class implements: `getChatCompletion()`, `streamGetChatCompletion()`, `embedChunks()`, `compressMessages()`, `promptWindowLimit()`.
 
-- **LLM providers** are dynamically loaded from `server/utils/AiProviders/` — each provider exports a class with a standard interface (chat, streamChat, etc.)
-- **Vector DB providers** follow the same pattern in `server/utils/vectorDbProviders/`
-- **Workspaces** are the core unit of organization — users chat within workspaces, each workspace has its own document collection and vector store namespace
-- **Multi-user mode** is a Docker-only feature; single-user mode is the default for bare-metal installs
-- **MCP servers** are configurable per-workspace via `server/utils/MCP/`
-- Code formatting is enforced by Prettier (configured in `.prettierrc`); linting uses ESLint flat config (`eslint.config.js`)
+Each vector DB class implements: `performSimilaritySearch()`, `addDocumentToNamespace()`, `deleteDocumentFromNamespace()`, `hasNamespace()`.
+
+### Chat pipeline (`utils/chats/stream.js`)
+
+1. Parse slash commands → early exit if built-in command
+2. Check agent mode → delegate to agent flow if enabled
+3. Gather context: chat history + pinned docs + parsed files + vector similarity search
+4. If `chatMode == "query"` and no context found → return refusal
+5. Assemble messages, compress to fit token budget (history 15% / system 15% / user 70%)
+6. Stream from LLM provider via SSE (`writeResponseChunk()`)
+7. Save result to `workspace_chats` table
+
+**Response format (Server-Sent Events):**
+```js
+{
+  uuid, type, textResponse,
+  sources: [{ text, metadata, score }],
+  metrics: { prompt_tokens, completion_tokens, duration, outputTps },
+  close, error
+}
+```
+
+### Key data models
+
+- **Workspace** — core unit; maps to a vector DB namespace (`slug`). Holds LLM/embedding settings, system prompt, `chatMode` ("chat" or "query"), `topN`, `similarityThreshold`.
+- **WorkspaceChats** — all messages per workspace (and per user in multi-user mode).
+- **WorkspaceThread** — conversation branches within a workspace.
+- **workspace_documents** — documents attached to a workspace.
+- **document_vectors** — maps document chunks to vector IDs in the vector DB.
+- **User** — multi-user support (admin / manager / default roles), daily message limits.
+
+### Multi-user mode
+
+Multi-user is Docker-only (not bare-metal). In single-user mode all data is visible. In multi-user mode workspaces are access-controlled per user via `workspace_users`. Middleware: `flexUserRoleValid([ROLES.admin, ROLES.manager])`.
+
+---
+
+## Frontend (`frontend/`)
+
+**Framework:** React 18 + Vite, Tailwind CSS, React Router v6 (lazy-loaded routes), i18next (28 languages).
+
+### Structure
+
+| Path | Purpose |
+|------|---------|
+| `src/pages/` | Route-level page components |
+| `src/components/` | 32 shared UI component directories |
+| `src/hooks/` | 26 custom React hooks |
+| `src/models/` | API communication layer (one file per domain) |
+| `src/locales/` | i18n translation files |
+| `src/App.jsx` | Root wrapper with context providers |
+| `src/main.jsx` | Full routing configuration |
+
+### Contexts
+- `AuthContext` — JWT auth state
+- `ThemeContext` — dark/light mode
+- `LogoContext` — custom branding
+- `PWAContext` — progressive web app mode
+
+### API communication
+
+All API calls go through model files in `src/models/`. Pattern:
+
+```js
+// workspace.js example
+static async streamChat({ slug }, message, handleChat, attachments) {
+  const response = await fetch(`/api/workspace/${slug}/stream-chat`, {
+    method: "POST",
+    headers: baseHeaders(),        // injects JWT
+    body: JSON.stringify({ message, attachments })
+  });
+  // SSE event parsing...
+}
+```
+
+Key hooks: `useGetProvidersModels` (fetch available LLM models), `useProviderEndpointAutoDiscovery` (auto-detect local providers), `useChatHistoryScrollHandle`.
+
+---
+
+## Collector (`collector/`)
+
+**Framework:** Express.js (port 8888). Converts files and URLs into JSON documents for embedding.
+
+### Endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /process` | Process uploaded file → save JSON doc |
+| `POST /parse` | Preview file without saving (parseOnly mode) |
+| `POST /process-link` | Scrape URL → save JSON doc |
+| `POST /util/get-link` | Fetch URL content (html/text/json) |
+| `POST /process-raw-text` | Process raw text string |
+| `GET /accepts` | List supported MIME types |
+
+### File handlers (`processSingleFile/convert/`)
+
+Each handler follows the same contract: `{ fullFilePath, filename, options, metadata } → { success, reason, documents[] }`.
+
+| Handler | Formats |
+|---------|---------|
+| `asTxt.js` | .txt, .md, .csv, .json, .html, .org, .rst |
+| `asPDF/` | .pdf (with OCR fallback via Tesseract) |
+| `asDocx.js` | .docx |
+| `asXlsx.js` | .xlsx |
+| `asOfficeMime.js` | .pptx, .odt |
+| `asEPub.js` | .epub |
+| `asMbox.js` | .mbox (email) |
+| `asAudio.js` | .mp3, .wav, .mp4 (Whisper transcription) |
+| `asImage.js` | .png, .jpg, .jpeg, .webp (OCR) |
+
+### Document output format
+
+```js
+{
+  id: "uuid-v4",
+  url: "file://path  or  link://url",
+  title, docAuthor, description, docSource,
+  chunkSource,          // "link://https://..."
+  published,            // file creation date
+  wordCount,
+  pageContent,          // full extracted text
+  token_count_estimate  // LLM token estimate
+}
+```
+
+### Link processing (`processLink/`)
+
+URL → `determineContentType()` → YouTube transcript OR Puppeteer scrape → JSON document. Supports YouTube transcripts natively.
+
+---
+
+## Key Design Patterns
+
+- **Workspace = vector DB namespace** — each workspace isolates its documents and embeddings under `workspace.slug`.
+- **Chat vs Query mode** — "query" refuses if no relevant docs found; "chat" allows general knowledge fallback.
+- **Pinned documents** — always included in context regardless of similarity score.
+- **Parse vs Process** — collector supports preview-only mode (`parseOnly=true`) before committing embeddings.
+- **Token budgeting** — messages are compressed to fit within model context window before every LLM call.
+- **Source attribution** — only new search results shown as citations, not re-cited history documents.
+- **Document sync queues** — background jobs refresh dynamic content (URLs etc.) on a schedule.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` file to help [Claude Code](https://claude.ai/code) quickly understand this repository when starting a new session.

The file documents:

- **Common commands** — dev server startup, build, lint, test, and all Prisma database commands (including how to run a single test file)
- **Three-service architecture** — Server (Express, port 3001), Frontend (React+Vite, port 3000), Collector (document processor, port 8888), with ports, roles, and key subdirectory map for each
- **Server internals** — LLM/vector DB/embedding provider factory pattern, full chat pipeline step-by-step (vector search → context assembly → token budgeting → streaming), key Prisma data models
- **Frontend internals** — routing structure, context providers, API communication layer pattern, key hooks
- **Collector internals** — supported file formats and handlers, parse vs process modes, document output format, link/URL processing
- **Key design patterns** — workspace-as-namespace, chat vs query mode, pinned documents, token budgeting, source attribution

## Test plan

- [ ] Verify all commands listed are accurate against current `package.json` scripts
- [ ] Confirm architecture descriptions match the codebase

🤖 Generated with [Claude Code](https://claude.ai/claude-code)