### PR TITLE
fix: preserve Confluence context paths

### DIFF
--- a/collector/__tests__/utils/extensions/Confluence/ConfluenceLoader.test.js
+++ b/collector/__tests__/utils/extensions/Confluence/ConfluenceLoader.test.js
@@ -1,0 +1,73 @@
+/* eslint-env jest, node */
+process.env.STORAGE_DIR = "test-storage";
+
+const { normalizeBaseUrl } = require("../../../../utils/extensions/Confluence");
+const {
+  ConfluencePagesLoader,
+} = require("../../../../utils/extensions/Confluence/ConfluenceLoader");
+
+describe("Confluence base URL handling", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("preserves self-hosted context paths", () => {
+    expect(normalizeBaseUrl("https://my.domain.com/confluence/", false)).toBe(
+      "https://my.domain.com/confluence"
+    );
+  });
+
+  test("ignores cloud URL paths before loader appends cloud routes", () => {
+    expect(
+      normalizeBaseUrl("https://example.atlassian.net/wiki/spaces/SP", true)
+    ).toBe("https://example.atlassian.net");
+  });
+
+  test("fetches self-hosted Confluence API through the configured context path", async () => {
+    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ size: 0, results: [] }),
+    });
+    const loader = new ConfluencePagesLoader({
+      baseUrl: normalizeBaseUrl("https://my.domain.com/confluence/", false),
+      spaceKey: "SP",
+      username: "user",
+      accessToken: "token",
+      cloud: false,
+    });
+
+    await loader.fetchAllPagesInSpace();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://my.domain.com/confluence/rest/api/content?spaceKey=SP&limit=25&start=0&expand=body.storage,version",
+      expect.any(Object)
+    );
+  });
+
+  test("builds self-hosted page URLs through the configured context path", () => {
+    const loader = new ConfluencePagesLoader({
+      baseUrl: normalizeBaseUrl("https://my.domain.com/confluence/", false),
+      spaceKey: "SP",
+      username: "user",
+      accessToken: "token",
+      cloud: false,
+    });
+
+    const document = loader.createDocumentFromPage({
+      id: "123",
+      status: "current",
+      title: "Context path page",
+      type: "page",
+      body: { storage: { value: "<p>Hello</p>" } },
+      version: {
+        number: 1,
+        by: { displayName: "User" },
+        when: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    expect(document.metadata.url).toBe(
+      "https://my.domain.com/confluence/spaces/SP/pages/123"
+    );
+  });
+});

--- a/collector/__tests__/utils/extensions/Confluence/ConfluenceLoader.test.js
+++ b/collector/__tests__/utils/extensions/Confluence/ConfluenceLoader.test.js
@@ -1,73 +1,125 @@
 /* eslint-env jest, node */
 process.env.STORAGE_DIR = "test-storage";
 
-const { normalizeBaseUrl } = require("../../../../utils/extensions/Confluence");
+const { resolveConfluenceBaseUrl } = require("../../../../utils/extensions/Confluence");
 const {
   ConfluencePagesLoader,
 } = require("../../../../utils/extensions/Confluence/ConfluenceLoader");
 
-describe("Confluence base URL handling", () => {
+describe("resolveConfluenceBaseUrl", () => {
+  test("cloud: strips path and returns origin only", () => {
+    expect(
+      resolveConfluenceBaseUrl("https://example.atlassian.net/wiki/spaces/SP", true)
+    ).toBe("https://example.atlassian.net");
+  });
+
+  test("self-hosted: preserves context path, strips trailing slash", () => {
+    expect(
+      resolveConfluenceBaseUrl("https://my.domain.com/confluence/", false)
+    ).toBe("https://my.domain.com/confluence");
+  });
+
+  test("self-hosted: returns origin when no context path", () => {
+    expect(
+      resolveConfluenceBaseUrl("https://my.domain.com/", false)
+    ).toBe("https://my.domain.com");
+  });
+});
+
+describe("ConfluencePagesLoader", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  test("preserves self-hosted context paths", () => {
-    expect(normalizeBaseUrl("https://my.domain.com/confluence/", false)).toBe(
-      "https://my.domain.com/confluence"
-    );
+  describe("cloud mode", () => {
+    test("API requests include /wiki prefix", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ size: 0, results: [] }),
+      });
+      const loader = new ConfluencePagesLoader({
+        baseUrl: resolveConfluenceBaseUrl("https://example.atlassian.net/wiki/spaces/SP", true),
+        spaceKey: "SP",
+        username: "user",
+        accessToken: "token",
+        cloud: true,
+      });
+
+      await loader.fetchAllPagesInSpace();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.atlassian.net/wiki/rest/api/content?spaceKey=SP&limit=25&start=0&expand=body.storage,version",
+        expect.any(Object)
+      );
+    });
+
+    test("page URLs include /wiki prefix", () => {
+      const loader = new ConfluencePagesLoader({
+        baseUrl: resolveConfluenceBaseUrl("https://example.atlassian.net/wiki", true),
+        spaceKey: "SP",
+        username: "user",
+        accessToken: "token",
+        cloud: true,
+      });
+
+      const document = loader.createDocumentFromPage({
+        id: "123",
+        status: "current",
+        title: "Cloud page",
+        type: "page",
+        body: { storage: { value: "<p>Hello</p>" } },
+        version: { number: 1, by: { displayName: "User" }, when: "2026-01-01T00:00:00.000Z" },
+      });
+
+      expect(document.metadata.url).toBe(
+        "https://example.atlassian.net/wiki/spaces/SP/pages/123"
+      );
+    });
   });
 
-  test("ignores cloud URL paths before loader appends cloud routes", () => {
-    expect(
-      normalizeBaseUrl("https://example.atlassian.net/wiki/spaces/SP", true)
-    ).toBe("https://example.atlassian.net");
-  });
+  describe("self-hosted mode", () => {
+    test("API requests use context path without /wiki", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ size: 0, results: [] }),
+      });
+      const loader = new ConfluencePagesLoader({
+        baseUrl: resolveConfluenceBaseUrl("https://my.domain.com/confluence/", false),
+        spaceKey: "SP",
+        username: "user",
+        accessToken: "token",
+        cloud: false,
+      });
 
-  test("fetches self-hosted Confluence API through the configured context path", async () => {
-    const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
-      ok: true,
-      json: jest.fn().mockResolvedValue({ size: 0, results: [] }),
-    });
-    const loader = new ConfluencePagesLoader({
-      baseUrl: normalizeBaseUrl("https://my.domain.com/confluence/", false),
-      spaceKey: "SP",
-      username: "user",
-      accessToken: "token",
-      cloud: false,
-    });
+      await loader.fetchAllPagesInSpace();
 
-    await loader.fetchAllPagesInSpace();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://my.domain.com/confluence/rest/api/content?spaceKey=SP&limit=25&start=0&expand=body.storage,version",
-      expect.any(Object)
-    );
-  });
-
-  test("builds self-hosted page URLs through the configured context path", () => {
-    const loader = new ConfluencePagesLoader({
-      baseUrl: normalizeBaseUrl("https://my.domain.com/confluence/", false),
-      spaceKey: "SP",
-      username: "user",
-      accessToken: "token",
-      cloud: false,
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://my.domain.com/confluence/rest/api/content?spaceKey=SP&limit=25&start=0&expand=body.storage,version",
+        expect.any(Object)
+      );
     });
 
-    const document = loader.createDocumentFromPage({
-      id: "123",
-      status: "current",
-      title: "Context path page",
-      type: "page",
-      body: { storage: { value: "<p>Hello</p>" } },
-      version: {
-        number: 1,
-        by: { displayName: "User" },
-        when: "2026-01-01T00:00:00.000Z",
-      },
-    });
+    test("page URLs use context path without /wiki", () => {
+      const loader = new ConfluencePagesLoader({
+        baseUrl: resolveConfluenceBaseUrl("https://my.domain.com/confluence/", false),
+        spaceKey: "SP",
+        username: "user",
+        accessToken: "token",
+        cloud: false,
+      });
 
-    expect(document.metadata.url).toBe(
-      "https://my.domain.com/confluence/spaces/SP/pages/123"
-    );
+      const document = loader.createDocumentFromPage({
+        id: "123",
+        status: "current",
+        title: "Self-hosted page",
+        type: "page",
+        body: { storage: { value: "<p>Hello</p>" } },
+        version: { number: 1, by: { displayName: "User" }, when: "2026-01-01T00:00:00.000Z" },
+      });
+
+      expect(document.metadata.url).toBe(
+        "https://my.domain.com/confluence/spaces/SP/pages/123"
+      );
+    });
   });
 });

