### PR TITLE
fix: ensure text wraps properly in narrow windows

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -856,6 +856,8 @@ dialog::backdrop {
 
 .markdown {
   text-wrap: wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .markdown pre {


### PR DESCRIPTION
## Problem
When the ALLM desktop window is made narrow, chat message text gets cut off instead of wrapping properly (Issue #5291).

## Solution
Added `overflow-wrap: break-word` and `word-break: break-word` CSS properties to the `.markdown` class to ensure text wraps correctly at any window width.

## Changes
- Updated `frontend/src/index.css` to add text wrapping properties

## Testing
- Text now wraps properly when window is resized to narrow widths
- Both user messages and AI responses display correctly without being cut off

Fixes #5291