### PR TITLE
feat: add custom base URL support for Anthropic provider

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -28,6 +28,7 @@ GID='1000'
 # ANTHROPIC_API_KEY=sk-ant-xxxx
 # ANTHROPIC_MODEL_PREF='claude-2'
 # ANTHROPIC_CACHE_CONTROL="5m" # Enable prompt caching (5m=5min cache, 1h=1hour cache). Reduces costs and improves speed by caching system prompts.
+# ANTHROPIC_BASE_URL= # Optional: override the Anthropic API base URL for self-hosted or compatible backends (e.g. http://localhost:8080)
 
 # LLM_PROVIDER='lmstudio'
 # LMSTUDIO_BASE_PATH='http://your-server:1234/v1'

--- a/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
@@ -84,6 +84,27 @@ export default function AnthropicAiOptions({ settings }) {
               </option>
             </select>
           </div>
+          <div className="flex flex-col w-60">
+            <label className="text-white text-sm font-semibold block mb-3">
+              Custom Base URL{" "}
+              <span className="font-normal text-theme-text-secondary">
+                (optional)
+              </span>
+            </label>
+            <input
+              type="url"
+              name="AnthropicBaseURL"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder="https://api.anthropic.com"
+              defaultValue={settings?.AnthropicBaseURL ?? ""}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className="text-xs text-theme-text-secondary mt-1">
+              Override the Anthropic API endpoint. Useful for self-hosted
+              Anthropic-compatible backends.
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/server/.env.example
+++ b/server/.env.example
@@ -25,6 +25,7 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # ANTHROPIC_API_KEY=sk-ant-xxxx
 # ANTHROPIC_MODEL_PREF='claude-2'
 # ANTHROPIC_CACHE_CONTROL="5m" # Enable prompt caching (5m=5min cache, 1h=1hour cache). Reduces costs and improves speed by caching system prompts.
+# ANTHROPIC_BASE_URL= # Optional: override the Anthropic API base URL for self-hosted or compatible backends (e.g. http://localhost:8080)
 
 # LLM_PROVIDER='lmstudio'
 # LMSTUDIO_BASE_PATH='http://your-server:1234/v1'

--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -21,6 +21,9 @@ class AnthropicLLM {
     const AnthropicAI = require("@anthropic-ai/sdk");
     const anthropic = new AnthropicAI({
       apiKey: process.env.ANTHROPIC_API_KEY,
+      ...(process.env.ANTHROPIC_BASE_URL
+        ? { baseURL: process.env.ANTHROPIC_BASE_URL }
+        : {}),
       defaultHeaders: {
         "User-Agent": getAnythingLLMUserAgent(),
       },
@@ -89,6 +92,9 @@ class AnthropicLLM {
       /** @type {import("@anthropic-ai/sdk").Anthropic} */
       const anthropic = new AnthropicAI({
         apiKey: process.env.ANTHROPIC_API_KEY,
+        ...(process.env.ANTHROPIC_BASE_URL
+          ? { baseURL: process.env.ANTHROPIC_BASE_URL }
+          : {}),
       });
       const model = await anthropic.models.retrieve(modelName);
       return Number(model.max_tokens ?? 4096);

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -67,6 +67,10 @@ const KEY_MAPPING = {
           : "Invalid cache control. Must be one of: 5m, 1h.",
     ],
   },
+  AnthropicBaseURL: {
+    envKey: "ANTHROPIC_BASE_URL",
+    checks: [isValidURL],
+  },
 
   GeminiLLMApiKey: {
     envKey: "GEMINI_API_KEY",
@@ -881,6 +885,8 @@ function validOpenAIKey(input = "") {
 }
 
 function validAnthropicApiKey(input = "") {
+  // When a custom base URL is configured the endpoint may accept any API key format.
+  if (process.env.ANTHROPIC_BASE_URL) return null;
   return input.startsWith("sk-ant-")
     ? null
     : "Anthropic Key must start with sk-ant-";


### PR DESCRIPTION
Closes #5234

## What

Adds an optional `ANTHROPIC_BASE_URL` setting that lets users route the Anthropic provider to any Anthropic-compatible backend instead of the default `api.anthropic.com`.

## Why

Self-hosted inference servers (oMLX, Azure AI Foundry, local proxies) expose Anthropic-compatible `/v1/messages` APIs but have no way to be used with the Anthropic provider today. Users are forced to use Generic OpenAI as a workaround, losing Anthropic-specific UX (model picker, prompt caching, etc.).

## Changes

| File | Change |
|------|--------|
| `server/utils/AiProviders/anthropic/index.js` | Pass `baseURL` to `AnthropicAI` constructor and `fetchModelMaxTokens` when `ANTHROPIC_BASE_URL` is set |
| `server/utils/helpers/updateENV.js` | Register `AnthropicBaseURL` → `ANTHROPIC_BASE_URL` with `isValidURL` check; relax `sk-ant-` key format check when a custom base URL is present |
| `frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx` | Add "Custom Base URL" input in the existing advanced settings panel |
| `server/.env.example` / `docker/.env.example` | Document `ANTHROPIC_BASE_URL` |

## Review notes

- No changes to existing behavior when `ANTHROPIC_BASE_URL` is unset — the SDK uses its default endpoint
- The API key format check (`sk-ant-`) is bypassed only when a custom base URL is configured, since third-party backends accept arbitrary key strings
- The UI field is placed alongside the existing Prompt Caching control in the advanced settings section to keep the primary settings clean