### PR TITLE
fix(embedding): throw on Lemonade engine failure instead of swallowing errors

### DIFF
--- a/server/utils/EmbeddingEngines/lemonade/index.js
+++ b/server/utils/EmbeddingEngines/lemonade/index.js
@@ -51,7 +51,8 @@ class LemonadeEmbedder {
         });
     });
 
-    if (error) throw new Error(`Lemonade Failed to embed: ${error.message}`);
+    if (error)
+      throw new Error(`Lemonade Failed to embed: [${error.type}]: ${error.message}`);
     return data.length > 0 &&
       data.every((embd) => embd.hasOwnProperty("embedding"))
       ? data.map((embd) => embd.embedding)

--- a/server/utils/EmbeddingEngines/lemonade/index.js
+++ b/server/utils/EmbeddingEngines/lemonade/index.js
@@ -26,31 +26,36 @@ class LemonadeEmbedder {
   }
 
   async embedTextInput(textInput) {
-    try {
-      this.log(`Embedding text input...`);
-      const response = await this.lemonade.embeddings.create({
-        model: this.model,
-        input: textInput,
-      });
-      return response?.data[0]?.embedding || [];
-    } catch (error) {
-      this.log("Failed to get embedding from Lemonade.", error.message);
-      throw new Error(`Lemonade Failed to embed: ${error.message}`);
-    }
+    const result = await this.embedChunks(
+      Array.isArray(textInput) ? textInput : [textInput]
+    );
+    return result?.[0] || [];
   }
 
   async embedChunks(textChunks = []) {
-    try {
-      this.log(`Embedding ${textChunks.length} chunks of text...`);
-      const response = await this.lemonade.embeddings.create({
-        model: this.model,
-        input: textChunks,
-      });
-      return response?.data?.map((emb) => emb.embedding) || [];
-    } catch (error) {
-      this.log("Failed to get embeddings from Lemonade.", error.message);
-      throw new Error(`Lemonade Failed to embed: ${error.message}`);
-    }
+    this.log(`Embedding ${textChunks.length} chunks of text...`);
+    const { data = [], error = null } = await new Promise((resolve) => {
+      this.lemonade.embeddings
+        .create({
+          model: this.model,
+          input: textChunks,
+        })
+        .then((result) => resolve({ data: result?.data, error: null }))
+        .catch((e) => {
+          e.type =
+            e?.response?.data?.error?.code ||
+            e?.response?.status ||
+            "failed_to_embed";
+          e.message = e?.response?.data?.error?.message || e.message;
+          resolve({ data: [], error: e });
+        });
+    });
+
+    if (error) throw new Error(`Lemonade Failed to embed: ${error.message}`);
+    return data.length > 0 &&
+      data.every((embd) => embd.hasOwnProperty("embedding"))
+      ? data.map((embd) => embd.embedding)
+      : null;
   }
 }
 

--- a/server/utils/EmbeddingEngines/lemonade/index.js
+++ b/server/utils/EmbeddingEngines/lemonade/index.js
@@ -34,8 +34,8 @@ class LemonadeEmbedder {
       });
       return response?.data[0]?.embedding || [];
     } catch (error) {
-      console.error("Failed to get embedding from Lemonade.", error.message);
-      return [];
+      this.log("Failed to get embedding from Lemonade.", error.message);
+      throw new Error(`Lemonade Failed to embed: ${error.message}`);
     }
   }
 
@@ -48,8 +48,8 @@ class LemonadeEmbedder {
       });
       return response?.data?.map((emb) => emb.embedding) || [];
     } catch (error) {
-      console.error("Failed to get embeddings from Lemonade.", error.message);
-      return new Array(textChunks.length).fill([]);
+      this.log("Failed to get embeddings from Lemonade.", error.message);
+      throw new Error(`Lemonade Failed to embed: ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #5305

The Lemonade embedding engine silently swallows errors and returns empty arrays, causing documents to be falsely reported as successfully embedded when embedding actually failed.

## Root Cause

Both `embedTextInput` and `embedChunks` in `server/utils/EmbeddingEngines/lemonade/index.js` catch errors and return empty arrays instead of rethrowing. Every other embedding engine (OpenAI, Cohere, VoyageAI, Ollama, LocalAI, Gemini) correctly throws on failure.

## Fix

Rethrow errors in both catch blocks to match the pattern used by all other embedding engines. This allows the caller to properly detect failures and mark documents as failed instead of falsely reporting success.

## Test Plan

- Disconnect/stop the Lemonade server
- Attempt to embed a document
- Before: document marked as embedded (with empty vectors)
- After: document correctly marked as failed with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)