### PR TITLE
fix Firefox LaTeX rendering

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1040,13 +1040,14 @@ does not extend the close button beyond the viewport. */
   }
 }
 
-/* Math/Katex formatting to prevent duplication of content on screen */
-.katex-html[aria-hidden="true"] {
-  display: none;
+/* KaTeX overrides - base CSS imported via markdown-katex.js plugin */
+.katex-display {
+  margin: 0 !important;
+  text-align: left !important;
 }
 
-.katex-mathml {
-  font-size: 20px;
+.katex-display > .katex {
+  text-align: left !important;
 }
 
 .rti--container {

--- a/frontend/src/utils/chat/plugins/markdown-katex.js
+++ b/frontend/src/utils/chat/plugins/markdown-katex.js
@@ -1,4 +1,5 @@
 import katex from "katex";
+import "katex/dist/katex.min.css";
 
 // Test if potential opening or closing delimieter
 // Assumes that there is a "$" at state.src[pos]


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [x] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5253

### Description

- Fixed LaTeX rendering in Firefox due to missing CSS imports that would handle this
- Does not break existing Chrome styling.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<img width="656" height="601" alt="Screenshot 2026-03-23 at 8 56 47 PM" src="https://github.com/user-attachments/assets/4e66fa4e-978d-48ff-82d6-0ca89497213b" />
<img width="788" height="746" alt="Screenshot 2026-03-23 at 8 56 35 PM" src="https://github.com/user-attachments/assets/c8797694-e6b4-4786-be95-8d89d201b6e9" />


<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
