### PR TITLE
fix: omit temperature param for Bedrock Claude Opus 4.7

### DIFF
--- a/server/utils/AiProviders/bedrock/index.js
+++ b/server/utils/AiProviders/bedrock/index.js
@@ -21,6 +21,9 @@ const {
   getBedrockAuthMethod,
 } = require("./utils");
 
+// Bedrock models known to reject the `temperature` inference parameter.
+const MODELS_THAT_REJECT_TEMPERATURE = ["anthropic.claude-opus-4-7"];
+
 class AWSBedrockLLM {
   /**
    * List of Bedrock models observed to not support system prompts when using the Converse API.
@@ -408,7 +411,9 @@ class AWSBedrockLLM {
             messages: history,
             inferenceConfig: {
               maxTokens: maxTokensToSend,
-              temperature: temperature ?? this.defaultTemp,
+              ...(!MODELS_THAT_REJECT_TEMPERATURE.includes(this.model)
+                ? { temperature: temperature ?? this.defaultTemp }
+                : {}),
             },
             system: systemBlock,
           })
@@ -483,7 +488,9 @@ class AWSBedrockLLM {
           messages: history,
           inferenceConfig: {
             maxTokens: maxTokensToSend,
-            temperature: temperature ?? this.defaultTemp,
+            ...(!MODELS_THAT_REJECT_TEMPERATURE.includes(this.model)
+              ? { temperature: temperature ?? this.defaultTemp }
+              : {}),
           },
           system: systemBlock,
         })

--- a/server/utils/AiProviders/bedrock/index.js
+++ b/server/utils/AiProviders/bedrock/index.js
@@ -21,9 +21,6 @@ const {
   getBedrockAuthMethod,
 } = require("./utils");
 
-// Bedrock models known to reject the `temperature` inference parameter.
-const MODELS_THAT_REJECT_TEMPERATURE = ["anthropic.claude-opus-4-7"];
-
 class AWSBedrockLLM {
   /**
    * List of Bedrock models observed to not support system prompts when using the Converse API.
@@ -35,6 +32,15 @@ class AWSBedrockLLM {
     "cohere.command-text-v14",
     "cohere.command-light-text-v14",
     "us.deepseek.r1-v1:0",
+    // Add other models here if identified
+  ];
+
+  /**
+   * List of Bedrock models observed to not support the `temperature` inference parameter.
+   * @type {string[]}
+   */
+  noTemperatureModels = [
+    "anthropic.claude-opus-4-7",
     // Add other models here if identified
   ];
 
@@ -104,6 +110,21 @@ class AWSBedrockLLM {
    */
   get credentials() {
     return createBedrockCredentials(this.authMethod);
+  }
+
+  /**
+   * Gets the temperature configuration for the AWS Bedrock LLM.
+   * @param {number} temperature - The temperature to use.
+   * @returns {{temperature: number}} The temperature configuration object with the temperature value as a float.
+   */
+  temperatureConfig(temperature = this.defaultTemp) {
+    if (typeof temperature !== "number") return {};
+
+    // So model names prefix `us.` and may not be exact matches - so we check with includes to see if the model
+    // substring matches any of the models in the noTemperatureModels array.
+    if (this.noTemperatureModels.some((model) => this.model.includes(model)))
+      return {};
+    return { temperature: parseFloat(temperature) };
   }
 
   /**
@@ -411,9 +432,7 @@ class AWSBedrockLLM {
             messages: history,
             inferenceConfig: {
               maxTokens: maxTokensToSend,
-              ...(!MODELS_THAT_REJECT_TEMPERATURE.includes(this.model)
-                ? { temperature: temperature ?? this.defaultTemp }
-                : {}),
+              ...this.temperatureConfig(temperature),
             },
             system: systemBlock,
           })
@@ -488,9 +507,7 @@ class AWSBedrockLLM {
           messages: history,
           inferenceConfig: {
             maxTokens: maxTokensToSend,
-            ...(!MODELS_THAT_REJECT_TEMPERATURE.includes(this.model)
-              ? { temperature: temperature ?? this.defaultTemp }
-              : {}),
+            ...this.temperatureConfig(temperature),
           },
           system: systemBlock,
         })


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5461

### Description

AWS Bedrock rejects requests to `anthropic.claude-opus-4-7` when `temperature` is included in `inferenceConfig` — the parameter is deprecated for that model and the call fails validation.

This PR introduces a module-level `MODELS_THAT_REJECT_TEMPERATURE` list in `server/utils/AiProviders/bedrock/index.js` and conditionally omits `temperature` from the Converse API payload in both call sites that build it:

- `getChatCompletion` (non-streaming)
- `streamGetChatCompletion` (streaming)

All other Bedrock models continue to receive `temperature ?? this.defaultTemp` exactly as before, so behavior is unchanged outside of the explicitly listed models. The agent-mode Bedrock provider (`server/utils/agents/aibitat/providers/bedrock.js`) never sent `temperature` in the first place, so no changes were needed there.

### Visuals (if applicable)

N/A

### Additional Information

If Bedrock later adds other models that reject `temperature`, extend the `MODELS_THAT_REJECT_TEMPERATURE` array at the top of `bedrock/index.js` — no other code changes required.

### Developer Validations

- [x] I ran \`yarn lint\` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [x] Docker build succeeds locally