### PR TITLE
feat: Add OpenAI API compatible STT provider

### DIFF
--- a/frontend/src/components/SpeechToText/OpenAiGenericOptions/index.jsx
+++ b/frontend/src/components/SpeechToText/OpenAiGenericOptions/index.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+export default function OpenAiGenericSTTOptions({ settings }) {
+  return (
+    <div className="w-full flex flex-col gap-y-7">
+      <div className="flex gap-x-4">
+        <div className="flex flex-col w-60">
+          <div className="flex justify-between items-start mb-2">
+            <label className="text-white text-sm font-semibold">Base URL</label>
+          </div>
+          <input
+            type="url"
+            name="STTOpenAICompatibleEndpoint"
+            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            placeholder="http://localhost:8000/v1"
+            defaultValue={settings?.STTOpenAICompatibleEndpoint}
+            required={false}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            This should be the base URL of the OpenAI compatible STT service you
+            will use for speech-to-text transcription.
+          </p>
+        </div>
+        <div className="flex flex-col w-60">
+          <label className="text-white text-sm font-semibold block mb-2">
+            API Key
+          </label>
+          <input
+            type="password"
+            name="STTOpenAICompatibleKey"
+            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            placeholder="API Key"
+            defaultValue={
+              settings?.STTOpenAICompatibleKey ? "*".repeat(20) : ""
+            }
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            Some STT services require an API key to generate transcriptions -
+            this is optional if your service does not require one.
+          </p>
+        </div>
+      </div>
+      <div className="flex gap-x-4">
+        <div className="flex flex-col w-60">
+          <label className="text-white text-sm font-semibold block mb-3">
+            STT Model
+          </label>
+          <input
+            type="text"
+            name="STTOpenAICompatibleModel"
+            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            placeholder="whisper-1"
+            defaultValue={settings?.STTOpenAICompatibleModel}
+            required={true}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            The model identifier for the STT model you want to use for
+            transcription.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/index.jsx
@@ -1,149 +1,33 @@
-import { useEffect, useCallback, useRef } from "react";
-import { Microphone } from "@phosphor-icons/react";
-import { Tooltip } from "react-tooltip";
-import "regenerator-runtime"; //required polyfill for speech recognition;
-import SpeechRecognition, {
-  useSpeechRecognition,
-} from "react-speech-recognition";
-import { PROMPT_INPUT_EVENT } from "../../PromptInput";
-import { useTranslation } from "react-i18next";
-import Appearance from "@/models/appearance";
+import { useEffect, useState } from "react";
+import System from "@/models/system";
+import NativeSpeechToText from "./native";
+import ServerSpeechToText from "./server";
 
-let timeout;
-const SILENCE_INTERVAL = 3_200; // wait in seconds of silence before closing.
+export const STOP_STT_EVENT = "stop_stt_session";
 
 /**
  * Speech-to-text input component for the chat window.
+ * Renders the appropriate STT implementation based on the system's SpeechToTextProvider setting.
  * @param {Object} props - The component props
- * @param {(textToAppend: string, autoSubmit: boolean) => void} props.sendCommand - The function to send the command
- * @returns {React.ReactElement} The SpeechToText component
+ * @param {Function} props.sendCommand - The function to send the command
+ * @returns {React.ReactElement|null}
  */
 export default function SpeechToText({ sendCommand }) {
-  const previousTranscriptRef = useRef("");
-  const {
-    transcript,
-    listening,
-    resetTranscript,
-    browserSupportsSpeechRecognition,
-    browserSupportsContinuousListening,
-    isMicrophoneAvailable,
-  } = useSpeechRecognition({
-    clearTranscriptOnListen: true,
-  });
-  const { t } = useTranslation();
-  function startSTTSession() {
-    if (!isMicrophoneAvailable) {
-      alert(
-        "AnythingLLM does not have access to microphone. Please enable for this site to use this feature."
-      );
-      return;
-    }
+  const [provider, setProvider] = useState(null);
+  const [loading, setLoading] = useState(true);
 
-    resetTranscript();
-    previousTranscriptRef.current = "";
-    SpeechRecognition.startListening({
-      continuous: browserSupportsContinuousListening,
-      language: window?.navigator?.language ?? "en-US",
+  useEffect(() => {
+    System.keys().then((res) => {
+      setProvider(res?.SpeechToTextProvider || "native");
+      setLoading(false);
     });
-  }
-
-  function endSTTSession() {
-    SpeechRecognition.stopListening();
-
-    // If auto submit is enabled, send an empty string to the chat window to submit the current transcript
-    // since every chunk of text should have been streamed to the chat window by now.
-    if (Appearance.get("autoSubmitSttInput")) {
-      sendCommand({
-        text: "",
-        autoSubmit: true,
-        writeMode: "append",
-      });
-    }
-
-    resetTranscript();
-    previousTranscriptRef.current = "";
-    clearTimeout(timeout);
-  }
-
-  const handleKeyPress = useCallback(
-    (event) => {
-      // CTRL + m on Mac and Windows to toggle STT listening
-      if (event.ctrlKey && event.keyCode === 77) {
-        if (listening) {
-          endSTTSession();
-        } else {
-          startSTTSession();
-        }
-      }
-    },
-    [listening, endSTTSession, startSTTSession]
-  );
-
-  function handlePromptUpdate(e) {
-    if (!e?.detail && timeout) {
-      endSTTSession();
-      clearTimeout(timeout);
-    }
-  }
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyPress);
-    return () => {
-      document.removeEventListener("keydown", handleKeyPress);
-    };
-  }, [handleKeyPress]);
-
-  useEffect(() => {
-    if (!!window)
-      window.addEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
-    return () =>
-      window?.removeEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
   }, []);
 
-  useEffect(() => {
-    if (transcript?.length > 0 && listening) {
-      const previousTranscript = previousTranscriptRef.current;
-      const newContent = transcript.slice(previousTranscript.length);
+  if (loading) return null;
 
-      // Stream just the diff of the new content since transcript is an accumulating string.
-      // and not just the new content transcribed.
-      if (newContent.length > 0)
-        sendCommand({ text: newContent, writeMode: "append" });
+  if (provider === "generic-openai") {
+    return <ServerSpeechToText sendCommand={sendCommand} />;
+  }
 
-      previousTranscriptRef.current = transcript;
-      clearTimeout(timeout);
-      timeout = setTimeout(() => {
-        endSTTSession();
-      }, SILENCE_INTERVAL);
-    }
-  }, [transcript, listening]);
-
-  if (!browserSupportsSpeechRecognition) return null;
-  return (
-    <div
-      data-tooltip-id="tooltip-microphone-btn"
-      data-tooltip-content={`${t("chat_window.microphone")} (CTRL + M)`}
-      aria-label={t("chat_window.microphone")}
-      onClick={listening ? endSTTSession : startSTTSession}
-      className={`group border-none relative flex justify-center items-center cursor-pointer w-8 h-8 rounded-full hover:bg-zinc-700 light:hover:bg-slate-200 ${
-        listening ? "bg-zinc-700 light:bg-slate-200" : ""
-      }`}
-    >
-      <Microphone
-        weight="regular"
-        size={18}
-        className={`pointer-events-none text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-600 shrink-0 ${
-          listening
-            ? "animate-pulse-glow !text-white light:!text-slate-800"
-            : ""
-        }`}
-      />
-      <Tooltip
-        id="tooltip-microphone-btn"
-        place="top"
-        delayShow={300}
-        className="tooltip !text-xs z-99"
-      />
-    </div>
-  );
+  return <NativeSpeechToText sendCommand={sendCommand} />;
 }

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/native.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/native.jsx
@@ -1,0 +1,146 @@
+import { useEffect, useCallback, useRef } from "react";
+import { Microphone } from "@phosphor-icons/react";
+import { Tooltip } from "react-tooltip";
+import "regenerator-runtime";
+import SpeechRecognition, {
+  useSpeechRecognition,
+} from "react-speech-recognition";
+import { PROMPT_INPUT_EVENT } from "../../PromptInput";
+import { STOP_STT_EVENT } from "./index";
+import { useTranslation } from "react-i18next";
+import Appearance from "@/models/appearance";
+
+let timeout;
+const SILENCE_INTERVAL = 3_200;
+
+export default function NativeSpeechToText({ sendCommand }) {
+  const previousTranscriptRef = useRef("");
+  const {
+    transcript,
+    listening,
+    resetTranscript,
+    browserSupportsSpeechRecognition,
+    browserSupportsContinuousListening,
+    isMicrophoneAvailable,
+  } = useSpeechRecognition({
+    clearTranscriptOnListen: true,
+  });
+  const { t } = useTranslation();
+
+  function startSTTSession() {
+    if (!isMicrophoneAvailable) {
+      alert(
+        "AnythingLLM does not have access to microphone. Please enable for this site to use this feature."
+      );
+      return;
+    }
+
+    resetTranscript();
+    previousTranscriptRef.current = "";
+    SpeechRecognition.startListening({
+      continuous: browserSupportsContinuousListening,
+      language: window?.navigator?.language ?? "en-US",
+    });
+  }
+
+  function endSTTSession() {
+    SpeechRecognition.stopListening();
+
+    if (Appearance.get("autoSubmitSttInput")) {
+      sendCommand({
+        text: "",
+        autoSubmit: true,
+        writeMode: "append",
+      });
+    }
+
+    resetTranscript();
+    previousTranscriptRef.current = "";
+    clearTimeout(timeout);
+  }
+
+  const handleKeyPress = useCallback(
+    (event) => {
+      if (event.ctrlKey && event.keyCode === 77) {
+        if (listening) {
+          endSTTSession();
+        } else {
+          startSTTSession();
+        }
+      }
+    },
+    [listening, endSTTSession, startSTTSession]
+  );
+
+  function handlePromptUpdate(e) {
+    if (!e?.detail && timeout) {
+      endSTTSession();
+      clearTimeout(timeout);
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyPress);
+    return () => {
+      document.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [handleKeyPress]);
+
+  useEffect(() => {
+    if (!!window)
+      window.addEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
+    return () =>
+      window?.removeEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => endSTTSession();
+    window.addEventListener(STOP_STT_EVENT, handler);
+    return () => window.removeEventListener(STOP_STT_EVENT, handler);
+  }, []);
+
+  useEffect(() => {
+    if (transcript?.length > 0 && listening) {
+      const previousTranscript = previousTranscriptRef.current;
+      const newContent = transcript.slice(previousTranscript.length);
+
+      if (newContent.length > 0)
+        sendCommand({ text: newContent, writeMode: "append" });
+
+      previousTranscriptRef.current = transcript;
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        endSTTSession();
+      }, SILENCE_INTERVAL);
+    }
+  }, [transcript, listening]);
+
+  if (!browserSupportsSpeechRecognition) return null;
+  return (
+    <div
+      data-tooltip-id="tooltip-microphone-btn"
+      data-tooltip-content={`${t("chat_window.microphone")} (CTRL + M)`}
+      aria-label={t("chat_window.microphone")}
+      onClick={listening ? endSTTSession : startSTTSession}
+      className={`group border-none relative flex justify-center items-center cursor-pointer w-8 h-8 rounded-full hover:bg-zinc-700 light:hover:bg-slate-200 ${
+        listening ? "bg-zinc-700 light:bg-slate-200" : ""
+      }`}
+    >
+      <Microphone
+        weight="regular"
+        size={18}
+        className={`pointer-events-none text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-600 shrink-0 ${
+          listening
+            ? "animate-pulse-glow !text-white light:!text-slate-800"
+            : ""
+        }`}
+      />
+      <Tooltip
+        id="tooltip-microphone-btn"
+        place="top"
+        delayShow={300}
+        className="tooltip !text-xs z-99"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
@@ -1,13 +1,11 @@
 import { useEffect, useCallback, useRef, useState } from "react";
 import { Microphone } from "@phosphor-icons/react";
 import { Tooltip } from "react-tooltip";
-import { PROMPT_INPUT_EVENT } from "../../PromptInput";
 import { STOP_STT_EVENT } from "./index";
 import { useTranslation } from "react-i18next";
 import Appearance from "@/models/appearance";
 import System from "@/models/system";
 
-let silenceTimeout;
 const SILENCE_INTERVAL = 3_200;
 const SILENCE_THRESHOLD = 0.01;
 const SILENCE_CHECK_INTERVAL = 200;
@@ -23,8 +21,8 @@ export default function ServerSpeechToText({ sendCommand }) {
   const mediaRecorderRef = useRef(null);
   const audioChunksRef = useRef([]);
   const streamRef = useRef(null);
-  const analyserRef = useRef(null);
   const silenceCheckRef = useRef(null);
+  const silenceTimeoutRef = useRef(null);
   const { t } = useTranslation();
 
   async function startSTTSession() {
@@ -37,7 +35,6 @@ export default function ServerSpeechToText({ sendCommand }) {
       const analyser = audioContext.createAnalyser();
       analyser.fftSize = 2048;
       source.connect(analyser);
-      analyserRef.current = analyser;
 
       const mediaRecorder = new MediaRecorder(stream);
       mediaRecorderRef.current = mediaRecorder;
@@ -101,7 +98,6 @@ export default function ServerSpeechToText({ sendCommand }) {
     }
     stopSilenceDetection();
     setListening(false);
-    clearTimeout(silenceTimeout);
   }
 
   function startSilenceDetection(analyser) {
@@ -115,14 +111,14 @@ export default function ServerSpeechToText({ sendCommand }) {
       const rms = Math.sqrt(sum / dataArray.length);
 
       if (rms < SILENCE_THRESHOLD) {
-        if (!silenceTimeout) {
-          silenceTimeout = setTimeout(() => {
+        if (!silenceTimeoutRef.current) {
+          silenceTimeoutRef.current = setTimeout(() => {
             endSTTSession();
           }, SILENCE_INTERVAL);
         }
       } else {
-        clearTimeout(silenceTimeout);
-        silenceTimeout = null;
+        clearTimeout(silenceTimeoutRef.current);
+        silenceTimeoutRef.current = null;
       }
     }, SILENCE_CHECK_INTERVAL);
   }
@@ -132,8 +128,8 @@ export default function ServerSpeechToText({ sendCommand }) {
       clearInterval(silenceCheckRef.current);
       silenceCheckRef.current = null;
     }
-    clearTimeout(silenceTimeout);
-    silenceTimeout = null;
+    clearTimeout(silenceTimeoutRef.current);
+    silenceTimeoutRef.current = null;
   }
 
   const handleKeyPress = useCallback(
@@ -155,26 +151,13 @@ export default function ServerSpeechToText({ sendCommand }) {
   }, [handleKeyPress]);
 
   useEffect(() => {
-    function handlePromptUpdate(e) {
-      if (!e?.detail && listening) {
-        endSTTSession();
-      }
-    }
-    window.addEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
-    return () =>
-      window.removeEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
-  }, [listening]);
-
-  useEffect(() => {
     const handler = () => endSTTSession();
     window.addEventListener(STOP_STT_EVENT, handler);
     return () => window.removeEventListener(STOP_STT_EVENT, handler);
   }, []);
 
   useEffect(() => {
-    return () => {
-      endSTTSession();
-    };
+    return () => endSTTSession();
   }, []);
 
   const isActive = listening || transcribing;

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef, useState } from "react";
-import { Microphone } from "@phosphor-icons/react";
+import { Microphone, CircleNotch } from "@phosphor-icons/react";
 import { Tooltip } from "react-tooltip";
 import { STOP_STT_EVENT } from "./index";
 import { useTranslation } from "react-i18next";
@@ -18,6 +18,7 @@ const SILENCE_CHECK_INTERVAL = 200;
 export default function ServerSpeechToText({ sendCommand }) {
   const [listening, setListening] = useState(false);
   const [transcribing, setTranscribing] = useState(false);
+  const [loading, setLoading] = useState(false);
   const mediaRecorderRef = useRef(null);
   const audioChunksRef = useRef([]);
   const streamRef = useRef(null);
@@ -28,6 +29,7 @@ export default function ServerSpeechToText({ sendCommand }) {
 
   async function startSTTSession() {
     try {
+      setLoading(true);
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
 
@@ -77,9 +79,11 @@ export default function ServerSpeechToText({ sendCommand }) {
       };
 
       mediaRecorder.start();
+      setLoading(false);
       setListening(true);
       startSilenceDetection(analyser);
     } catch (e) {
+      setLoading(false);
       console.error("Failed to start recording:", e);
       alert(
         "AnythingLLM does not have access to microphone. Please enable for this site to use this feature."
@@ -172,18 +176,27 @@ export default function ServerSpeechToText({ sendCommand }) {
       data-tooltip-id="tooltip-microphone-btn"
       data-tooltip-content={`${t("chat_window.microphone")} (CTRL + M)`}
       aria-label={t("chat_window.microphone")}
-      onClick={isActive ? endSTTSession : startSTTSession}
-      className={`group border-none relative flex justify-center items-center cursor-pointer w-8 h-8 rounded-full hover:bg-zinc-700 light:hover:bg-slate-200 ${
+      onClick={loading ? null : isActive ? endSTTSession : startSTTSession}
+      className={`group border-none relative flex justify-center items-center ${loading ? "cursor-wait" : "cursor-pointer"} w-8 h-8 rounded-full hover:bg-zinc-700 light:hover:bg-slate-200 ${
         isActive ? "bg-zinc-700 light:bg-slate-200" : ""
       }`}
     >
-      <Microphone
-        weight="regular"
-        size={18}
-        className={`pointer-events-none text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-600 shrink-0 ${
-          isActive ? "animate-pulse-glow !text-white light:!text-slate-800" : ""
-        }`}
-      />
+      {loading ? (
+        <CircleNotch
+          size={18}
+          className="pointer-events-none text-zinc-300 light:text-slate-600 shrink-0 animate-spin"
+        />
+      ) : (
+        <Microphone
+          weight="regular"
+          size={18}
+          className={`pointer-events-none text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-600 shrink-0 ${
+            isActive
+              ? "animate-pulse-glow !text-white light:!text-slate-800"
+              : ""
+          }`}
+        />
+      )}
       <Tooltip
         id="tooltip-microphone-btn"
         place="top"

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
@@ -1,0 +1,206 @@
+import { useEffect, useCallback, useRef, useState } from "react";
+import { Microphone } from "@phosphor-icons/react";
+import { Tooltip } from "react-tooltip";
+import { PROMPT_INPUT_EVENT } from "../../PromptInput";
+import { STOP_STT_EVENT } from "./index";
+import { useTranslation } from "react-i18next";
+import Appearance from "@/models/appearance";
+import System from "@/models/system";
+
+let silenceTimeout;
+const SILENCE_INTERVAL = 3_200;
+const SILENCE_THRESHOLD = 0.01;
+const SILENCE_CHECK_INTERVAL = 200;
+
+/**
+ * Server-backed Speech-to-Text component that records audio via MediaRecorder,
+ * sends it to the server for transcription via an OpenAI-compatible STT API,
+ * and feeds the transcript into the chat input.
+ */
+export default function ServerSpeechToText({ sendCommand }) {
+  const [listening, setListening] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const mediaRecorderRef = useRef(null);
+  const audioChunksRef = useRef([]);
+  const streamRef = useRef(null);
+  const analyserRef = useRef(null);
+  const silenceCheckRef = useRef(null);
+  const { t } = useTranslation();
+
+  async function startSTTSession() {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const audioContext = new AudioContext();
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 2048;
+      source.connect(analyser);
+      analyserRef.current = analyser;
+
+      const mediaRecorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+      audioChunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = async () => {
+        stopSilenceDetection();
+        const audioBlob = new Blob(audioChunksRef.current, {
+          type: "audio/webm",
+        });
+        audioChunksRef.current = [];
+
+        if (audioBlob.size > 0) {
+          setTranscribing(true);
+          const { text, error } = await System.transcribeAudio(audioBlob);
+          setTranscribing(false);
+
+          if (text && !error) {
+            if (Appearance.get("autoSubmitSttInput")) {
+              sendCommand({
+                text,
+                autoSubmit: true,
+                writeMode: "append",
+              });
+            } else {
+              sendCommand({ text, writeMode: "append" });
+            }
+          } else if (error) {
+            console.error("STT transcription error:", error);
+          }
+        }
+      };
+
+      mediaRecorder.start();
+      setListening(true);
+      startSilenceDetection(analyser);
+    } catch (e) {
+      console.error("Failed to start recording:", e);
+      alert(
+        "AnythingLLM does not have access to microphone. Please enable for this site to use this feature."
+      );
+    }
+  }
+
+  function endSTTSession() {
+    if (
+      mediaRecorderRef.current &&
+      mediaRecorderRef.current.state !== "inactive"
+    ) {
+      mediaRecorderRef.current.stop();
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+    stopSilenceDetection();
+    setListening(false);
+    clearTimeout(silenceTimeout);
+  }
+
+  function startSilenceDetection(analyser) {
+    const dataArray = new Float32Array(analyser.fftSize);
+    silenceCheckRef.current = setInterval(() => {
+      analyser.getFloatTimeDomainData(dataArray);
+      let sum = 0;
+      for (let i = 0; i < dataArray.length; i++) {
+        sum += dataArray[i] * dataArray[i];
+      }
+      const rms = Math.sqrt(sum / dataArray.length);
+
+      if (rms < SILENCE_THRESHOLD) {
+        if (!silenceTimeout) {
+          silenceTimeout = setTimeout(() => {
+            endSTTSession();
+          }, SILENCE_INTERVAL);
+        }
+      } else {
+        clearTimeout(silenceTimeout);
+        silenceTimeout = null;
+      }
+    }, SILENCE_CHECK_INTERVAL);
+  }
+
+  function stopSilenceDetection() {
+    if (silenceCheckRef.current) {
+      clearInterval(silenceCheckRef.current);
+      silenceCheckRef.current = null;
+    }
+    clearTimeout(silenceTimeout);
+    silenceTimeout = null;
+  }
+
+  const handleKeyPress = useCallback(
+    (event) => {
+      if (event.ctrlKey && event.keyCode === 77) {
+        if (listening) {
+          endSTTSession();
+        } else {
+          startSTTSession();
+        }
+      }
+    },
+    [listening]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyPress);
+    return () => document.removeEventListener("keydown", handleKeyPress);
+  }, [handleKeyPress]);
+
+  useEffect(() => {
+    function handlePromptUpdate(e) {
+      if (!e?.detail && listening) {
+        endSTTSession();
+      }
+    }
+    window.addEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
+    return () =>
+      window.removeEventListener(PROMPT_INPUT_EVENT, handlePromptUpdate);
+  }, [listening]);
+
+  useEffect(() => {
+    const handler = () => endSTTSession();
+    window.addEventListener(STOP_STT_EVENT, handler);
+    return () => window.removeEventListener(STOP_STT_EVENT, handler);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      endSTTSession();
+    };
+  }, []);
+
+  const isActive = listening || transcribing;
+  return (
+    <div
+      data-tooltip-id="tooltip-microphone-btn"
+      data-tooltip-content={`${t("chat_window.microphone")} (CTRL + M)`}
+      aria-label={t("chat_window.microphone")}
+      onClick={isActive ? endSTTSession : startSTTSession}
+      className={`group border-none relative flex justify-center items-center cursor-pointer w-8 h-8 rounded-full hover:bg-zinc-700 light:hover:bg-slate-200 ${
+        isActive ? "bg-zinc-700 light:bg-slate-200" : ""
+      }`}
+    >
+      <Microphone
+        weight="regular"
+        size={18}
+        className={`pointer-events-none text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-600 shrink-0 ${
+          isActive ? "animate-pulse-glow !text-white light:!text-slate-800" : ""
+        }`}
+      />
+      <Tooltip
+        id="tooltip-microphone-btn"
+        place="top"
+        delayShow={300}
+        className="tooltip !text-xs z-99"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/server.jsx
@@ -21,6 +21,7 @@ export default function ServerSpeechToText({ sendCommand }) {
   const mediaRecorderRef = useRef(null);
   const audioChunksRef = useRef([]);
   const streamRef = useRef(null);
+  const audioContextRef = useRef(null);
   const silenceCheckRef = useRef(null);
   const silenceTimeoutRef = useRef(null);
   const { t } = useTranslation();
@@ -31,6 +32,7 @@ export default function ServerSpeechToText({ sendCommand }) {
       streamRef.current = stream;
 
       const audioContext = new AudioContext();
+      audioContextRef.current = audioContext;
       const source = audioContext.createMediaStreamSource(stream);
       const analyser = audioContext.createAnalyser();
       analyser.fftSize = 2048;
@@ -95,6 +97,10 @@ export default function ServerSpeechToText({ sendCommand }) {
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+      audioContextRef.current = null;
     }
     stopSilenceDetection();
     setListening(false);

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -18,9 +18,7 @@ import handleSocketResponse, {
   setAgentSessionActive,
 } from "@/utils/chat/agent";
 import DnDFileUploaderWrapper from "./DnDWrapper";
-import SpeechRecognition, {
-  useSpeechRecognition,
-} from "react-speech-recognition";
+import { STOP_STT_EVENT } from "./PromptInput/SpeechToText";
 import { ChatTooltips } from "./ChatTooltips";
 import { MetricsProvider } from "./ChatHistory/HistoricalMessage/Actions/RenderMetrics";
 import useChatContainerQuickScroll from "@/hooks/useChatContainerQuickScroll";
@@ -46,10 +44,6 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
   const { files, parseAttachments } = useContext(DndUploaderContext);
   const { chatHistoryRef } = useChatContainerQuickScroll();
   const pendingMessageChecked = useRef(false);
-
-  const { listening, resetTranscript } = useSpeechRecognition({
-    clearTranscriptOnListen: true,
-  });
 
   /**
    * Emit an update to the state of the prompt input without directly
@@ -91,18 +85,15 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
       },
     ];
 
-    if (listening) {
-      // Stop the mic if the send button is clicked
-      endSTTSession();
-    }
+    // Stop any active STT session when the user submits a message
+    endSTTSession();
     setChatHistory(prevChatHistory);
     setMessageEmit("");
     setLoadingResponse(true);
   };
 
   function endSTTSession() {
-    SpeechRecognition.stopListening();
-    resetTranscript();
+    window.dispatchEvent(new CustomEvent(STOP_STT_EVENT));
   }
 
   const regenerateAssistantMessage = (chatId) => {

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -189,6 +189,20 @@ const System = {
         return { newValues: null, error: e.message };
       });
   },
+  transcribeAudio: async (audioBlob) => {
+    const formData = new FormData();
+    formData.append("audio", audioBlob, "recording.wav");
+    return await fetch(`${API_BASE}/system/stt`, {
+      method: "POST",
+      headers: baseHeaders(),
+      body: formData,
+    })
+      .then((res) => res.json())
+      .catch((e) => {
+        console.error(e);
+        return { text: null, error: e.message };
+      });
+  },
   updateSystemPassword: async (data) => {
     return await fetch(`${API_BASE}/system/update-password`, {
       method: "POST",

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -191,7 +191,7 @@ const System = {
   },
   transcribeAudio: async (audioBlob) => {
     const formData = new FormData();
-    formData.append("audio", audioBlob, "recording.wav");
+    formData.append("audio", audioBlob, "recording.webm");
     return await fetch(`${API_BASE}/system/stt`, {
       method: "POST",
       headers: baseHeaders(),

--- a/frontend/src/pages/GeneralSettings/AudioPreference/stt.jsx
+++ b/frontend/src/pages/GeneralSettings/AudioPreference/stt.jsx
@@ -5,7 +5,9 @@ import LLMItem from "@/components/LLMSelection/LLMItem";
 import { CaretUpDown, MagnifyingGlass, X } from "@phosphor-icons/react";
 import CTAButton from "@/components/lib/CTAButton";
 import AnythingLLMIcon from "@/media/logo/anything-llm-icon.png";
+import GenericOpenAiLogo from "@/media/ttsproviders/generic-openai.png";
 import BrowserNative from "@/components/SpeechToText/BrowserNative";
+import OpenAiGenericSTTOptions from "@/components/SpeechToText/OpenAiGenericOptions";
 
 const PROVIDERS = [
   {
@@ -14,6 +16,14 @@ const PROVIDERS = [
     logo: AnythingLLMIcon,
     options: (settings) => <BrowserNative settings={settings} />,
     description: "Uses your browser's built in STT service if supported.",
+  },
+  {
+    name: "OpenAI Compatible",
+    value: "generic-openai",
+    logo: GenericOpenAiLogo,
+    options: (settings) => <OpenAiGenericSTTOptions settings={settings} />,
+    description:
+      "Connect to an OpenAI compatible STT service running locally or remotely.",
   },
 ];
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -326,6 +326,12 @@ TTS_PROVIDER="native"
 # TTS_OPEN_AI_COMPATIBLE_VOICE_MODEL=nova
 # TTS_OPEN_AI_COMPATIBLE_ENDPOINT="https://api.openai.com/v1"
 
+# STT_PROVIDER="native"
+# STT_PROVIDER="generic-openai"
+# STT_OPEN_AI_COMPATIBLE_KEY=sk-example
+# STT_OPEN_AI_COMPATIBLE_MODEL=whisper-1
+# STT_OPEN_AI_COMPATIBLE_ENDPOINT="https://api.openai.com/v1"
+
 # CLOUD DEPLOYMENT VARIRABLES ONLY
 # AUTH_TOKEN="hunter2" # This is the password to your application if remote hosting.
 # STORAGE_DIR= # absolute filesystem path with no trailing slash

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -560,9 +560,11 @@ function systemEndpoints(app) {
     async (request, response) => {
       try {
         const multer = require("multer");
+
         const upload = multer({ storage: multer.memoryStorage() }).single(
           "audio"
         );
+
         upload(request, response, async function (err) {
           if (err) {
             return response

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -555,6 +555,49 @@ function systemEndpoints(app) {
   );
 
   app.post(
+    "/system/stt",
+    [validatedRequest, flexUserRoleValid([ROLES.all])],
+    async (request, response) => {
+      try {
+        const multer = require("multer");
+        const upload = multer({ storage: multer.memoryStorage() }).single(
+          "audio"
+        );
+        upload(request, response, async function (err) {
+          if (err) {
+            return response
+              .status(500)
+              .json({ text: null, error: `Upload failed: ${err.message}` });
+          }
+
+          if (!request.file) {
+            return response
+              .status(400)
+              .json({ text: null, error: "No audio file provided." });
+          }
+
+          const { getSTTProvider } = require("../utils/SpeechToText");
+          const provider = getSTTProvider();
+          const { text, error } = await provider.transcribe(
+            request.file.buffer,
+            request.file.originalname || "audio.wav"
+          );
+
+          if (error) {
+            return response.status(500).json({ text: null, error });
+          }
+          return response.status(200).json({ text, error: null });
+        });
+      } catch (e) {
+        console.error(e.message, e);
+        response
+          .status(500)
+          .json({ text: null, error: "Failed to transcribe audio." });
+      }
+    }
+  );
+
+  app.post(
     "/system/update-password",
     [validatedRequest],
     async (request, response) => {

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -293,6 +293,14 @@ const SystemSettings = {
         process.env.TTS_OPEN_AI_COMPATIBLE_VOICE_MODEL,
       TTSOpenAICompatibleEndpoint: process.env.TTS_OPEN_AI_COMPATIBLE_ENDPOINT,
 
+      // STT Provider Settings
+      SpeechToTextProvider: process.env.STT_PROVIDER || "native",
+      // OpenAI Generic STT
+      STTOpenAICompatibleKey: !!process.env.STT_OPEN_AI_COMPATIBLE_KEY,
+      STTOpenAICompatibleModel: process.env.STT_OPEN_AI_COMPATIBLE_MODEL,
+      STTOpenAICompatibleEndpoint:
+        process.env.STT_OPEN_AI_COMPATIBLE_ENDPOINT,
+
       // --------------------------------------------------------
       // Agent Settings & Configs
       // --------------------------------------------------------

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -298,8 +298,7 @@ const SystemSettings = {
       // OpenAI Generic STT
       STTOpenAICompatibleKey: !!process.env.STT_OPEN_AI_COMPATIBLE_KEY,
       STTOpenAICompatibleModel: process.env.STT_OPEN_AI_COMPATIBLE_MODEL,
-      STTOpenAICompatibleEndpoint:
-        process.env.STT_OPEN_AI_COMPATIBLE_ENDPOINT,
+      STTOpenAICompatibleEndpoint: process.env.STT_OPEN_AI_COMPATIBLE_ENDPOINT,
 
       // --------------------------------------------------------
       // Agent Settings & Configs

--- a/server/utils/SpeechToText/index.js
+++ b/server/utils/SpeechToText/index.js
@@ -1,0 +1,14 @@
+function getSTTProvider() {
+  const provider = process.env.STT_PROVIDER || "native";
+  switch (provider) {
+    case "generic-openai":
+      const { GenericOpenAiSTT } = require("./openAiGeneric");
+      return new GenericOpenAiSTT();
+    default:
+      throw new Error(
+        "STT_PROVIDER is not set to a valid server-side provider."
+      );
+  }
+}
+
+module.exports = { getSTTProvider };

--- a/server/utils/SpeechToText/openAiGeneric/index.js
+++ b/server/utils/SpeechToText/openAiGeneric/index.js
@@ -34,7 +34,7 @@ class GenericOpenAiSTT {
    * @param {string} [filename="audio.wav"] - The filename for the audio data.
    * @returns {Promise<{text: string|null, error: string|null}>}
    */
-  async transcribe(audioBuffer, filename = "audio.wav") {
+  async transcribe(audioBuffer, filename = "audio.webm") {
     try {
       const { toFile } = require("openai");
       const file = await toFile(audioBuffer, filename, {

--- a/server/utils/SpeechToText/openAiGeneric/index.js
+++ b/server/utils/SpeechToText/openAiGeneric/index.js
@@ -1,0 +1,57 @@
+class GenericOpenAiSTT {
+  constructor() {
+    if (!process.env.STT_OPEN_AI_COMPATIBLE_ENDPOINT)
+      throw new Error(
+        "No OpenAI compatible endpoint was set. Please set this to use your OpenAI compatible STT service."
+      );
+    if (!process.env.STT_OPEN_AI_COMPATIBLE_KEY)
+      this.#log(
+        "No OpenAI compatible API key was set. You might need to set this to use your OpenAI compatible STT service."
+      );
+    if (!process.env.STT_OPEN_AI_COMPATIBLE_MODEL)
+      this.#log(
+        "No OpenAI compatible STT model was set. We will use the default model 'whisper-1'. This may not exist or be valid for your selected endpoint."
+      );
+
+    const { OpenAI: OpenAIApi } = require("openai");
+    this.openai = new OpenAIApi({
+      apiKey: process.env.STT_OPEN_AI_COMPATIBLE_KEY || null,
+      baseURL: process.env.STT_OPEN_AI_COMPATIBLE_ENDPOINT,
+    });
+    this.model = process.env.STT_OPEN_AI_COMPATIBLE_MODEL ?? "whisper-1";
+    this.#log(
+      `Service (${process.env.STT_OPEN_AI_COMPATIBLE_ENDPOINT}) with model: ${this.model}`
+    );
+  }
+
+  #log(text, ...args) {
+    console.log(`\x1b[32m[OpenAiGenericSTT]\x1b[0m ${text}`, ...args);
+  }
+
+  /**
+   * Transcribes an audio file using the OpenAI compatible STT service.
+   * @param {Buffer} audioBuffer - The audio data buffer.
+   * @param {string} [filename="audio.wav"] - The filename for the audio data.
+   * @returns {Promise<{text: string|null, error: string|null}>}
+   */
+  async transcribe(audioBuffer, filename = "audio.wav") {
+    try {
+      const { toFile } = require("openai");
+      const file = await toFile(audioBuffer, filename, {
+        type: "audio/webm",
+      });
+      const result = await this.openai.audio.transcriptions.create({
+        file,
+        model: this.model,
+      });
+      return { text: result.text, error: null };
+    } catch (e) {
+      console.error("GenericOpenAiSTT transcription error:", e);
+      return { text: null, error: e.message };
+    }
+  }
+}
+
+module.exports = {
+  GenericOpenAiSTT,
+};

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -612,6 +612,24 @@ const KEY_MAPPING = {
     envKey: "TTS_PROVIDER",
     checks: [supportedTTSProvider],
   },
+  SpeechToTextProvider: {
+    envKey: "STT_PROVIDER",
+    checks: [supportedSTTProvider],
+  },
+
+  // STT OpenAI Generic
+  STTOpenAICompatibleKey: {
+    envKey: "STT_OPEN_AI_COMPATIBLE_KEY",
+    checks: [],
+  },
+  STTOpenAICompatibleModel: {
+    envKey: "STT_OPEN_AI_COMPATIBLE_MODEL",
+    checks: [],
+  },
+  STTOpenAICompatibleEndpoint: {
+    envKey: "STT_OPEN_AI_COMPATIBLE_ENDPOINT",
+    checks: [isValidURL],
+  },
 
   // TTS OpenAI
   TTSOpenAIKey: {
@@ -918,6 +936,11 @@ function supportedTTSProvider(input = "") {
     "generic-openai",
   ].includes(input);
   return validSelection ? null : `${input} is not a valid TTS provider.`;
+}
+
+function supportedSTTProvider(input = "") {
+  const validSelection = ["native", "generic-openai"].includes(input);
+  return validSelection ? null : `${input} is not a valid STT provider.`;
 }
 
 function validLocalWhisper(input = "") {


### PR DESCRIPTION

### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #3812

### Description

Adds a "Generic OpenAI Compatible" STT provider option, allowing users to use any OpenAI-compatible speech-to-text service (OpenAI Whisper, Groq, Deepgram, self-hosted faster-whisper, etc.) for voice-to-text transcription in the chat prompt input.

**What changed:**

- **New STT provider selection**: Users can now choose between "System native" (browser Web Speech API) and "OpenAI Compatible" in Settings > Audio Preference > Speech-to-text
- **Server-backed transcription**: When using the OpenAI Compatible provider, audio is recorded via the browser's MediaRecorder API, sent to a new `POST /system/stt` endpoint, which proxies the audio to the configured OpenAI-compatible transcription API (`/audio/transcriptions`)
- **Configurable settings**: Base URL, API Key, and Model are configurable via the settings UI
- **Silence detection**: Uses Web Audio API's AnalyserNode to detect silence and auto-stop recording after 3.2s (matching native provider behavior)
- **Auto-submit support**: Works with the existing "Auto Submit Speech Input" setting
- **CTRL+M shortcut**: Works with both providers
- **Decoupled ChatContainer from react-speech-recognition**: ChatContainer now uses a custom `STOP_STT_EVENT` to signal STT stop, making it provider-agnostic
- **Loading spinner on mic button**: When using the server-backed provider, clicking the mic shows a spinner while the browser acquires the microphone via `getUserMedia`. Unlike the native Web Speech API (which manages the mic internally and returns synchronously), the server provider must explicitly request the raw audio stream from the OS — this hardware initialization takes 1-3 seconds depending on the device and browser. The spinner provides visual feedback during this unavoidable delay so users know the app is responding. 
### Visuals (if applicable)

<img width="1822" height="1186" alt="image" src="https://github.com/user-attachments/assets/d6feae20-255d-4706-95cf-eb27287e96c0" />


### Additional Information

- The native browser STT provider is completely unchanged — this is purely additive
- Tested with OpenAI (`whisper-1`) and Groq (`whisper-large-v3`) successfully
- Audio is recorded as `audio/webm` (browser default) and sent through multer memory storage — no files written to disk

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally