### PR TITLE
Patch OpenRouter finish_reason bug

### DIFF
--- a/server/utils/AiProviders/openRouter/index.js
+++ b/server/utils/AiProviders/openRouter/index.js
@@ -164,9 +164,9 @@ class OpenRouterLLM {
     const cacheModelPath = path.resolve(cacheFolder, "models.json");
     const availableModels = fs.existsSync(cacheModelPath)
       ? safeJsonParse(
-        fs.readFileSync(cacheModelPath, { encoding: "utf-8" }),
-        {}
-      )
+          fs.readFileSync(cacheModelPath, { encoding: "utf-8" }),
+          {}
+        )
       : {};
     return availableModels[modelName]?.maxLength || 4096;
   }


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5112 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

-   OpenRouter recently started sending a trailing stream chunk with an empty choices array containing usage data
- This caused a crash (Cannot read properties of undefined (reading 'finish_reason')) because the code didn't account for chunks without choices
- Added guard against chunks with no message to prevent last chunk from throwing an error
- Store the real usage data given to us by OpenRouter and use this in TPS calculations done in `endMeasurement` for more accurate results 

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally