### PR TITLE
fix: persist API agent chats in thread history

### DIFF
--- a/server/__tests__/utils/chats/apiChatHandler.test.js
+++ b/server/__tests__/utils/chats/apiChatHandler.test.js
@@ -1,0 +1,137 @@
+/* eslint-env jest, node */
+jest.mock("../../../models/workspaceChats", () => ({
+  WorkspaceChats: {
+    new: jest.fn(),
+    markThreadHistoryInvalidV2: jest.fn(),
+  },
+}));
+jest.mock("../../../models/telemetry", () => ({
+  Telemetry: {
+    sendTelemetry: jest.fn(),
+  },
+}));
+jest.mock("../../../utils/chats/index", () => ({
+  chatPrompt: jest.fn(),
+  sourceIdentifier: jest.fn(),
+  recentChatHistory: jest.fn(),
+  grepAllSlashCommands: jest.fn(async (message) => message),
+}));
+jest.mock("../../../utils/helpers", () => ({
+  getVectorDbClass: jest.fn(),
+  getLLMProvider: jest.fn(),
+}));
+jest.mock("../../../utils/DocumentManager", () => ({
+  DocumentManager: jest.fn(),
+}));
+jest.mock("../../../utils/collectorApi", () => ({
+  CollectorApi: jest.fn(),
+}));
+jest.mock("../../../utils/files", () => ({
+  hotdirPath: "/tmp/anything-llm-test-hotdir",
+  normalizePath: jest.fn((filePath) => filePath),
+  isWithin: jest.fn(() => true),
+  sanitizeFileName: jest.fn((filename) => filename),
+}));
+jest.mock("../../../utils/agents/ephemeral", () => {
+  const waitForClose = jest.fn();
+  const streamAgentEvents = jest.fn();
+  const EphemeralAgentHandler = jest.fn().mockImplementation(function (args) {
+    this.args = args;
+    this.init = jest.fn().mockResolvedValue();
+    this.createAIbitat = jest.fn().mockResolvedValue();
+    this.startAgentCluster = jest.fn();
+  });
+  EphemeralAgentHandler.isAgentInvocation = jest.fn();
+
+  const EphemeralEventListener = jest.fn().mockImplementation(function () {
+    this.waitForClose = waitForClose;
+    this.streamAgentEvents = streamAgentEvents;
+  });
+
+  return {
+    EphemeralAgentHandler,
+    EphemeralEventListener,
+    __mocks: {
+      waitForClose,
+      streamAgentEvents,
+    },
+  };
+});
+
+const { ApiChatHandler } = require("../../../utils/chats/apiChatHandler");
+const { WorkspaceChats } = require("../../../models/workspaceChats");
+const {
+  EphemeralAgentHandler,
+  __mocks: ephemeralMocks,
+} = require("../../../utils/agents/ephemeral");
+
+describe("ApiChatHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    EphemeralAgentHandler.isAgentInvocation.mockResolvedValue(true);
+    WorkspaceChats.new.mockResolvedValue({ chat: { id: 123 } });
+    ephemeralMocks.waitForClose.mockResolvedValue({
+      thoughts: ["Look up the requested data"],
+      textResponse: "Agent result",
+    });
+  });
+
+  describe("chatSync", () => {
+    test("persists agent chats to the target API thread history", async () => {
+      const workspace = { id: 1, slug: "workspace", chatMode: "chat" };
+      const user = { id: 2 };
+      const thread = { id: 3 };
+      const attachments = [
+        {
+          name: "image.png",
+          mime: "image/png",
+          contentString: "data:image/png;base64,abc123",
+        },
+      ];
+
+      const result = await ApiChatHandler.chatSync({
+        workspace,
+        message: "@agent summarize this",
+        mode: "chat",
+        user,
+        thread,
+        sessionId: "external-session",
+        attachments,
+      });
+
+      expect(EphemeralAgentHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspace,
+          prompt: "@agent summarize this",
+          userId: user.id,
+          threadId: thread.id,
+          sessionId: "external-session",
+          attachments,
+        })
+      );
+      expect(WorkspaceChats.new).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: workspace.id,
+          prompt: "@agent summarize this",
+          include: true,
+          threadId: thread.id,
+          apiSessionId: "external-session",
+          user,
+          response: expect.objectContaining({
+            text: "Agent result",
+            attachments,
+            type: "chat",
+            thoughts: ["Look up the requested data"],
+          }),
+        })
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          chatId: 123,
+          textResponse: "Agent result",
+          thoughts: ["Look up the requested data"],
+        })
+      );
+    });
+  });
+});

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -190,7 +190,7 @@ async function chatSync({
     return await eventListener
       .waitForClose()
       .then(async ({ thoughts, textResponse }) => {
-        await WorkspaceChats.new({
+        const { chat } = await WorkspaceChats.new({
           workspaceId: workspace.id,
           prompt: String(message),
           response: {
@@ -200,8 +200,10 @@ async function chatSync({
             type: chatMode,
             thoughts,
           },
-          include: false,
+          include: true,
+          threadId: thread?.id || null,
           apiSessionId: sessionId,
+          user,
         });
         return {
           id: uuid,
@@ -209,6 +211,7 @@ async function chatSync({
           sources: [],
           close: true,
           error: null,
+          chatId: chat?.id,
           textResponse,
           thoughts,
         };
@@ -538,7 +541,7 @@ async function streamChat({
     return eventListener
       .streamAgentEvents(response, uuid)
       .then(async ({ thoughts, textResponse }) => {
-        await WorkspaceChats.new({
+        const { chat } = await WorkspaceChats.new({
           workspaceId: workspace.id,
           prompt: String(message),
           response: {
@@ -551,6 +554,7 @@ async function streamChat({
           include: true,
           threadId: thread?.id || null,
           apiSessionId: sessionId,
+          user,
         });
         writeResponseChunk(response, {
           uuid,
@@ -559,6 +563,7 @@ async function streamChat({
           thoughts,
           close: true,
           error: false,
+          chatId: chat?.id,
         });
       });
   }


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5060

### Description

Persist API `@agent` chat results with the same thread/user/session metadata as normal API chats so thread-scoped agent interactions are returned by thread history endpoints and visible in the UI.

This updates the synchronous API agent path to save visible chat history rows with `threadId`, `user`, and `apiSessionId`, and aligns the streaming API agent save path with the same metadata. Both API agent paths now return the saved `chatId` when persistence succeeds.

### Visuals (if applicable)

N/A

### Additional Information

No public API contract changes beyond including the saved `chatId` in API agent responses, matching normal chat behavior.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

Focused validations run:

- `corepack yarn test server/__tests__/utils/chats/apiChatHandler.test.js --runInBand`
- `cd server && corepack yarn eslint utils/chats/apiChatHandler.js`
- `cd server && corepack yarn prettier --check utils/chats/apiChatHandler.js __tests__/utils/chats/apiChatHandler.test.js`
