### PR TITLE
fix: coerce env values to string before .includes() check in updateENV

### DIFF
--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1196,7 +1196,7 @@ async function updateENV(newENVs = {}, force = false, userId = null) {
   const runAfterAll = [];
   const validKeys = Object.keys(KEY_MAPPING);
   const ENV_KEYS = Object.keys(newENVs).filter(
-    (key) => validKeys.includes(key) && !newENVs[key].includes("******") // strip out answers where the value is all asterisks
+    (key) => validKeys.includes(key) && !String(newENVs[key]).includes("******") // strip out answers where the value is all asterisks
   );
   const newValues = {};
 


### PR DESCRIPTION
## Summary
- Fix crash (500) in `POST /api/v1/system/update-env` when numeric values are passed
- Root cause: `.includes("******")` called on Number type — Number has no `.includes()` method
- Fix: wrap with `String()` before calling `.includes()`

## Steps to reproduce
```bash
curl -X POST /api/v1/system/update-env   -d '{"GenericOpenAiEmbeddingMaxConcurrentChunks": 1}'
# => 500 Internal Server Error
# => TypeError: newENVs[key].includes is not a function
```

## Change
```diff
- (key) => validKeys.includes(key) && !newENVs[key].includes("******")
+ (key) => validKeys.includes(key) && !String(newENVs[key]).includes("******")
```

## Test plan
- [ ] POST numeric value to `/api/v1/system/update-env` — no crash, value saved
- [ ] POST string with `******` — still filtered correctly
- [ ] POST normal string — saved as before