### PR TITLE
feat: add missing Lemonade LLM provider env vars to .env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -176,6 +176,11 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # SAMBANOVA_LLM_API_KEY='xxx-xxx-xxx'
 # SAMBANOVA_LLM_MODEL_PREF='gpt-oss-120b'
 
+# LLM_PROVIDER='lemonade'
+# LEMONADE_LLM_BASE_PATH='http://127.0.0.1:8000'
+# LEMONADE_LLM_MODEL_PREF='Llama-3.2-1B-Instruct-GGUF'
+# LEMONADE_LLM_MODEL_TOKEN_LIMIT=8192
+
 ###########################################
 ######## Embedding API SElECTION ##########
 ###########################################


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5274

### Description

Adds missing `LLM_PROVIDER='lemonade'` environment variable templates to `server/.env.example`. Only the embedding engine section was documented in the example env file.

### Visuals (if applicable)

N/A

### Additional Information

N/A

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally