### PR TITLE
feat: show document counts in My Documents and workspace headers

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
@@ -183,6 +183,11 @@ function Directory({
   }, 500);
 
   const filteredFiles = filterFileSearchResults(files, searchTerm);
+  const documentCount =
+    files?.items?.reduce(
+      (sum, folder) => sum + (folder.items?.length ?? 0),
+      0
+    ) ?? 0;
 
   const handleContextMenu = (event) => {
     event.preventDefault();
@@ -199,7 +204,7 @@ function Directory({
         <div className="flex flex-col gap-y-6">
           <div className="flex items-center justify-between w-[560px] px-5 relative">
             <h3 className="text-white text-base font-bold">
-              {t("connectors.directory.my-documents")}
+              {t("connectors.directory.my-documents")} ({documentCount})
             </h3>
             <div className="relative">
               <input

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/index.jsx
@@ -28,6 +28,11 @@ function WorkspaceDirectory({
 }) {
   const { t } = useTranslation();
   const [selectedItems, setSelectedItems] = useState({});
+  const documentCount =
+    files?.items?.reduce(
+      (sum, folder) => sum + (folder.items?.length ?? 0),
+      0
+    ) ?? 0;
 
   const toggleSelection = (item) => {
     setSelectedItems((prevSelectedItems) => {
@@ -119,7 +124,7 @@ function WorkspaceDirectory({
       <div className="px-8">
         <div className="flex items-center justify-start w-[560px]">
           <h3 className="text-white text-base font-bold ml-5">
-            {workspace.name}
+            {workspace.name} ({documentCount})
           </h3>
         </div>
         <div className="relative w-[560px] h-[445px] mt-5">


### PR DESCRIPTION
### pull Request Type

- [x] feat (New feature)

### Relevant Issues
resolves : #5121

### Description

- My Documents: show total document count in the header.
- AI Workspace: show document count in the header.
- Counts update when documents are moved.

### Visuals (if applicable)
- Screenshot of the modal with the new counts.

### Additional Information
- None.

### Developer Validations
[ ] I ran yarn lint from the root of the repo & committed changes
[ ] Relevant documentation has been updated (if applicable)
[ ] I have tested my code functionality
[ ] Docker build succeeds locally
