### PR TITLE
feat: add Desktop Assistant disable + shortcut settings

### DIFF
--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -392,6 +392,12 @@ const SidebarOptions = ({ user = null, t }) => (
               flex: true,
               roles: ["admin"],
             },
+            {
+              btnText: t("settings.desktop-assistant"),
+              href: paths.settings.desktopAssistant(),
+              flex: true,
+              roles: ["admin"],
+            },
           ]}
         />
         <Option

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -113,6 +113,7 @@ const TRANSLATIONS = {
     contact: "Contact Support",
     "browser-extension": "Browser Extension",
     "mobile-app": "AnythingLLM Mobile",
+    "desktop-assistant": "Desktop Assistant",
   },
 
   // Page Definitions
@@ -559,6 +560,27 @@ const TRANSLATIONS = {
         description:
           "Render HTML responses in assistant responses.\nThis can result in a much higher fidelity of response quality, but can also lead to potential security risks.",
       },
+    },
+  },
+
+  "desktop-assistant": {
+    title: "Desktop Assistant",
+    description:
+      "Configure the Desktop Assistant overlay. These settings only apply when running AnythingLLM Desktop.",
+    enabled: {
+      title: "Enable Desktop Assistant",
+      description:
+        "When disabled, the Desktop Assistant overlay will not be available.",
+    },
+    "shortcut-enabled": {
+      title: "Enable keyboard shortcut",
+      description:
+        "When disabled, the keyboard shortcut will not open the Desktop Assistant.",
+    },
+    "shortcut-modifier": {
+      title: "Shortcut modifier key",
+      description:
+        "Choose which modifier key to use with the shortcut.",
     },
   },
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -372,6 +372,17 @@ const router = createBrowserRouter([
           return { element: <ManagerRoute Component={MobileConnections} /> };
         },
       },
+      {
+        path: "/settings/desktop-assistant",
+        lazy: async () => {
+          const { default: DesktopAssistantSettings } = await import(
+            "@/pages/GeneralSettings/DesktopAssistant"
+          );
+          return {
+            element: <ManagerRoute Component={DesktopAssistantSettings} />,
+          };
+        },
+      },
       // Catch-all route for 404s
       {
         path: "*",

--- a/frontend/src/models/desktopAssistant.js
+++ b/frontend/src/models/desktopAssistant.js
@@ -1,0 +1,39 @@
+import { DESKTOP_ASSISTANT_SETTINGS } from "@/utils/constants";
+import { safeJsonParse } from "@/utils/request";
+
+const SHORTCUT_MODIFIERS = ["ctrl", "alt", "meta"];
+
+function getDefaultModifier() {
+  if (typeof navigator === "undefined") return "ctrl";
+  return navigator.platform.toUpperCase().indexOf("MAC") >= 0 ? "meta" : "ctrl";
+}
+
+const DesktopAssistant = {
+  getSettings: () => {
+    const raw = localStorage.getItem(DESKTOP_ASSISTANT_SETTINGS);
+    const settings = safeJsonParse(raw, {});
+    return {
+      enabled: settings.enabled ?? true,
+      shortcutEnabled: settings.shortcutEnabled ?? true,
+      shortcutModifier: settings.shortcutModifier ?? getDefaultModifier(),
+    };
+  },
+
+  updateSettings: (newSettings) => {
+    const updated = {
+      ...DesktopAssistant.getSettings(),
+      ...newSettings,
+    };
+    if (
+      updated.shortcutModifier &&
+      !SHORTCUT_MODIFIERS.includes(updated.shortcutModifier)
+    ) {
+      updated.shortcutModifier = getDefaultModifier();
+    }
+    localStorage.setItem(DESKTOP_ASSISTANT_SETTINGS, JSON.stringify(updated));
+    return updated;
+  },
+};
+
+export default DesktopAssistant;
+export { SHORTCUT_MODIFIERS };

--- a/frontend/src/pages/GeneralSettings/DesktopAssistant/index.jsx
+++ b/frontend/src/pages/GeneralSettings/DesktopAssistant/index.jsx
@@ -1,0 +1,115 @@
+import { useState, useEffect } from "react";
+import Sidebar from "@/components/SettingsSidebar";
+import { isMobile } from "react-device-detect";
+import { useTranslation } from "react-i18next";
+import DesktopAssistant from "@/models/desktopAssistant";
+import { SHORTCUT_MODIFIERS } from "@/models/desktopAssistant";
+import Toggle from "@/components/lib/Toggle";
+import { isMac } from "@/utils/keyboardShortcuts";
+
+const MODIFIER_LABELS = {
+  ctrl: { win: "Ctrl", mac: "Control" },
+  alt: { win: "Alt", mac: "Option" },
+  meta: { win: "Meta", mac: "Cmd" },
+};
+
+function getModifierLabel(value) {
+  const labels = MODIFIER_LABELS[value];
+  if (!labels) return value;
+  return isMac ? labels.mac : labels.win;
+}
+
+export default function DesktopAssistantSettings() {
+  const { t } = useTranslation();
+  const [enabled, setEnabled] = useState(true);
+  const [shortcutEnabled, setShortcutEnabled] = useState(true);
+  const [shortcutModifier, setShortcutModifier] = useState(() =>
+    DesktopAssistant.getSettings().shortcutModifier
+  );
+
+  useEffect(() => {
+    const settings = DesktopAssistant.getSettings();
+    setEnabled(settings.enabled);
+    setShortcutEnabled(settings.shortcutEnabled);
+    setShortcutModifier(settings.shortcutModifier);
+  }, []);
+
+  function handleEnabledChange(checked) {
+    setEnabled(checked);
+    DesktopAssistant.updateSettings({ enabled: checked });
+  }
+
+  function handleShortcutEnabledChange(checked) {
+    setShortcutEnabled(checked);
+    DesktopAssistant.updateSettings({ shortcutEnabled: checked });
+  }
+
+  function handleModifierChange(e) {
+    const value = e.target.value;
+    setShortcutModifier(value);
+    DesktopAssistant.updateSettings({ shortcutModifier: value });
+  }
+
+  return (
+    <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
+      <Sidebar />
+      <div
+        style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
+        className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-[16px] bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
+      >
+        <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[86px] md:py-6 py-16">
+          <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+            <p className="text-lg leading-6 font-bold text-white">
+              {t("desktop-assistant.title")}
+            </p>
+            <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+              {t("desktop-assistant.description")}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-y-6 mt-6">
+            <Toggle
+              size="md"
+              variant="horizontal"
+              enabled={enabled}
+              onChange={handleEnabledChange}
+              label={t("desktop-assistant.enabled.title")}
+              description={t("desktop-assistant.enabled.description")}
+            />
+
+            <Toggle
+              size="md"
+              variant="horizontal"
+              enabled={shortcutEnabled}
+              onChange={handleShortcutEnabledChange}
+              disabled={!enabled}
+              label={t("desktop-assistant.shortcut-enabled.title")}
+              description={t("desktop-assistant.shortcut-enabled.description")}
+            />
+
+            <div className="flex flex-col gap-y-0.5">
+              <p className="text-sm leading-6 font-semibold text-white">
+                {t("desktop-assistant.shortcut-modifier.title")}
+              </p>
+              <p className="text-xs text-white/60">
+                {t("desktop-assistant.shortcut-modifier.description")}
+              </p>
+              <select
+                value={shortcutModifier}
+                onChange={handleModifierChange}
+                disabled={!enabled || !shortcutEnabled}
+                className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {SHORTCUT_MODIFIERS.map((mod) => (
+                  <option key={mod} value={mod}>
+                    {getModifierLabel(mod)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -12,6 +12,7 @@ export const USER_PROMPT_INPUT_MAP = "anythingllm_user_prompt_input_map";
 export const PENDING_HOME_MESSAGE = "anythingllm_pending_home_message";
 
 export const APPEARANCE_SETTINGS = "anythingllm_appearance_settings";
+export const DESKTOP_ASSISTANT_SETTINGS = "anythingllm_desktop_assistant_settings";
 
 export const OLLAMA_COMMON_URLS = [
   "http://127.0.0.1:11434",

--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -170,6 +170,9 @@ export default {
     mobileConnections: () => {
       return `/settings/mobile-connections`;
     },
+    desktopAssistant: () => {
+      return `/settings/desktop-assistant`;
+    },
   },
   agents: {
     builder: () => {


### PR DESCRIPTION
### pull Request Type
- [x] feat (New feature)

### Relevant Issues
resolves : #5120

### Description

- Adds a Desktop Assistant settings page so users can:
- Turn the Desktop Assistant on or off
- Turn the keyboard shortcut on or off
- Choose the modifier key (Ctrl, Alt, or Cmd) used with the shortcut instead of always using Ctrl

- Settings are stored in localStorage and can be read by the Electron desktop app. The page is under Settings > Tools > Desktop Assistant.