--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -46,7 +46,7 @@ async function loadConfluence(
     };
   }
 
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, cloud);
+  const normalizedBaseUrl = resolveConfluenceBaseUrl(baseUrl, cloud);
   const { hostname } = new URL(normalizedBaseUrl);
   console.log(`-- Working Confluence ${normalizedBaseUrl} --`);
   const loader = new ConfluencePagesLoader({
@@ -183,7 +183,7 @@ async function fetchConfluencePage({
   }
 
   console.log(`-- Working Confluence Page ${pageUrl} --`);
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, cloud);
+  const normalizedBaseUrl = resolveConfluenceBaseUrl(baseUrl, cloud);
   const loader = new ConfluencePagesLoader({
     baseUrl: normalizedBaseUrl,
     spaceKey,
@@ -246,19 +246,18 @@ function validBaseUrl(baseUrl) {
 }
 
 /**
- * Normalizes the configured Confluence base URL while preserving context paths
- * for self-hosted deployments.
+ * Resolves the Confluence base URL, preserving context paths for self-hosted deployments.
  * @param {string} baseUrl
  * @param {boolean} cloud
  * @returns {string}
  */
-function normalizeBaseUrl(baseUrl, cloud = true) {
+function resolveConfluenceBaseUrl(baseUrl, cloud = true) {
   const url = new URL(baseUrl);
-  const pathname = url.pathname.replace(/\/+$/, "");
-  const normalizedPath = pathname === "/" ? "" : pathname;
-  const basePath = cloud ? "" : normalizedPath;
+  // Cloud URLs use just the origin; self-hosted may have a context path like /confluence
+  if (cloud) return url.origin;
 
-  return `${url.origin}${basePath}`;
+  const contextPath = url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${contextPath}`;
 }
 
 /**
@@ -289,5 +288,5 @@ function generateChunkSource(
 module.exports = {
   loadConfluence,
   fetchConfluencePage,
-  normalizeBaseUrl,
+  resolveConfluenceBaseUrl,
 };

--- a/collector/utils/extensions/Confluence/index.js
+++ b/collector/utils/extensions/Confluence/index.js
@@ -46,10 +46,11 @@ async function loadConfluence(
     };
   }
 
-  const { origin, hostname } = new URL(baseUrl);
-  console.log(`-- Working Confluence ${origin} --`);
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, cloud);
+  const { hostname } = new URL(normalizedBaseUrl);
+  console.log(`-- Working Confluence ${normalizedBaseUrl} --`);
   const loader = new ConfluencePagesLoader({
-    baseUrl: origin, // Use the origin to avoid issues with subdomains, ports, protocols, etc.
+    baseUrl: normalizedBaseUrl,
     spaceKey,
     username,
     accessToken,
@@ -98,13 +99,13 @@ async function loadConfluence(
       id: v4(),
       url: doc.metadata.url + ".page",
       title: doc.metadata.title || doc.metadata.source,
-      docAuthor: origin,
+      docAuthor: normalizedBaseUrl,
       description: doc.metadata.title,
-      docSource: `${origin} Confluence`,
+      docSource: `${normalizedBaseUrl} Confluence`,
       chunkSource: generateChunkSource(
         {
           doc,
-          baseUrl: origin,
+          baseUrl: normalizedBaseUrl,
           spaceKey,
           accessToken,
           username,
@@ -182,8 +183,9 @@ async function fetchConfluencePage({
   }
 
   console.log(`-- Working Confluence Page ${pageUrl} --`);
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, cloud);
   const loader = new ConfluencePagesLoader({
-    baseUrl, // Should be the origin of the baseUrl
+    baseUrl: normalizedBaseUrl,
     spaceKey,
     username,
     accessToken,
@@ -244,6 +246,22 @@ function validBaseUrl(baseUrl) {
 }
 
 /**
+ * Normalizes the configured Confluence base URL while preserving context paths
+ * for self-hosted deployments.
+ * @param {string} baseUrl
+ * @param {boolean} cloud
+ * @returns {string}
+ */
+function normalizeBaseUrl(baseUrl, cloud = true) {
+  const url = new URL(baseUrl);
+  const pathname = url.pathname.replace(/\/+$/, "");
+  const normalizedPath = pathname === "/" ? "" : pathname;
+  const basePath = cloud ? "" : normalizedPath;
+
+  return `${url.origin}${basePath}`;
+}
+
+/**
  * Generate the full chunkSource for a specific Confluence page so that we can resync it later.
  * This data is encrypted into a single `payload` query param so we can replay credentials later
  * since this was encrypted with the systems persistent password and salt.
@@ -271,4 +289,5 @@ function generateChunkSource(
 module.exports = {
   loadConfluence,
   fetchConfluencePage,
+  normalizeBaseUrl,
 };


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #4678

### Description

Preserve configured context paths for self-hosted Confluence base URLs so instances hosted under paths like `https://my.domain.com/confluence` call the REST API through that path instead of stripping back to the origin.

Cloud deployments continue to normalize to the URL origin before the loader appends Atlassian Cloud `/wiki` routes, which keeps existing cloud behavior intact.

### Visuals (if applicable)

N/A

### Additional Information

The saved document source and encrypted resync payload now use the normalized Confluence base URL, so future resyncs keep the same self-hosted context path.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

Focused validations run:

- `corepack yarn test collector/__tests__/utils/extensions/Confluence/ConfluenceLoader.test.js --runInBand`
- `cd collector && corepack yarn eslint utils/extensions/Confluence/index.js`
- `cd collector && corepack yarn prettier --check utils/extensions/Confluence/index.js __tests__/utils/extensions/Confluence/ConfluenceLoader.test.js`
