### PR TITLE
fix: add missing /wiki to Confluence cloud citation URLs

### DIFF
--- a/collector/utils/extensions/Confluence/ConfluenceLoader/index.js
+++ b/collector/utils/extensions/Confluence/ConfluenceLoader/index.js
@@ -131,7 +131,7 @@ class ConfluencePagesLoader {
       /\n{3,}/g,
       "\n\n"
     );
-    const pageUrl = `${this.baseUrl}/spaces/${this.spaceKey}/pages/${page.id}`;
+    const pageUrl = `${this.baseUrl}${this.cloud ? "/wiki" : ""}/spaces/${this.spaceKey}/pages/${page.id}`;
 
     return {
       pageContent: textWithPreservedStructure,


### PR DESCRIPTION
## Summary

Fixes #4225

The Confluence connector generates citation URLs missing `/wiki` in the path for cloud instances:

- **Broken**: `https://SUBDOMAIN.atlassian.net/spaces/SPACE/pages/ID`
- **Fixed**: `https://SUBDOMAIN.atlassian.net/wiki/spaces/SPACE/pages/ID`

The API URL construction in `fetchAllPagesInSpace` already correctly handles this with `${this.cloud ? "/wiki" : ""}`, but the same conditional was missing from the `pageUrl` construction in `createDocumentFromPage`.

## Changes

- `collector/utils/extensions/Confluence/ConfluenceLoader/index.js`: Added `${this.cloud ? "/wiki" : ""}` to the `pageUrl` template literal, matching the existing pattern used for API calls. This ensures `/wiki` is included for cloud Confluence instances while leaving self-hosted URLs unchanged.

**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**