### PR TITLE
fix: long-prompt bubble flicker & See More collapse on streaming/scroll

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useRef, useState } from "react";
+import React, { memo, useLayoutEffect, useRef, useState } from "react";
 import { Info, Warning } from "@phosphor-icons/react";
 import Actions from "./Actions";
 import renderMarkdown from "@/utils/chat/markdown";
@@ -22,7 +22,7 @@ import HistoricalOutputs from "./HistoricalOutputs";
 import { openImageLightbox } from "@/components/ImageLightbox";
 
 const HistoricalMessage = ({
-  uuid = v4(),
+  uuid: uuidProp,
   message,
   role,
   workspace,
@@ -38,6 +38,10 @@ const HistoricalMessage = ({
   metrics = {},
   outputs = [],
 }) => {
+  // Freeze uuid on first render. User messages arrive without a uuid and this value
+  // is used as the wrapper div's `key` — a default param fallback would regenerate
+  // on every render and remount the subtree, wiping TruncatableContent state.
+  const [uuid] = useState(() => uuidProp ?? v4());
   const { t } = useTranslation();
   const { isEditing } = useEditMessage({ chatId, role });
   const { isDeleted, completeDelete, onEndAnimation } = useWatchDeleteMessage({
@@ -238,7 +242,9 @@ function TruncatableContent({ children }) {
   const [isOverflowing, setIsOverflowing] = useState(false);
   const { t } = useTranslation();
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so collapse applies before paint — avoids a
+  // one-frame flash of uncollapsed content on mount.
+  useLayoutEffect(() => {
     if (contentRef.current) {
       setIsOverflowing(contentRef.current.scrollHeight > 250);
     }


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

resolves #5455

### Description

Fixes two related bugs with the \"See More\" collapse bubble on long user prompts in the chat UI:

1. **Flicker during streaming** — When a long prompt is collapsed (above the 250px threshold) and a new response is streaming out, the bubble briefly flashes its full content, then re-collapses. Visible as a jarring flicker near the end of every stream.
2. **\"See More\" re-collapses on scroll / unrelated re-renders** — After clicking \"See More\" to expand a long prompt, the bubble collapses itself again while reading/scrolling.

**Root cause (both bugs):** `HistoricalMessage` used `uuid = v4()` as a default parameter. User messages are pushed to history without a uuid (`ChatContainer/index.jsx`) and the server's `convertToChatHistory` also omits it (`server/utils/helpers/chat/responses.js`). Default params run on every call, so `v4()` generated a fresh uuid on every re-render. That uuid is used as `key={uuid}` on the wrapper `<div>` — when React sees a new key it unmounts and remounts the subtree, wiping `TruncatableContent`'s `isExpanded` / `isOverflowing` state.

- The \"flicker at end of stream\" triggers when `finalizeResponseStream` backfills the user message's `chatId` (`utils/chat/index.js:107`). The memo comparison flips on `chatId`, re-render fires, uuid regenerates, subtree remounts.
- The \"re-collapse on scroll\" is the same mechanism — any memo miss remounts and resets `isExpanded`.

**Fix** in `frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx`:

1. Freeze uuid on first render via `useState(() => uuidProp ?? v4())` so it stays stable across re-renders and the wrapper div's `key` never changes.
2. Swap `useEffect` → `useLayoutEffect` for the `scrollHeight` measurement in `TruncatableContent` so the collapse applies before the first paint, eliminating a one-frame flash of uncollapsed content on mount.

### Visuals (if applicable)

N/A — fix removes a visual flicker.

### Additional Information

Small, scoped change to one file (9 insertions, 3 deletions). Behavior for assistant messages is unchanged since they always arrive with a uuid.

### Developer Validations

- [x] I ran \`yarn lint\` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally