### PR TITLE
chore: add ESLint CI workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,72 @@
+name: Lint
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "server/**/*.js"
+      - "server/eslint.config.mjs"
+      - "collector/**/*.js"
+      - "collector/eslint.config.mjs"
+      - "frontend/src/**/*.js"
+      - "frontend/src/**/*.jsx"
+      - "frontend/eslint.config.js"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Cache server dependencies
+        uses: actions/cache@v4
+        with:
+          path: server/node_modules
+          key: ${{ runner.os }}-yarn-server-${{ hashFiles('server/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-server-
+
+      - name: Cache frontend dependencies
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-yarn-frontend-${{ hashFiles('frontend/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-frontend-
+
+      - name: Cache collector dependencies
+        uses: actions/cache@v4
+        with:
+          path: collector/node_modules
+          key: ${{ runner.os }}-yarn-collector-${{ hashFiles('collector/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-collector-
+
+      - name: Install server dependencies
+        run: cd server && yarn install --frozen-lockfile
+
+      - name: Install frontend dependencies
+        run: cd frontend && yarn install --frozen-lockfile
+
+      - name: Install collector dependencies
+        run: cd collector && yarn install --frozen-lockfile
+
+      - name: Lint server
+        run: cd server && yarn lint:check
+
+      - name: Lint frontend
+        run: cd frontend && yarn lint:check
+
+      - name: Lint collector
+        run: cd collector && yarn lint:check

--- a/collector/package.json
+++ b/collector/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development nodemon --ignore hotdir --ignore storage --trace-warnings index.js",
     "start": "cross-env NODE_ENV=production node index.js",
-    "lint": "eslint --fix ."
+    "lint": "eslint --fix .",
+    "lint:check": "eslint ."
   },
   "dependencies": {
     "@langchain/community": "^0.2.23",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "jest",
     "lint": "cd server && yarn lint && cd ../frontend && yarn lint && cd ../collector && yarn lint",
+    "lint:ci": "cd server && yarn lint:check && cd ../frontend && yarn lint:check && cd ../collector && yarn lint:check",
     "setup": "cd server && yarn && cd ../collector && yarn && cd ../frontend && yarn && cd .. && yarn setup:envs && yarn prisma:setup && echo \"Please run yarn dev:server, yarn dev:collector, and yarn dev:frontend in separate terminal tabs.\"",
     "setup:envs": "cp -n ./frontend/.env.example ./frontend/.env; cp -n ./server/.env.example ./server/.env.development; cp -n ./collector/.env.example ./collector/.env; cp -n ./docker/.env.example ./docker/.env; echo \"All ENV files copied!\n\"",
     "dev:server": "cd server && yarn dev",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "dev": "cross-env NODE_ENV=development nodemon --ignore documents --ignore vector-cache --ignore storage --ignore swagger --trace-warnings index.js",
     "start": "cross-env NODE_ENV=production node index.js",
     "lint": "eslint --fix .",
+    "lint:check": "eslint .",
     "swagger": "node ./swagger/init.js"
   },
   "prisma": {


### PR DESCRIPTION
### Pull Request Type

- [x] 🔨 chore (Build, CI, maintenance)

### Relevant Issues

resolves #

### Description

Adds a GitHub Actions CI workflow that runs ESLint across all three monorepo projects (`server`, `frontend`, `collector`) on pull requests.

- Added `lint:check` scripts to `server` and `collector` (`eslint` without `--fix`)
- Added top-level `yarn lint:ci` script that runs `lint:check` in all three projects
- Created `.github/workflows/lint.yaml` that triggers on PRs touching `.js`/`.jsx` source files or ESLint configs
- The existing `yarn lint` (with `--fix`) remains unchanged for local development use

### Additional Information

- The top-level `eslint.config.js` is not used by this workflow — each project uses its own ESLint config (`server/eslint.config.mjs`, `collector/eslint.config.mjs`, `frontend/eslint.config.js`)
- `frontend` already had a `lint:check` script, so no change was needed there
- All three projects pass `lint:check` locally as of this PR

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] I have tested my code functionality