### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
   <a href="https://github.com/Mintplex-Labs/anything-llm/blob/master/LICENSE" target="_blank">
       <img src="https://img.shields.io/static/v1?label=license&message=MIT&color=white" alt="License">
   </a> |
+  <a href="https://gitcgr.com/Mintplex-Labs/anything-llm">
+    <img src="https://gitcgr.com/badge/Mintplex-Labs/anything-llm.svg" alt="gitcgr" />
+  </a>
   <a href="https://docs.anythingllm.com" target="_blank">
     Docs
   </a> |


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/Mintplex-Labs/anything-llm.svg)](https://gitcgr.com/Mintplex-Labs/anything-llm)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).