### PR TITLE
fix: replace UA-based mobile detection with viewport size checks for workspace modal

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/index.jsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import Workspace from "../../../models/workspace";
 import System from "../../../models/system";
-import { isMobile } from "react-device-detect";
 import useUser from "../../../hooks/useUser";
 import DocumentSettings from "./Documents";
 import DataConnectors from "./DataConnectors";
@@ -37,7 +36,7 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
 
   if (!workspace) return null;
 
-  if (isMobile) {
+  if (window.innerWidth < 560 || window.innerHeight < 600) {
     return (
       <ModalWrapper isOpen={true}>
         <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
@@ -82,7 +81,7 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
   return (
     <div className="w-screen h-screen fixed top-0 left-0 flex justify-center items-center z-99">
       <div className="backdrop h-full w-full absolute top-0 z-10" />
-      <div className="absolute max-h-full w-fit transition duration-300 z-20 md:overflow-y-auto py-10">
+      <div className="absolute max-h-full w-fit transition duration-300 z-20 overflow-y-auto py-10">
         <div className="relative bg-theme-bg-secondary rounded-[12px] shadow border-2 border-theme-modal-border">
           <div className="flex items-start justify-between p-2 rounded-t border-theme-modal-border relative">
             <button

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
@@ -163,6 +163,11 @@ export default function ActiveWorkspaces() {
                               >
                                 <button
                                   type="button"
+                                  onTouchEnd={(e) => {
+                                    e.preventDefault();
+                                    setSelectedWs(workspace);
+                                    showModal();
+                                  }}
                                   onClick={(e) => {
                                     e.preventDefault();
                                     setSelectedWs(workspace);

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -867,7 +867,7 @@ const TRANSLATIONS = {
       documents: "Documents",
       "data-connectors": "Data Connectors",
       "desktop-only":
-        "Editing these settings are only available on a desktop device. Please access this page on your desktop to continue.",
+        "This panel requires a wider screen to display properly. Please use a larger device or a desktop browser to manage documents and data connectors.",
       dismiss: "Dismiss",
       editing: "Editing",
     },


### PR DESCRIPTION
## Summary

- Replaces `isMobile` from `react-device-detect` (user-agent based) with `window.innerWidth < 560 || window.innerHeight < 600` so that "Request Desktop Site" on iPad is correctly respected
- Removes `md:` prefix from `overflow-y-auto` on the modal container so scrolling works on iPad mini in portrait mode (744px wide, which falls below the 768px `md` breakpoint)
- Adds `onTouchEnd` handler to the workspace upload button in the sidebar to fix an iOS double-tap issue caused by the button being a descendant of an `<a>` element
- Updates the blocking message to accurately describe the screen width requirement rather than incorrectly stating "desktop only"

## Motivation

Fixes #5055 — on iPadOS, "Request Desktop Site" was ignored because `isMobile` from `react-device-detect` uses the user agent string, which does not reliably change when requesting desktop mode. The fix uses actual viewport dimensions, which do reflect the rendered layout regardless of user agent.

## Test plan

- [x] iPhone (portrait + landscape) — blocking message shown in both orientations
- [x] iPad mini portrait — modal opens, scrolls correctly
- [x] iPad mini landscape — modal opens, scrolls correctly
- [x] iPad with Magic Keyboard/trackpad — hover-to-reveal behavior unchanged
- [x] Desktop browser — behavior unchanged
- [x] Upload button in sidebar opens on first tap (not double-tap) on touch devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)