### PR TITLE
fix: surface readable error messages in web-scraping agent and ai-provider

### DIFF
--- a/server/utils/agents/aibitat/plugins/web-scraping.js
+++ b/server/utils/agents/aibitat/plugins/web-scraping.js
@@ -49,17 +49,14 @@ const webScraping = {
               if (url) return await this.scrape(url);
               return "There is nothing we can do. This function call returns no information.";
             } catch (error) {
-              const errorDetails =
-                error instanceof Error
-                  ? error.message
-                  : JSON.stringify(error, Object.getOwnPropertyNames(error), 2);
+              const errorMessage = error?.message ?? JSON.stringify(error);
               this.super.handlerProps.log(
-                `Web Scraping Error: ${errorDetails}`
+                `Web Scraping Error: ${errorMessage}`
               );
               this.super.introspect(
-                `${this.caller}: Web Scraping Error: ${error?.message ?? errorDetails}`
+                `${this.caller}: Web Scraping Error: ${errorMessage}`
               );
-              return `There was an error while calling the function. No data or response was found. Let the user know this was the error: ${error.message}`;
+              return `There was an error while calling the function. No data or response was found. Let the user know this was the error: ${errorMessage}`;
             }
           },
 

--- a/server/utils/agents/aibitat/plugins/web-scraping.js
+++ b/server/utils/agents/aibitat/plugins/web-scraping.js
@@ -49,11 +49,15 @@ const webScraping = {
               if (url) return await this.scrape(url);
               return "There is nothing we can do. This function call returns no information.";
             } catch (error) {
+              const errorDetails =
+                error instanceof Error
+                  ? error.message
+                  : JSON.stringify(error, Object.getOwnPropertyNames(error), 2);
               this.super.handlerProps.log(
-                `Web Scraping Error: ${error.message}`
+                `Web Scraping Error: ${errorDetails}`
               );
               this.super.introspect(
-                `${this.caller}: Web Scraping Error: ${error.message}`
+                `${this.caller}: Web Scraping Error: ${error?.message ?? errorDetails}`
               );
               return `There was an error while calling the function. No data or response was found. Let the user know this was the error: ${error.message}`;
             }

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -406,7 +406,9 @@ class Provider {
           ...config,
         });
       default:
-        throw new Error(`Unsupported provider ${provider} for this task.`);
+        throw new Error(
+          `Unsupported provider ${typeof provider === "string" ? provider : JSON.stringify(provider)} for this task.`
+        );
     }
   }
 

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -407,7 +407,7 @@ class Provider {
         });
       default:
         throw new Error(
-          `Unsupported provider ${typeof provider === "string" ? provider : JSON.stringify(provider)} for this task.`
+          `Unsupported provider ${JSON.stringify(provider)} for this task.`
         );
     }
   }


### PR DESCRIPTION
### Pull Request Type


- [x] 🐛 fix (Bug fix)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

connects #5353 

### Description

Instead of clear messages, error objects passed through template literals in the web-scraping handler and LangChainChatModel showed [object Object]. Fixed both to surface `error.message` or a JSON serialized fallback.

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->
Before:
```
Tool Call: web-scraping({"url":"https://example.com"})
@agent is executing `web-scraping` tool { "url": "https://example.com" }
@agent: Scraping the content of https://example.com
@agent: This page's content exceeds the model's context limit. Summarizing it right now.
@agent: Web Scraping Error: Unsupported provider [object Object] for this task.
```

After:
<img width="788" height="434" alt="image" src="https://github.com/user-attachments/assets/5ceff6e6-9a13-4493-afa6-a95cb5b5ce3d" />



### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] I have tested my code functionality
