### PR TITLE
feat: show Generic OpenAI in workspace model switcher with free-form

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
@@ -1,6 +1,7 @@
 import useGetProviderModels, {
   DISABLED_PROVIDERS,
 } from "@/hooks/useGetProvidersModels";
+import { useTranslation } from "react-i18next";
 
 export default function ChatModelSelection({
   provider,
@@ -8,8 +9,35 @@ export default function ChatModelSelection({
   selectedLLMModel,
   setSelectedLLMModel,
 }) {
+  const { t } = useTranslation();
   const { defaultModels, customModels, loading } =
     useGetProviderModels(provider);
+
+  if (provider === "generic-openai") {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <label
+          htmlFor="workspace-llm-model-select"
+          className="text-xs font-medium text-zinc-400 light:text-slate-500"
+        >
+          {t("chat.model.title")}
+        </label>
+        <input
+          id="workspace-llm-model-select"
+          type="text"
+          value={selectedLLMModel ?? ""}
+          onChange={(e) => {
+            setHasChanges(true);
+            setSelectedLLMModel(e.target.value);
+          }}
+          className="bg-zinc-900 light:bg-white text-white light:text-slate-900 text-sm rounded-lg h-8 w-full px-2.5 outline-none border border-zinc-900 light:border-slate-400"
+          placeholder="Enter model name exactly as referenced in the API (e.g., gpt-3.5-turbo)"
+          autoComplete="off"
+        />
+      </div>
+    );
+  }
+
   if (DISABLED_PROVIDERS.includes(provider)) return null;
 
   if (loading) {

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/utils.js
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/utils.js
@@ -25,21 +25,20 @@ export function autoScrollToSelectedLLMProvider(
  */
 export function validatedModelSelection(model) {
   try {
-    // If the entire select element is not found, return the model as is and cross our fingers
-    const selectOption = document.getElementById(`workspace-llm-model-select`);
-    if (!selectOption) return model;
+    const el = document.getElementById(`workspace-llm-model-select`);
+    if (!el) return model;
 
-    // If the model is not in the dropdown, return the first model in the dropdown
-    // to prevent invalid provider<>model selection issues
-    const selectedOption = selectOption.querySelector(
-      `option[value="${model}"]`
-    );
-    if (!selectedOption) return selectOption.querySelector(`option`).value;
+    if (el.tagName === "INPUT") {
+      const value = String(el.value ?? model ?? "").trim();
+      return value || null;
+    }
 
-    // If the model is in the dropdown, return the model as is
+    const selectedOption = el.querySelector(`option[value="${model}"]`);
+    if (!selectedOption) return el.querySelector(`option`)?.value ?? null;
+
     return model;
   } catch {
-    return null; // If the dropdown was empty or something else went wrong, return null to abort the save
+    return null;
   }
 }
 

--- a/frontend/src/hooks/useGetProvidersModels.js
+++ b/frontend/src/hooks/useGetProvidersModels.js
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 export const DISABLED_PROVIDERS = [
   "azure",
   "textgenwebui",
-  "generic-openai",
   "bedrock",
 ];
 const PROVIDER_DEFAULT_MODELS = {

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
@@ -43,6 +43,33 @@ export default function AgentModelSelection({
     useGetProviderModels(provider);
 
   const { t } = useTranslation();
+
+  if (provider === "generic-openai") {
+    return (
+      <div>
+        <div className="flex flex-col">
+          <label htmlFor="name" className="block input-label">
+            {t("agent.mode.title")}
+          </label>
+          <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+            {t("agent.mode.description")}
+          </p>
+        </div>
+        <input
+          type="text"
+          name="agentModel"
+          defaultValue={workspace?.agentModel || ""}
+          onChange={() => {
+            setHasChanges(true);
+          }}
+          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          placeholder="Enter model name exactly as referenced in the API (e.g., gpt-3.5-turbo)"
+          autoComplete="off"
+        />
+      </div>
+    );
+  }
+
   if (DISABLED_PROVIDERS.includes(provider)) {
     return (
       <div className="w-full h-10 justify-center items-center flex">


### PR DESCRIPTION
### description

- Adds Generic OpenAI to the top-left workspace model switcher and uses a text field for the model name (no model list).
- Updates save validation for that input and the agent model row so Generic OpenAI does not show an empty dropdown.

### Relevant Issues

resolves : #5337