### PR TITLE
Model Router: Multi-condition rules, updated designs, and router edit support

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -996,7 +996,15 @@ const TRANSLATIONS = {
       "property-label": "Property",
       "property-select": "Select",
       "comparator-label": "Comparator",
+      "comparator-select": "Select",
       "value-label": "Value",
+      "logic-label": "Match",
+      "logic-and": "ALL of the following (AND)",
+      "logic-or": "ANY of the following (OR)",
+      "add-condition": "Add condition",
+      "remove-condition": "Remove condition",
+      "conditions-incomplete":
+        "Condition {{index}} is incomplete — fill in property, comparator, and value.",
       "match-description-label": "Match Description",
       "match-description-placeholder":
         "e.g. The user is asking about legal topics, contracts, or compliance",

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -927,7 +927,10 @@ const TRANSLATIONS = {
       rules: "Rules",
       workspaces: "Workspaces",
     },
-    "no-routers": "No model routers created yet",
+    "no-routers": "No model routers yet",
+    "empty-description":
+      "No model routers configured yet. Create one to get started.",
+    "new-router-button": "New Router",
     "delete-confirm":
       'Are you sure you want to delete the router "{{name}}"?\nThis will remove all its rules and unlink any workspaces using it.\n\nThis action is irreversible.',
     "toast-deleted": "Router deleted",
@@ -971,6 +974,7 @@ const TRANSLATIONS = {
     },
     rules: {
       title: "Routing Rules",
+      "title-with-name": "Router Rules: {{name}}",
       description:
         "Rules are evaluated top-to-bottom by priority. Drag to reorder. First match wins.",
       "add-rule": "Add Rule",
@@ -978,7 +982,10 @@ const TRANSLATIONS = {
       "toast-deleted": "Rule deleted",
       "toast-delete-failed": "Failed to delete rule",
       "toast-reorder-failed": "Failed to reorder rules",
-      "no-rules": "No rules yet. Add a rule to start routing.",
+      "no-rules": "No rules yet",
+      "empty-description":
+        "Add a rule to start routing chat messages to specific providers and models.",
+      "new-rule-button": "New Rule",
     },
     "rule-form": {
       "edit-title": "Edit Rule",

--- a/frontend/src/pages/GeneralSettings/ModelRouters/LLMProviderModelPicker/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/LLMProviderModelPicker/index.jsx
@@ -108,21 +108,21 @@ export default function LLMProviderModelPicker({
 
   return (
     <div className="flex flex-col gap-y-1.5">
-      <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
+      <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
         {label}
       </label>
       {description && (
-        <p className="text-xs text-zinc-400 light:text-slate-600">
+        <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
           {description}
         </p>
       )}
-      <div className="flex gap-x-4 mt-1">
+      <div className="flex gap-x-3">
         <div className="flex-1">
           <select
             name={providerFieldName}
             value={selectedProvider}
             onChange={handleProviderChange}
-            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
             required
           >
             <option value="">
@@ -143,14 +143,14 @@ export default function LLMProviderModelPicker({
             <button
               type="button"
               onClick={openModal}
-              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-blue-400 light:text-blue-500 text-sm rounded-lg block w-full p-2.5 text-left hover:text-blue-300 light:hover:text-blue-600 transition-colors"
+              className="border-none bg-zinc-800 light:bg-white light:border light:border-slate-300 text-blue-400 light:text-blue-500 text-sm rounded-[8px] block w-full h-8 px-3.5 text-left hover:text-blue-300 light:hover:text-blue-600 transition-colors"
             >
               {t("model-router.provider-picker.configure-to-continue", {
                 name: selectedLlm.name,
               })}
             </button>
           ) : loadingModels ? (
-            <div className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-zinc-400 light:text-slate-500 text-sm rounded-lg p-2.5">
+            <div className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-zinc-400 light:text-slate-500 text-sm rounded-[8px] h-8 px-3.5 flex items-center">
               {t("model-router.provider-picker.loading-models")}
             </div>
           ) : models.length > 0 ? (
@@ -158,7 +158,7 @@ export default function LLMProviderModelPicker({
               name={modelFieldName}
               value={selectedModel}
               onChange={(e) => setSelectedModel(e.target.value)}
-              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
               required
             >
               <option value="">
@@ -182,7 +182,7 @@ export default function LLMProviderModelPicker({
                   : t("model-router.provider-picker.select-provider-first")
               }
               disabled={!selectedProvider}
-              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 disabled:opacity-50"
+              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5 disabled:opacity-50"
               required
             />
           )}
@@ -206,7 +206,7 @@ function ProviderSetupModal({ isOpen, provider, settings, onSave, onClose }) {
 
   return (
     <ModalWrapper isOpen={isOpen}>
-      <div className="w-full max-w-2xl bg-zinc-900 light:bg-white rounded-lg shadow-lg border border-zinc-700 light:border-slate-300">
+      <div className="w-full max-w-2xl bg-zinc-900 light:bg-white rounded-[8px] shadow-lg border border-zinc-700 light:border-slate-300">
         <div className="flex items-center justify-between p-6 border-b border-zinc-700 light:border-slate-300">
           <div className="flex items-center gap-x-3">
             {provider.logo && (
@@ -216,7 +216,7 @@ function ProviderSetupModal({ isOpen, provider, settings, onSave, onClose }) {
                 className="w-8 h-8 rounded-md"
               />
             )}
-            <h3 className="text-lg font-semibold text-white light:text-slate-900">
+            <h3 className="text-base font-semibold leading-6 text-white light:text-slate-950">
               {t("model-router.provider-picker.configure-provider", {
                 name: provider.name,
               })}
@@ -225,32 +225,32 @@ function ProviderSetupModal({ isOpen, provider, settings, onSave, onClose }) {
           <button
             onClick={onClose}
             type="button"
-            className="p-1 rounded-lg text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 hover:bg-zinc-800 light:hover:bg-slate-100 transition-colors"
+            className="border-none p-1 rounded-lg text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 hover:bg-zinc-800 light:hover:bg-slate-100 transition-colors"
           >
-            <X size={20} weight="bold" />
+            <X size={16} weight="bold" />
           </button>
         </div>
         <form id="provider-setup-form" onSubmit={onSave}>
           <div className="px-6 py-5">
-            <p className="text-sm text-zinc-400 light:text-slate-600 mb-4">
+            <p className="text-xs leading-4 text-zinc-400 light:text-slate-600 mb-4">
               {t("model-router.provider-picker.setup-credentials", {
                 name: provider.name,
               })}
             </p>
             <div className="space-y-4">{provider.options(settings ?? {})}</div>
           </div>
-          <div className="flex justify-end gap-x-3 px-6 py-4 border-t border-zinc-700 light:border-slate-300">
+          <div className="flex justify-between gap-x-3 px-6 py-4 border-t border-zinc-700 light:border-slate-300">
             <button
               type="button"
               onClick={onClose}
-              className="text-sm font-medium text-zinc-400 light:text-slate-600 hover:text-white light:hover:text-slate-900 px-4 py-2 rounded-lg transition-colors"
+              className="border border-zinc-600 light:border-slate-600 text-white light:text-slate-900 text-sm font-medium leading-5 rounded-[8px] h-[34px] px-3.5 hover:opacity-90 transition-opacity"
             >
               {t("model-router.provider-picker.cancel")}
             </button>
             <button
               type="submit"
               form="provider-setup-form"
-              className="text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg px-5 py-2 hover:opacity-90 transition-opacity duration-200"
+              className="border-none text-sm font-medium leading-5 bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-[8px] h-[34px] px-3.5 hover:opacity-90 transition-opacity"
             >
               {t("model-router.provider-picker.save-settings")}
             </button>

--- a/frontend/src/pages/GeneralSettings/ModelRouters/NewRouterModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/NewRouterModal/index.jsx
@@ -6,12 +6,18 @@ import showToast from "@/utils/toast";
 import ModalWrapper from "@/components/ModalWrapper";
 import LLMProviderModelPicker from "../LLMProviderModelPicker";
 
-export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
+export default function NewRouterModal({
+  isOpen,
+  closeModal,
+  onSuccess,
+  router = null,
+}) {
   const { t } = useTranslation();
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
+  const isEdit = !!router;
 
-  const handleCreate = async (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
     setLoading(true);
@@ -37,17 +43,28 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
       return;
     }
 
-    const { router, error: apiError } = await ModelRouter.create(data);
+    const { router: saved, error: apiError } = isEdit
+      ? await ModelRouter.update(router.id, data)
+      : await ModelRouter.create(data);
     setLoading(false);
 
-    if (router) {
-      showToast(t("model-router.new-router.toast-created"), "success", {
-        clear: true,
-      });
+    if (saved) {
+      showToast(
+        t(
+          isEdit
+            ? "model-router.edit-router.toast-updated"
+            : "model-router.new-router.toast-created"
+        ),
+        "success",
+        { clear: true }
+      );
       onSuccess();
       closeModal();
     } else {
-      setError(apiError);
+      setError(
+        apiError ||
+          (isEdit ? t("model-router.edit-router.toast-update-failed") : null)
+      );
     }
   };
 
@@ -56,7 +73,9 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
       <div className="relative w-full max-w-2xl bg-zinc-900 light:bg-white rounded-xl shadow border border-zinc-700 light:border-slate-300">
         <div className="relative p-6 border-b border-zinc-700 light:border-slate-200">
           <h3 className="text-lg font-semibold text-white light:text-slate-900">
-            {t("model-router.new-router.title")}
+            {isEdit
+              ? t("model-router.edit-router.title", { name: router.name })
+              : t("model-router.new-router.title")}
           </h3>
           <button
             onClick={closeModal}
@@ -67,7 +86,7 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
           </button>
         </div>
         <div className="px-6 py-6">
-          <form onSubmit={handleCreate}>
+          <form onSubmit={handleSubmit}>
             <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
               <div className="flex flex-col gap-y-1.5">
@@ -77,6 +96,7 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
                 <input
                   type="text"
                   name="name"
+                  defaultValue={router?.name || ""}
                   placeholder={t("model-router.new-router.name-placeholder")}
                   className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
                   required
@@ -89,6 +109,7 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
                 <input
                   type="text"
                   name="description"
+                  defaultValue={router?.description || ""}
                   placeholder={t(
                     "model-router.new-router.description-placeholder"
                   )}
@@ -100,6 +121,8 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
                 modelFieldName="fallback_model"
                 label={t("model-router.new-router.fallback-label")}
                 description={t("model-router.new-router.fallback-description")}
+                defaultProvider={router?.fallback_provider}
+                defaultModel={router?.fallback_model}
               />
               <div className="flex flex-col gap-y-1.5">
                 <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
@@ -108,7 +131,7 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
                 <input
                   type="number"
                   name="cooldown_seconds"
-                  defaultValue={30}
+                  defaultValue={router?.cooldown_seconds ?? 30}
                   min={0}
                   max={3600}
                   className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
@@ -134,8 +157,14 @@ export default function NewRouterModal({ isOpen, closeModal, onSuccess }) {
                 {loading ? (
                   <>
                     <CircleNotch className="h-4 w-4 animate-spin" />
-                    {t("model-router.new-router.creating")}
+                    {t(
+                      isEdit
+                        ? "model-router.edit-router.saving"
+                        : "model-router.new-router.creating"
+                    )}
                   </>
+                ) : isEdit ? (
+                  t("model-router.edit-router.save")
                 ) : (
                   t("model-router.new-router.create")
                 )}

--- a/frontend/src/pages/GeneralSettings/ModelRouters/NewRouterModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/NewRouterModal/index.jsx
@@ -70,108 +70,119 @@ export default function NewRouterModal({
 
   return (
     <ModalWrapper isOpen={isOpen}>
-      <div className="relative w-full max-w-2xl bg-zinc-900 light:bg-white rounded-xl shadow border border-zinc-700 light:border-slate-300">
-        <div className="relative p-6 border-b border-zinc-700 light:border-slate-200">
-          <h3 className="text-lg font-semibold text-white light:text-slate-900">
-            {isEdit
-              ? t("model-router.edit-router.title", { name: router.name })
-              : t("model-router.new-router.title")}
-          </h3>
-          <button
-            onClick={closeModal}
-            type="button"
-            className="absolute top-4 right-4 text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
-          >
-            <X size={20} weight="bold" />
-          </button>
-        </div>
-        <div className="px-6 py-6">
-          <form onSubmit={handleSubmit}>
-            <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
-              {error && <p className="text-red-400 text-sm">Error: {error}</p>}
-              <div className="flex flex-col gap-y-1.5">
-                <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                  {t("model-router.new-router.name")}
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  defaultValue={router?.name || ""}
-                  placeholder={t("model-router.new-router.name-placeholder")}
-                  className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
-                  required
-                />
-              </div>
-              <div className="flex flex-col gap-y-1.5">
-                <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                  {t("model-router.new-router.description")}
-                </label>
-                <input
-                  type="text"
-                  name="description"
-                  defaultValue={router?.description || ""}
-                  placeholder={t(
-                    "model-router.new-router.description-placeholder"
-                  )}
-                  className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
-                />
-              </div>
-              <LLMProviderModelPicker
-                providerFieldName="fallback_provider"
-                modelFieldName="fallback_model"
-                label={t("model-router.new-router.fallback-label")}
-                description={t("model-router.new-router.fallback-description")}
-                defaultProvider={router?.fallback_provider}
-                defaultModel={router?.fallback_model}
-              />
-              <div className="flex flex-col gap-y-1.5">
-                <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                  {t("model-router.new-router.cooldown-label")}
-                </label>
-                <input
-                  type="number"
-                  name="cooldown_seconds"
-                  defaultValue={router?.cooldown_seconds ?? 30}
-                  min={0}
-                  max={3600}
-                  className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
-                />
-                <p className="text-[10px] text-zinc-400 light:text-slate-500">
-                  {t("model-router.new-router.cooldown-help")}
-                </p>
-              </div>
-            </div>
-            <div className="flex justify-end items-center mt-6 pt-6 border-t border-zinc-700 light:border-slate-200">
+      <div className="relative w-full max-w-2xl bg-zinc-900 light:bg-white rounded-[8px] shadow border border-zinc-700 light:border-slate-300">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-5 p-6">
+          <div className="flex flex-col gap-y-1">
+            <div className="flex items-start justify-between">
+              <h3 className="text-base font-semibold leading-6 text-white light:text-slate-950">
+                {isEdit
+                  ? t("model-router.edit-router.title", { name: router.name })
+                  : t("model-router.new-router.title")}
+              </h3>
               <button
                 onClick={closeModal}
                 type="button"
-                className="text-sm font-medium text-zinc-400 light:text-slate-600 hover:text-white light:hover:text-slate-900 px-4 py-2 rounded-lg transition-colors mr-2"
+                className="border-none text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
               >
-                {t("model-router.new-router.cancel")}
-              </button>
-              <button
-                type="submit"
-                disabled={loading}
-                className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading ? (
-                  <>
-                    <CircleNotch className="h-4 w-4 animate-spin" />
-                    {t(
-                      isEdit
-                        ? "model-router.edit-router.saving"
-                        : "model-router.new-router.creating"
-                    )}
-                  </>
-                ) : isEdit ? (
-                  t("model-router.edit-router.save")
-                ) : (
-                  t("model-router.new-router.create")
-                )}
+                <X size={16} weight="bold" />
               </button>
             </div>
-          </form>
-        </div>
+            {isEdit && router?.description && (
+              <p className="text-xs leading-4 text-zinc-400 light:text-slate-600 truncate">
+                {router.description}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
+              {t("model-router.new-router.name")}
+            </label>
+            <input
+              type="text"
+              name="name"
+              defaultValue={router?.name || ""}
+              placeholder={t("model-router.new-router.name-placeholder")}
+              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
+              {t("model-router.new-router.description")}
+            </label>
+            <input
+              type="text"
+              name="description"
+              defaultValue={router?.description || ""}
+              placeholder={t("model-router.new-router.description-placeholder")}
+              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
+            />
+          </div>
+
+          <LLMProviderModelPicker
+            providerFieldName="fallback_provider"
+            modelFieldName="fallback_model"
+            label={t("model-router.new-router.fallback-label")}
+            description={t("model-router.new-router.fallback-description")}
+            defaultProvider={router?.fallback_provider}
+            defaultModel={router?.fallback_model}
+          />
+
+          <div className="flex flex-col gap-y-1.5">
+            <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
+              {t("model-router.new-router.cooldown-label")}
+            </label>
+            <input
+              type="number"
+              name="cooldown_seconds"
+              defaultValue={router?.cooldown_seconds ?? 30}
+              min={0}
+              max={3600}
+              className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
+            />
+            <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
+              {t("model-router.new-router.cooldown-help")}
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-xs leading-4 text-red-400 light:text-red-600">
+              Error: {error}
+            </p>
+          )}
+
+          <div className="flex items-center justify-between">
+            <button
+              onClick={closeModal}
+              type="button"
+              className="border border-zinc-600 light:border-slate-600 text-white light:text-slate-900 text-sm font-medium leading-5 rounded-[8px] h-[34px] px-3.5 hover:opacity-90 transition-opacity"
+            >
+              {t("model-router.new-router.cancel")}
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="border-none flex items-center gap-x-1.5 text-sm font-medium leading-5 bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-[8px] h-[34px] px-3.5 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? (
+                <>
+                  <CircleNotch className="h-4 w-4 animate-spin" />
+                  {t(
+                    isEdit
+                      ? "model-router.edit-router.saving"
+                      : "model-router.new-router.creating"
+                  )}
+                </>
+              ) : isEdit ? (
+                t("model-router.edit-router.save")
+              ) : (
+                t("model-router.new-router.create")
+              )}
+            </button>
+          </div>
+        </form>
       </div>
     </ModalWrapper>
   );

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RouterForm/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RouterForm/index.jsx
@@ -7,7 +7,6 @@ import { ArrowLeft, CircleNotch } from "@phosphor-icons/react";
 import ModelRouter from "@/models/modelRouter";
 import showToast from "@/utils/toast";
 import paths from "@/utils/paths";
-import LLMProviderModelPicker from "../LLMProviderModelPicker";
 import RuleBuilder from "../RuleBuilder";
 
 export default function RouterFormPage() {
@@ -15,7 +14,6 @@ export default function RouterFormPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [router, setRouter] = useState(null);
 
   const fetchRouter = async () => {
@@ -33,35 +31,6 @@ export default function RouterFormPage() {
     fetchRouter();
   }, [id]);
 
-  const handleSave = async (e) => {
-    e.preventDefault();
-    setSaving(true);
-
-    const formData = new FormData(e.target);
-    const data = {
-      name: formData.get("name"),
-      description: formData.get("description"),
-      fallback_provider: formData.get("fallback_provider"),
-      fallback_model: formData.get("fallback_model"),
-      cooldown_seconds: Number(formData.get("cooldown_seconds")),
-    };
-
-    const { router: updated, error } = await ModelRouter.update(id, data);
-    setSaving(false);
-
-    if (updated) {
-      showToast(t("model-router.edit-router.toast-updated"), "success", {
-        clear: true,
-      });
-      setRouter({ ...router, ...updated });
-    } else {
-      showToast(
-        error || t("model-router.edit-router.toast-update-failed"),
-        "error"
-      );
-    }
-  };
-
   return (
     <div className="w-screen h-screen overflow-hidden bg-zinc-950 light:bg-slate-50 flex md:mt-0 mt-6">
       <Sidebar />
@@ -74,7 +43,7 @@ export default function RouterFormPage() {
             onClick={() => navigate(paths.settings.modelRouters())}
             className="flex items-center gap-x-2 text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 text-sm mb-4 transition-colors"
           >
-            <ArrowLeft className="h-4 w-4" />{" "}
+            <ArrowLeft className="h-4 w-4" />
             {t("model-router.edit-router.back-to-routers")}
           </button>
 
@@ -83,95 +52,12 @@ export default function RouterFormPage() {
               <CircleNotch className="h-8 w-8 text-zinc-400 light:text-slate-400 animate-spin" />
             </div>
           ) : (
-            <>
-              <div className="w-full flex flex-col gap-y-2 pb-6 border-b border-white/20 light:border-slate-300">
-                <p className="text-lg font-semibold leading-7 text-white light:text-slate-900">
-                  {t("model-router.edit-router.title", { name: router.name })}
-                </p>
-                <p className="text-xs leading-4 text-zinc-400 light:text-slate-600 max-w-[700px]">
-                  {t("model-router.edit-router.description")}
-                </p>
-              </div>
-
-              <form onSubmit={handleSave} className="mt-6">
-                <div className="space-y-4 max-w-[700px]">
-                  <div className="flex flex-col gap-y-1.5">
-                    <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                      {t("model-router.edit-router.name")}
-                    </label>
-                    <input
-                      type="text"
-                      name="name"
-                      defaultValue={router.name}
-                      className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
-                      required
-                    />
-                  </div>
-                  <div className="flex flex-col gap-y-1.5">
-                    <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                      {t("model-router.edit-router.description-label")}
-                    </label>
-                    <input
-                      type="text"
-                      name="description"
-                      defaultValue={router.description || ""}
-                      placeholder={t(
-                        "model-router.edit-router.description-placeholder"
-                      )}
-                      className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
-                    />
-                  </div>
-                  <LLMProviderModelPicker
-                    providerFieldName="fallback_provider"
-                    modelFieldName="fallback_model"
-                    label={t("model-router.edit-router.fallback-label")}
-                    description={t(
-                      "model-router.edit-router.fallback-description"
-                    )}
-                    defaultProvider={router.fallback_provider}
-                    defaultModel={router.fallback_model}
-                  />
-                  <div className="flex flex-col gap-y-1.5">
-                    <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                      {t("model-router.edit-router.cooldown-label")}
-                    </label>
-                    <input
-                      type="number"
-                      name="cooldown_seconds"
-                      defaultValue={router.cooldown_seconds ?? 30}
-                      min={0}
-                      max={3600}
-                      className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
-                    />
-                    <p className="text-[10px] text-zinc-400 light:text-slate-500">
-                      {t("model-router.edit-router.cooldown-help")}
-                    </p>
-                  </div>
-                  <div className="flex justify-end pt-4">
-                    <button
-                      type="submit"
-                      disabled={saving}
-                      className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {saving ? (
-                        <>
-                          <CircleNotch className="h-4 w-4 animate-spin" />
-                          {t("model-router.edit-router.saving")}
-                        </>
-                      ) : (
-                        t("model-router.edit-router.save")
-                      )}
-                    </button>
-                  </div>
-                </div>
-              </form>
-
-              <RuleBuilder
-                routerId={router.id}
-                rules={router.rules || []}
-                onRulesChanged={fetchRouter}
-              />
-            </>
+            <RuleBuilder
+              routerId={router.id}
+              routerName={router.name}
+              rules={router.rules || []}
+              onRulesChanged={fetchRouter}
+            />
           )}
         </div>
       </div>

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/CalculatedFields/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/CalculatedFields/index.jsx
@@ -22,7 +22,18 @@ function valuePlaceholder(property, comparator) {
   if (property === "currentHour") return "e.g. 18 (0-23)";
   if (property === "conversationMessageCount") return "e.g. 10";
   if (NUMERIC_PROPERTIES.includes(property)) return "e.g. 4000";
+  if (comparator === "contains") return "e.g. code, python, rust";
+  if (comparator === "matches") return "e.g. /\\bpython\\b/i";
   return "e.g. code";
+}
+
+function valueHelp(property, comparator) {
+  if (NUMERIC_PROPERTIES.includes(property)) return null;
+  if (comparator === "contains")
+    return "Comma-separated list — matches if the prompt contains any of the values (case-insensitive).";
+  if (comparator === "matches")
+    return "Regex pattern. Use /pattern/flags for case sensitivity (defaults to case-insensitive).";
+  return null;
 }
 
 export default function CalculatedFields({
@@ -139,9 +150,16 @@ function ComparatorAndValueFields({
           name="value"
           defaultValue={existingRule?.value || ""}
           placeholder={valuePlaceholder(property, comparator)}
-          className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5"
+          className={`bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 ${
+            comparator === "matches" ? "font-mono" : ""
+          }`}
           required
         />
+        {valueHelp(property, comparator) && (
+          <p className="text-[10px] text-zinc-400 light:text-slate-500">
+            {valueHelp(property, comparator)}
+          </p>
+        )}
       </div>
     </>
   );

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/CalculatedFields/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/CalculatedFields/index.jsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { Plus, X } from "@phosphor-icons/react";
 
 const PROPERTIES = [
   { value: "promptContent", label: "Prompt Content" },
@@ -8,13 +9,36 @@ const PROPERTIES = [
   { value: "hasImageAttachment", label: "Has Image Attachment" },
 ];
 
-export const NUMERIC_PROPERTIES = [
+const NUMERIC_PROPERTIES = [
   "conversationTokenCount",
   "conversationMessageCount",
   "currentHour",
 ];
 
 const BOOLEAN_PROPERTIES = ["hasImageAttachment"];
+
+const STRING_COMPARATORS = [
+  { value: "contains", label: "contains" },
+  { value: "matches", label: "matches (regex)" },
+  { value: "eq", label: "equals" },
+  { value: "neq", label: "not equals" },
+];
+
+const NUMERIC_COMPARATORS = [
+  { value: "gt", label: "greater than" },
+  { value: "gte", label: "greater than or equal" },
+  { value: "lt", label: "less than" },
+  { value: "lte", label: "less than or equal" },
+  { value: "eq", label: "equals" },
+  { value: "neq", label: "not equals" },
+  { value: "between", label: "between (inclusive)" },
+];
+
+function comparatorsFor(property) {
+  return NUMERIC_PROPERTIES.includes(property)
+    ? NUMERIC_COMPARATORS
+    : STRING_COMPARATORS;
+}
 
 function valuePlaceholder(property, comparator) {
   if (comparator === "between")
@@ -37,101 +61,203 @@ function valueHelp(property, comparator) {
 }
 
 export default function CalculatedFields({
-  property,
-  setProperty,
-  comparator,
-  setComparator,
-  comparators,
-  existingRule,
+  conditionLogic,
+  setConditionLogic,
+  conditions,
+  setConditions,
 }) {
   const { t } = useTranslation();
-  const isBoolean = BOOLEAN_PROPERTIES.includes(property);
+
+  const updateCondition = (index, changes) => {
+    setConditions((prev) =>
+      prev.map((c, i) => (i === index ? { ...c, ...changes } : c))
+    );
+  };
+
+  const addCondition = () => {
+    setConditions((prev) => [
+      ...prev,
+      { property: "", comparator: "", value: "" },
+    ]);
+  };
+
+  const removeCondition = (index) => {
+    setConditions((prev) => prev.filter((_, i) => i !== index));
+  };
 
   return (
-    <div className={`grid ${isBoolean ? "grid-cols-2" : "grid-cols-3"} gap-4`}>
-      <div className="flex flex-col gap-y-1.5">
-        <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-          {t("model-router.rule-form.property-label")}
-        </label>
-        <select
-          name="property"
-          defaultValue={existingRule?.property || ""}
-          onChange={(e) => setProperty(e.target.value)}
-          className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
-          required
-        >
-          <option value="">
-            {t("model-router.rule-form.property-select")}
-          </option>
-          {PROPERTIES.map((p) => (
-            <option key={p.value} value={p.value}>
-              {p.label}
-            </option>
-          ))}
-        </select>
+    <div className="flex flex-col gap-y-3">
+      {conditions.length > 1 && (
+        <LogicToggle value={conditionLogic} onChange={setConditionLogic} />
+      )}
+
+      <div className="flex flex-col gap-y-2">
+        {conditions.map((condition, index) => (
+          <ConditionRow
+            key={index}
+            condition={condition}
+            onChange={(changes) => updateCondition(index, changes)}
+            onRemove={
+              conditions.length > 1 ? () => removeCondition(index) : null
+            }
+          />
+        ))}
       </div>
 
-      {isBoolean ? (
-        <BooleanValueField existingRule={existingRule} />
-      ) : (
-        <ComparatorAndValueFields
-          comparator={comparator}
-          setComparator={setComparator}
-          comparators={comparators}
-          property={property}
-          existingRule={existingRule}
-        />
-      )}
+      <button
+        type="button"
+        onClick={addCondition}
+        className="self-start flex items-center gap-x-1.5 text-xs font-medium text-zinc-300 light:text-slate-700 hover:text-white light:hover:text-slate-900 border border-zinc-700 light:border-slate-300 hover:border-zinc-500 light:hover:border-slate-400 rounded-lg px-3 py-1.5 transition-colors"
+      >
+        <Plus size={14} weight="bold" />
+        {t("model-router.rule-form.add-condition")}
+      </button>
     </div>
   );
 }
 
-function BooleanValueField({ existingRule }) {
+function LogicToggle({ value, onChange }) {
   const { t } = useTranslation();
+  const options = [
+    { value: "AND", label: t("model-router.rule-form.logic-and") },
+    { value: "OR", label: t("model-router.rule-form.logic-or") },
+  ];
   return (
-    <>
-      <input type="hidden" name="comparator" value="eq" />
-      <div className="flex flex-col gap-y-1.5">
-        <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-          {t("model-router.rule-form.value-label")}
-        </label>
-        <select
-          name="value"
-          defaultValue={existingRule?.value || "true"}
-          className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
-          required
-        >
-          <option value="true">True</option>
-          <option value="false">False</option>
-        </select>
+    <div className="flex flex-col gap-y-1.5">
+      <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
+        {t("model-router.rule-form.logic-label")}
+      </label>
+      <div
+        role="radiogroup"
+        className="inline-flex self-start rounded-lg border border-zinc-700 light:border-slate-300 bg-zinc-800 light:bg-white p-0.5"
+      >
+        {options.map((opt) => {
+          const selected = value === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => onChange(opt.value)}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                selected
+                  ? "bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white"
+                  : "text-zinc-300 light:text-slate-700 hover:text-white light:hover:text-slate-900"
+              }`}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
       </div>
-    </>
+    </div>
   );
 }
 
-function ComparatorAndValueFields({
-  comparator,
-  setComparator,
-  comparators,
-  property,
-  existingRule,
-}) {
+function ConditionRow({ condition, onChange, onRemove }) {
   const { t } = useTranslation();
+  const isBoolean = BOOLEAN_PROPERTIES.includes(condition.property);
+
+  // Boolean properties (hasImageAttachment) have a fixed comparator (eq) and a
+  // True/False value picker, so we short-circuit the normal comparator/value
+  // fields when one is selected.
+  const handlePropertyChange = (nextProperty) => {
+    if (BOOLEAN_PROPERTIES.includes(nextProperty)) {
+      onChange({ property: nextProperty, comparator: "eq", value: "true" });
+      return;
+    }
+    const prevComparators = comparatorsFor(condition.property);
+    const nextComparators = comparatorsFor(nextProperty);
+    const comparatorStillValid =
+      !!condition.comparator &&
+      nextComparators.some((c) => c.value === condition.comparator) &&
+      prevComparators.some((c) => c.value === condition.comparator);
+    onChange({
+      property: nextProperty,
+      comparator: comparatorStillValid ? condition.comparator : "",
+      // Clear the value when switching from a boolean property since True/False
+      // isn't meaningful for other properties.
+      value: BOOLEAN_PROPERTIES.includes(condition.property)
+        ? ""
+        : condition.value,
+    });
+  };
+
+  return (
+    <div className="flex items-start gap-x-2">
+      <div
+        className={`grid flex-1 ${isBoolean ? "grid-cols-2" : "grid-cols-3"} gap-3`}
+      >
+        <div className="flex flex-col gap-y-1">
+          <select
+            value={condition.property}
+            onChange={(e) => handlePropertyChange(e.target.value)}
+            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+            required
+          >
+            <option value="">
+              {t("model-router.rule-form.property-select")}
+            </option>
+            {PROPERTIES.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {isBoolean ? (
+          <BooleanValueField
+            value={condition.value}
+            onChange={(value) => onChange({ value })}
+          />
+        ) : (
+          <ComparatorAndValueFields condition={condition} onChange={onChange} />
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onRemove || undefined}
+        disabled={!onRemove}
+        aria-label={t("model-router.rule-form.remove-condition")}
+        className="mt-1.5 text-zinc-400 light:text-slate-500 hover:text-red-400 light:hover:text-red-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+      >
+        <X size={16} weight="bold" />
+      </button>
+    </div>
+  );
+}
+
+function BooleanValueField({ value, onChange }) {
+  return (
+    <select
+      value={value || "true"}
+      onChange={(e) => onChange(e.target.value)}
+      className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+      required
+    >
+      <option value="true">True</option>
+      <option value="false">False</option>
+    </select>
+  );
+}
+
+function ComparatorAndValueFields({ condition, onChange }) {
+  const { t } = useTranslation();
+  const comparators = comparatorsFor(condition.property);
   return (
     <>
-      <div className="flex flex-col gap-y-1.5">
-        <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-          {t("model-router.rule-form.comparator-label")}
-        </label>
+      <div className="flex flex-col gap-y-1">
         <select
-          name="comparator"
-          defaultValue={existingRule?.comparator || ""}
-          onChange={(e) => setComparator(e.target.value)}
+          value={condition.comparator}
+          onChange={(e) => onChange({ comparator: e.target.value })}
           className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
           required
         >
           <option value="">
-            {t("model-router.rule-form.property-select")}
+            {t("model-router.rule-form.comparator-select")}
           </option>
           {comparators.map((c) => (
             <option key={c.value} value={c.value}>
@@ -141,23 +267,23 @@ function ComparatorAndValueFields({
         </select>
       </div>
 
-      <div className="flex flex-col gap-y-1.5">
-        <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-          {t("model-router.rule-form.value-label")}
-        </label>
+      <div className="flex flex-col gap-y-1">
         <input
           type="text"
-          name="value"
-          defaultValue={existingRule?.value || ""}
-          placeholder={valuePlaceholder(property, comparator)}
+          value={condition.value}
+          onChange={(e) => onChange({ value: e.target.value })}
+          placeholder={valuePlaceholder(
+            condition.property,
+            condition.comparator
+          )}
           className={`bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 ${
-            comparator === "matches" ? "font-mono" : ""
+            condition.comparator === "matches" ? "font-mono" : ""
           }`}
           required
         />
-        {valueHelp(property, comparator) && (
+        {valueHelp(condition.property, condition.comparator) && (
           <p className="text-[10px] text-zinc-400 light:text-slate-500">
-            {valueHelp(property, comparator)}
+            {valueHelp(condition.property, condition.comparator)}
           </p>
         )}
       </div>

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/CalculatedFields/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/CalculatedFields/index.jsx
@@ -85,17 +85,23 @@ export default function CalculatedFields({
     setConditions((prev) => prev.filter((_, i) => i !== index));
   };
 
-  return (
-    <div className="flex flex-col gap-y-3">
-      {conditions.length > 1 && (
-        <LogicToggle value={conditionLogic} onChange={setConditionLogic} />
-      )}
+  const toggleLogic = () => {
+    setConditionLogic((prev) => (prev === "AND" ? "OR" : "AND"));
+  };
 
-      <div className="flex flex-col gap-y-2">
+  return (
+    <div className="flex flex-col gap-y-1.5 items-start">
+      <div className="flex flex-col gap-y-5 w-full">
         {conditions.map((condition, index) => (
           <ConditionRow
             key={index}
             condition={condition}
+            showLabels={index === 0}
+            logicBadge={
+              index === 0 ? null : (
+                <LogicBadge value={conditionLogic} onClick={toggleLogic} />
+              )
+            }
             onChange={(changes) => updateCondition(index, changes)}
             onRemove={
               conditions.length > 1 ? () => removeCondition(index) : null
@@ -107,55 +113,34 @@ export default function CalculatedFields({
       <button
         type="button"
         onClick={addCondition}
-        className="self-start flex items-center gap-x-1.5 text-xs font-medium text-zinc-300 light:text-slate-700 hover:text-white light:hover:text-slate-900 border border-zinc-700 light:border-slate-300 hover:border-zinc-500 light:hover:border-slate-400 rounded-lg px-3 py-1.5 transition-colors"
+        aria-label={t("model-router.rule-form.add-condition")}
+        className="border-none bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-md p-1 hover:opacity-90 transition-opacity"
       >
-        <Plus size={14} weight="bold" />
-        {t("model-router.rule-form.add-condition")}
+        <Plus size={16} weight="bold" />
       </button>
     </div>
   );
 }
 
-function LogicToggle({ value, onChange }) {
-  const { t } = useTranslation();
-  const options = [
-    { value: "AND", label: t("model-router.rule-form.logic-and") },
-    { value: "OR", label: t("model-router.rule-form.logic-or") },
-  ];
+function LogicBadge({ value, onClick }) {
   return (
-    <div className="flex flex-col gap-y-1.5">
-      <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-        {t("model-router.rule-form.logic-label")}
-      </label>
-      <div
-        role="radiogroup"
-        className="inline-flex self-start rounded-lg border border-zinc-700 light:border-slate-300 bg-zinc-800 light:bg-white p-0.5"
-      >
-        {options.map((opt) => {
-          const selected = value === opt.value;
-          return (
-            <button
-              key={opt.value}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              onClick={() => onChange(opt.value)}
-              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
-                selected
-                  ? "bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white"
-                  : "text-zinc-300 light:text-slate-700 hover:text-white light:hover:text-slate-900"
-              }`}
-            >
-              {opt.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      className="border-none shrink-0 bg-zinc-700 light:bg-slate-200 text-white light:text-slate-950 text-xs font-medium leading-4 tracking-[1.2px] uppercase px-2.5 py-1.5 rounded-md hover:opacity-80 transition-opacity"
+    >
+      {value}
+    </button>
   );
 }
 
-function ConditionRow({ condition, onChange, onRemove }) {
+function ConditionRow({
+  condition,
+  showLabels,
+  logicBadge,
+  onChange,
+  onRemove,
+}) {
   const { t } = useTranslation();
   const isBoolean = BOOLEAN_PROPERTIES.includes(condition.property);
 
@@ -185,15 +170,18 @@ function ConditionRow({ condition, onChange, onRemove }) {
   };
 
   return (
-    <div className="flex items-start gap-x-2">
+    <div className="flex items-end gap-x-5">
+      {logicBadge}
       <div
-        className={`grid flex-1 ${isBoolean ? "grid-cols-2" : "grid-cols-3"} gap-3`}
+        className={`grid flex-1 ${isBoolean ? "grid-cols-2" : "grid-cols-3"} gap-x-5`}
       >
-        <div className="flex flex-col gap-y-1">
+        <FieldColumn
+          label={showLabels ? t("model-router.rule-form.property-label") : null}
+        >
           <select
             value={condition.property}
             onChange={(e) => handlePropertyChange(e.target.value)}
-            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
             required
           >
             <option value="">
@@ -205,27 +193,49 @@ function ConditionRow({ condition, onChange, onRemove }) {
               </option>
             ))}
           </select>
-        </div>
+        </FieldColumn>
 
         {isBoolean ? (
-          <BooleanValueField
-            value={condition.value}
-            onChange={(value) => onChange({ value })}
-          />
+          <FieldColumn
+            label={showLabels ? t("model-router.rule-form.value-label") : null}
+          >
+            <BooleanValueField
+              value={condition.value}
+              onChange={(value) => onChange({ value })}
+            />
+          </FieldColumn>
         ) : (
-          <ComparatorAndValueFields condition={condition} onChange={onChange} />
+          <ComparatorAndValueFields
+            condition={condition}
+            onChange={onChange}
+            showLabels={showLabels}
+          />
         )}
       </div>
 
-      <button
-        type="button"
-        onClick={onRemove || undefined}
-        disabled={!onRemove}
-        aria-label={t("model-router.rule-form.remove-condition")}
-        className="mt-1.5 text-zinc-400 light:text-slate-500 hover:text-red-400 light:hover:text-red-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-      >
-        <X size={16} weight="bold" />
-      </button>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={t("model-router.rule-form.remove-condition")}
+          className="border-none shrink-0 mb-2 text-zinc-400 light:text-slate-500 hover:text-red-400 light:hover:text-red-500 transition-colors"
+        >
+          <X size={16} weight="bold" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function FieldColumn({ label, children }) {
+  return (
+    <div className="flex flex-col gap-y-1.5">
+      {label && (
+        <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
+          {label}
+        </label>
+      )}
+      {children}
     </div>
   );
 }
@@ -235,7 +245,7 @@ function BooleanValueField({ value, onChange }) {
     <select
       value={value || "true"}
       onChange={(e) => onChange(e.target.value)}
-      className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+      className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
       required
     >
       <option value="true">True</option>
@@ -244,16 +254,18 @@ function BooleanValueField({ value, onChange }) {
   );
 }
 
-function ComparatorAndValueFields({ condition, onChange }) {
+function ComparatorAndValueFields({ condition, onChange, showLabels }) {
   const { t } = useTranslation();
   const comparators = comparatorsFor(condition.property);
   return (
     <>
-      <div className="flex flex-col gap-y-1">
+      <FieldColumn
+        label={showLabels ? t("model-router.rule-form.comparator-label") : null}
+      >
         <select
           value={condition.comparator}
           onChange={(e) => onChange({ comparator: e.target.value })}
-          className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+          className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
           required
         >
           <option value="">
@@ -265,9 +277,11 @@ function ComparatorAndValueFields({ condition, onChange }) {
             </option>
           ))}
         </select>
-      </div>
+      </FieldColumn>
 
-      <div className="flex flex-col gap-y-1">
+      <FieldColumn
+        label={showLabels ? t("model-router.rule-form.value-label") : null}
+      >
         <input
           type="text"
           value={condition.value}
@@ -276,17 +290,17 @@ function ComparatorAndValueFields({ condition, onChange }) {
             condition.property,
             condition.comparator
           )}
-          className={`bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 ${
+          className={`bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5 ${
             condition.comparator === "matches" ? "font-mono" : ""
           }`}
           required
         />
         {valueHelp(condition.property, condition.comparator) && (
-          <p className="text-[10px] text-zinc-400 light:text-slate-500">
+          <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
             {valueHelp(condition.property, condition.comparator)}
           </p>
         )}
-      </div>
+      </FieldColumn>
     </>
   );
 }

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/LLMDescriptionField/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/LLMDescriptionField/index.jsx
@@ -4,7 +4,7 @@ export default function LLMDescriptionField({ existingRule }) {
   const { t } = useTranslation();
   return (
     <div className="flex flex-col gap-y-1.5">
-      <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
+      <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
         {t("model-router.rule-form.match-description-label")}
       </label>
       <textarea
@@ -12,10 +12,10 @@ export default function LLMDescriptionField({ existingRule }) {
         defaultValue={existingRule?.description || ""}
         placeholder={t("model-router.rule-form.match-description-placeholder")}
         rows={2}
-        className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 resize-none"
+        className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full px-3.5 py-2.5 resize-none"
         required
       />
-      <p className="text-[10px] text-zinc-400 light:text-slate-500">
+      <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
         {t("model-router.rule-form.match-description-help")}
       </p>
     </div>

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
@@ -5,7 +5,7 @@ import ModalWrapper from "@/components/ModalWrapper";
 import ModelRouterAPI from "@/models/modelRouter";
 import showToast from "@/utils/toast";
 import LLMProviderModelPicker from "../../LLMProviderModelPicker";
-import CalculatedFields, { NUMERIC_PROPERTIES } from "./CalculatedFields";
+import CalculatedFields from "./CalculatedFields";
 import LLMDescriptionField from "./LLMDescriptionField";
 
 const RULE_TYPES = [
@@ -23,22 +23,9 @@ const RULE_TYPES = [
   },
 ];
 
-const STRING_COMPARATORS = [
-  { value: "contains", label: "contains" },
-  { value: "matches", label: "matches (regex)" },
-  { value: "eq", label: "equals" },
-  { value: "neq", label: "not equals" },
-];
-
-const NUMERIC_COMPARATORS = [
-  { value: "gt", label: "greater than" },
-  { value: "gte", label: "greater than or equal" },
-  { value: "lt", label: "less than" },
-  { value: "lte", label: "less than or equal" },
-  { value: "eq", label: "equals" },
-  { value: "neq", label: "not equals" },
-  { value: "between", label: "between (inclusive)" },
-];
+function emptyCondition() {
+  return { property: "", comparator: "", value: "" };
+}
 
 function slugify(text) {
   return text
@@ -60,12 +47,14 @@ export default function RuleForm({
   const isEditing = !!existingRule;
   const [loading, setLoading] = useState(false);
   const [ruleType, setRuleType] = useState(existingRule?.type || "calculated");
-  const [property, setProperty] = useState(existingRule?.property || "");
-  const [comparator, setComparator] = useState(existingRule?.comparator || "");
-
-  const comparators = NUMERIC_PROPERTIES.includes(property)
-    ? NUMERIC_COMPARATORS
-    : STRING_COMPARATORS;
+  const [conditionLogic, setConditionLogic] = useState(
+    existingRule?.condition_logic || "AND"
+  );
+  const [conditions, setConditions] = useState(
+    Array.isArray(existingRule?.conditions) && existingRule.conditions.length
+      ? existingRule.conditions
+      : [emptyCondition()]
+  );
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -89,15 +78,26 @@ export default function RuleForm({
     };
 
     if (ruleType === "calculated") {
-      data.property = formData.get("property");
-      data.comparator = formData.get("comparator");
-      data.value = formData.get("value");
+      const incomplete = conditions.findIndex(
+        (c) => !c.property || !c.comparator || !String(c.value ?? "").trim()
+      );
+      if (incomplete !== -1) {
+        showToast(
+          t("model-router.rule-form.conditions-incomplete", {
+            index: incomplete + 1,
+          }),
+          "error"
+        );
+        setLoading(false);
+        return;
+      }
+      data.condition_logic = conditionLogic;
+      data.conditions = conditions;
       data.description = null;
     } else if (ruleType === "llm") {
       data.description = formData.get("description");
-      data.property = null;
-      data.comparator = null;
-      data.value = null;
+      data.condition_logic = null;
+      data.conditions = null;
     }
 
     let result;
@@ -189,12 +189,10 @@ export default function RuleForm({
 
               {ruleType === "calculated" ? (
                 <CalculatedFields
-                  property={property}
-                  setProperty={setProperty}
-                  comparator={comparator}
-                  setComparator={setComparator}
-                  comparators={comparators}
-                  existingRule={existingRule}
+                  conditionLogic={conditionLogic}
+                  setConditionLogic={setConditionLogic}
+                  conditions={conditions}
+                  setConditions={setConditions}
                 />
               ) : (
                 <LLMDescriptionField existingRule={existingRule} />

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
@@ -13,13 +13,13 @@ const RULE_TYPES = [
     value: "calculated",
     label: "Calculated",
     description:
-      "Match based on message properties like content, token count, or time of day",
+      "Match based on message properties like content, token count, or time of day.",
   },
   {
     value: "llm",
     label: "LLM Classified",
     description:
-      "Use the fallback model to decide if the message matches a description you provide",
+      "Use the fallback model to decide if the message matches a description you provide.",
   },
 ];
 
@@ -128,113 +128,112 @@ export default function RuleForm({
 
   return (
     <ModalWrapper isOpen={isOpen}>
-      <div className="relative w-full max-w-3xl bg-zinc-900 light:bg-white rounded-xl shadow border border-zinc-700 light:border-slate-300">
-        <div className="relative p-6 border-b border-zinc-700 light:border-slate-200">
-          <h3 className="text-lg font-semibold text-white light:text-slate-900">
-            {isEditing
-              ? t("model-router.rule-form.edit-title")
-              : t("model-router.rule-form.new-title")}
-          </h3>
-          <button
-            onClick={closeModal}
-            type="button"
-            className="absolute top-4 right-4 text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
-          >
-            <X size={20} weight="bold" />
-          </button>
-        </div>
-        <div className="px-6 py-6">
-          <form onSubmit={handleSubmit}>
-            <div className="flex flex-col gap-y-4 max-h-[60vh] overflow-y-auto pr-2">
-              <div className="flex gap-x-4">
-                <div className="flex-1 flex flex-col gap-y-1.5">
-                  <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                    {t("model-router.rule-form.title-label")}
-                  </label>
-                  <input
-                    type="text"
-                    name="title"
-                    defaultValue={existingRule?.title || ""}
-                    placeholder="e.g. route_code_to_claude"
-                    className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 font-mono"
-                    required
-                  />
-                  <p className="text-[10px] text-zinc-400 light:text-slate-500">
-                    {t("model-router.rule-form.title-help")}
-                  </p>
-                </div>
-                <div className="w-[200px] flex flex-col gap-y-1.5">
-                  <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-                    {t("model-router.rule-form.rule-type")}
-                  </label>
-                  <select
-                    value={ruleType}
-                    onChange={(e) => setRuleType(e.target.value)}
-                    className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
-                  >
-                    {RULE_TYPES.map((rt) => (
-                      <option key={rt.value} value={rt.value}>
-                        {rt.label}
-                      </option>
-                    ))}
-                  </select>
-                  <p className="text-[10px] text-zinc-400 light:text-slate-500">
-                    {
-                      RULE_TYPES.find((rt) => rt.value === ruleType)
-                        ?.description
-                    }
-                  </p>
-                </div>
-              </div>
-
-              {ruleType === "calculated" ? (
-                <CalculatedFields
-                  conditionLogic={conditionLogic}
-                  setConditionLogic={setConditionLogic}
-                  conditions={conditions}
-                  setConditions={setConditions}
-                />
-              ) : (
-                <LLMDescriptionField existingRule={existingRule} />
-              )}
-
-              <LLMProviderModelPicker
-                providerFieldName="route_provider"
-                modelFieldName="route_model"
-                label={t("model-router.rule-form.route-to-label")}
-                description={t("model-router.rule-form.route-to-description")}
-                defaultProvider={existingRule?.route_provider || ""}
-                defaultModel={existingRule?.route_model || ""}
-              />
-            </div>
-
-            <div className="flex justify-end items-center mt-6 pt-6 border-t border-zinc-700 light:border-slate-200">
+      <div className="relative w-full max-w-3xl bg-zinc-900 light:bg-white rounded-[8px] shadow border border-zinc-700 light:border-slate-300">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-5 p-6">
+          <div className="flex flex-col gap-y-1">
+            <div className="flex items-start justify-between">
+              <h3 className="text-base font-semibold leading-6 text-white light:text-slate-950">
+                {t("model-router.rules.title")}
+              </h3>
               <button
-                type="button"
                 onClick={closeModal}
-                className="text-sm font-medium text-zinc-400 light:text-slate-600 hover:text-white light:hover:text-slate-900 px-4 py-2 rounded-lg transition-colors mr-2"
+                type="button"
+                className="border-none text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
               >
-                {t("model-router.rule-form.cancel")}
-              </button>
-              <button
-                type="submit"
-                disabled={loading}
-                className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading ? (
-                  <>
-                    <CircleNotch className="h-4 w-4 animate-spin" />
-                    {t("model-router.rule-form.saving")}
-                  </>
-                ) : isEditing ? (
-                  t("model-router.rule-form.update-rule")
-                ) : (
-                  t("model-router.rule-form.create-rule")
-                )}
+                <X size={16} weight="bold" />
               </button>
             </div>
-          </form>
-        </div>
+            <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
+              {t("model-router.rules.description")}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-y-5 max-h-[60vh] overflow-y-auto">
+            <div className="flex gap-x-5 items-start">
+              <div className="flex flex-col gap-y-1.5 w-[500px]">
+                <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
+                  {t("model-router.rule-form.title-label")}
+                </label>
+                <input
+                  type="text"
+                  name="title"
+                  defaultValue={existingRule?.title || ""}
+                  placeholder="e.g. route_code_to_claude"
+                  className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 placeholder:text-zinc-400 light:placeholder:text-slate-400 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5 font-mono"
+                  required
+                />
+                <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
+                  {t("model-router.rule-form.title-help")}
+                </p>
+              </div>
+              <div className="flex flex-col gap-y-1.5 w-[300px]">
+                <label className="text-sm font-medium leading-5 text-white light:text-slate-950">
+                  {t("model-router.rule-form.rule-type")}
+                </label>
+                <select
+                  value={ruleType}
+                  onChange={(e) => setRuleType(e.target.value)}
+                  className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-700 text-sm rounded-[8px] outline-none block w-full h-8 px-3.5"
+                >
+                  {RULE_TYPES.map((rt) => (
+                    <option key={rt.value} value={rt.value}>
+                      {rt.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs leading-4 text-zinc-400 light:text-slate-600">
+                  {RULE_TYPES.find((rt) => rt.value === ruleType)?.description}
+                </p>
+              </div>
+            </div>
+
+            {ruleType === "calculated" ? (
+              <CalculatedFields
+                conditionLogic={conditionLogic}
+                setConditionLogic={setConditionLogic}
+                conditions={conditions}
+                setConditions={setConditions}
+              />
+            ) : (
+              <LLMDescriptionField existingRule={existingRule} />
+            )}
+
+            <LLMProviderModelPicker
+              providerFieldName="route_provider"
+              modelFieldName="route_model"
+              label={t("model-router.rule-form.route-to-label")}
+              description={t("model-router.rule-form.route-to-description")}
+              defaultProvider={existingRule?.route_provider || ""}
+              defaultModel={existingRule?.route_model || ""}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={closeModal}
+              className="border border-zinc-600 light:border-slate-600 text-white light:text-slate-900 text-sm font-medium leading-5 rounded-[8px] h-[34px] px-3.5 hover:opacity-90 transition-opacity"
+            >
+              {t("model-router.rule-form.cancel")}
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="border-none flex items-center gap-x-1.5 text-sm font-medium leading-5 bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-[8px] h-[34px] px-3.5 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? (
+                <>
+                  <CircleNotch className="h-4 w-4 animate-spin" />
+                  {t("model-router.rule-form.saving")}
+                </>
+              ) : isEditing ? (
+                t("model-router.rule-form.update-rule")
+              ) : (
+                t("model-router.rule-form.create-rule")
+              )}
+            </button>
+          </div>
+        </form>
       </div>
     </ModalWrapper>
   );

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CircleNotch } from "@phosphor-icons/react";
+import { CircleNotch, X } from "@phosphor-icons/react";
+import ModalWrapper from "@/components/ModalWrapper";
 import ModelRouterAPI from "@/models/modelRouter";
 import showToast from "@/utils/toast";
 import LLMProviderModelPicker from "../../LLMProviderModelPicker";
@@ -47,11 +48,12 @@ function slugify(text) {
 }
 
 export default function RuleForm({
+  isOpen,
+  closeModal,
   routerId,
   existingRule = null,
   nextPriority,
   onSaved,
-  onCancel,
 }) {
   const { t } = useTranslation();
   const isEditing = !!existingRule;
@@ -111,11 +113,10 @@ export default function RuleForm({
           ? t("model-router.rule-form.toast-updated")
           : t("model-router.rule-form.toast-created"),
         "success",
-        {
-          clear: true,
-        }
+        { clear: true }
       );
       onSaved();
+      closeModal();
     } else {
       showToast(
         result.error || t("model-router.rule-form.toast-save-failed"),
@@ -125,98 +126,117 @@ export default function RuleForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-y-4">
-      <p className="text-sm font-semibold text-white light:text-slate-900">
-        {isEditing
-          ? t("model-router.rule-form.edit-title")
-          : t("model-router.rule-form.new-title")}
-      </p>
-
-      <div className="flex gap-x-4">
-        <div className="flex-1 flex flex-col gap-y-1.5">
-          <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-            {t("model-router.rule-form.title-label")}
-          </label>
-          <input
-            type="text"
-            name="title"
-            defaultValue={existingRule?.title || ""}
-            placeholder="e.g. route_code_to_claude"
-            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 font-mono"
-            required
-          />
-          <p className="text-[10px] text-zinc-400 light:text-slate-500">
-            {t("model-router.rule-form.title-help")}
-          </p>
-        </div>
-        <div className="w-[200px] flex flex-col gap-y-1.5">
-          <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
-            {t("model-router.rule-form.rule-type")}
-          </label>
-          <select
-            value={ruleType}
-            onChange={(e) => setRuleType(e.target.value)}
-            className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+    <ModalWrapper isOpen={isOpen}>
+      <div className="relative w-full max-w-3xl bg-zinc-900 light:bg-white rounded-xl shadow border border-zinc-700 light:border-slate-300">
+        <div className="relative p-6 border-b border-zinc-700 light:border-slate-200">
+          <h3 className="text-lg font-semibold text-white light:text-slate-900">
+            {isEditing
+              ? t("model-router.rule-form.edit-title")
+              : t("model-router.rule-form.new-title")}
+          </h3>
+          <button
+            onClick={closeModal}
+            type="button"
+            className="absolute top-4 right-4 text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
           >
-            {RULE_TYPES.map((rt) => (
-              <option key={rt.value} value={rt.value}>
-                {rt.label}
-              </option>
-            ))}
-          </select>
-          <p className="text-[10px] text-zinc-400 light:text-slate-500">
-            {RULE_TYPES.find((rt) => rt.value === ruleType)?.description}
-          </p>
+            <X size={20} weight="bold" />
+          </button>
+        </div>
+        <div className="px-6 py-6">
+          <form onSubmit={handleSubmit}>
+            <div className="flex flex-col gap-y-4 max-h-[60vh] overflow-y-auto pr-2">
+              <div className="flex gap-x-4">
+                <div className="flex-1 flex flex-col gap-y-1.5">
+                  <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
+                    {t("model-router.rule-form.title-label")}
+                  </label>
+                  <input
+                    type="text"
+                    name="title"
+                    defaultValue={existingRule?.title || ""}
+                    placeholder="e.g. route_code_to_claude"
+                    className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 placeholder:text-zinc-400 light:placeholder:text-slate-500 text-sm rounded-lg outline-none block w-full p-2.5 font-mono"
+                    required
+                  />
+                  <p className="text-[10px] text-zinc-400 light:text-slate-500">
+                    {t("model-router.rule-form.title-help")}
+                  </p>
+                </div>
+                <div className="w-[200px] flex flex-col gap-y-1.5">
+                  <label className="text-sm font-medium text-zinc-200 light:text-slate-900">
+                    {t("model-router.rule-form.rule-type")}
+                  </label>
+                  <select
+                    value={ruleType}
+                    onChange={(e) => setRuleType(e.target.value)}
+                    className="bg-zinc-800 light:bg-white light:border light:border-slate-300 text-white light:text-slate-900 text-sm rounded-lg outline-none block w-full p-2.5"
+                  >
+                    {RULE_TYPES.map((rt) => (
+                      <option key={rt.value} value={rt.value}>
+                        {rt.label}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-[10px] text-zinc-400 light:text-slate-500">
+                    {
+                      RULE_TYPES.find((rt) => rt.value === ruleType)
+                        ?.description
+                    }
+                  </p>
+                </div>
+              </div>
+
+              {ruleType === "calculated" ? (
+                <CalculatedFields
+                  property={property}
+                  setProperty={setProperty}
+                  comparator={comparator}
+                  setComparator={setComparator}
+                  comparators={comparators}
+                  existingRule={existingRule}
+                />
+              ) : (
+                <LLMDescriptionField existingRule={existingRule} />
+              )}
+
+              <LLMProviderModelPicker
+                providerFieldName="route_provider"
+                modelFieldName="route_model"
+                label={t("model-router.rule-form.route-to-label")}
+                description={t("model-router.rule-form.route-to-description")}
+                defaultProvider={existingRule?.route_provider || ""}
+                defaultModel={existingRule?.route_model || ""}
+              />
+            </div>
+
+            <div className="flex justify-end items-center mt-6 pt-6 border-t border-zinc-700 light:border-slate-200">
+              <button
+                type="button"
+                onClick={closeModal}
+                className="text-sm font-medium text-zinc-400 light:text-slate-600 hover:text-white light:hover:text-slate-900 px-4 py-2 rounded-lg transition-colors mr-2"
+              >
+                {t("model-router.rule-form.cancel")}
+              </button>
+              <button
+                type="submit"
+                disabled={loading}
+                className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading ? (
+                  <>
+                    <CircleNotch className="h-4 w-4 animate-spin" />
+                    {t("model-router.rule-form.saving")}
+                  </>
+                ) : isEditing ? (
+                  t("model-router.rule-form.update-rule")
+                ) : (
+                  t("model-router.rule-form.create-rule")
+                )}
+              </button>
+            </div>
+          </form>
         </div>
       </div>
-
-      {ruleType === "calculated" ? (
-        <CalculatedFields
-          property={property}
-          setProperty={setProperty}
-          comparator={comparator}
-          setComparator={setComparator}
-          comparators={comparators}
-          existingRule={existingRule}
-        />
-      ) : (
-        <LLMDescriptionField existingRule={existingRule} />
-      )}
-
-      <LLMProviderModelPicker
-        providerFieldName="route_provider"
-        modelFieldName="route_model"
-        label={t("model-router.rule-form.route-to-label")}
-        description={t("model-router.rule-form.route-to-description")}
-        defaultProvider={existingRule?.route_provider || ""}
-        defaultModel={existingRule?.route_model || ""}
-      />
-
-      <div className="flex justify-end gap-x-2 pt-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="text-sm font-medium text-zinc-400 light:text-slate-600 hover:text-white light:hover:text-slate-900 px-4 py-2 rounded-lg transition-colors"
-        >
-          {t("model-router.rule-form.cancel")}
-        </button>
-        <button
-          type="submit"
-          disabled={loading}
-          className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {loading ? (
-            <>
-              <CircleNotch className="h-4 w-4 animate-spin" />
-              {t("model-router.rule-form.saving")}
-            </>
-          ) : isEditing ? (
-            t("model-router.rule-form.update-rule")
-          ) : (
-            t("model-router.rule-form.create-rule")
-          )}
-        </button>
-      </div>
-    </form>
+    </ModalWrapper>
   );
 }

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleForm/index.jsx
@@ -25,6 +25,7 @@ const RULE_TYPES = [
 
 const STRING_COMPARATORS = [
   { value: "contains", label: "contains" },
+  { value: "matches", label: "matches (regex)" },
   { value: "eq", label: "equals" },
   { value: "neq", label: "not equals" },
 ];

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleRow/index.jsx
@@ -20,71 +20,68 @@ export default function RuleRow({
   dragHandleProps,
 }) {
   const comparatorLabel = COMPARATOR_LABELS[rule.comparator] || rule.comparator;
+  const isDisabled = !rule.enabled;
 
   return (
     <div
-      className={`flex items-center border rounded-xl p-3 ${
-        isEditing
-          ? "border-blue-500/50"
-          : rule.enabled
-            ? "border-zinc-700 light:border-slate-200"
-            : "border-zinc-800 light:border-slate-100 opacity-50"
-      }`}
+      className={`group flex items-center gap-3 px-3 py-2 rounded-lg bg-zinc-800 light:bg-slate-100 transition-colors ${
+        isEditing ? "ring-1 ring-blue-500/60" : ""
+      } ${isDisabled ? "opacity-50" : ""}`}
     >
-      <div {...dragHandleProps} className="cursor-grab mr-2 shrink-0">
-        <DotsSixVertical
-          size={18}
-          weight="bold"
-          className="text-zinc-500 light:text-slate-400"
-        />
+      <div
+        {...dragHandleProps}
+        className="cursor-grab shrink-0 text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-700 transition-colors"
+        aria-label="Drag to reorder"
+      >
+        <DotsSixVertical size={24} weight="bold" />
       </div>
-      <div className="flex flex-col gap-y-1 flex-1 min-w-0">
-        <div className="flex items-baseline gap-x-2">
-          <span className="text-xs font-mono text-zinc-400 light:text-slate-500 w-5 shrink-0">
-            #{rule.priority}
-          </span>
-          <span className="text-sm font-semibold text-white light:text-slate-900 truncate">
+      <p className="shrink-0 text-sm font-semibold text-zinc-400 light:text-slate-500 tabular-nums">
+        #{rule.priority}
+      </p>
+      <div className="flex flex-col flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium leading-5 text-white light:text-slate-900 truncate">
             {rule.title}
           </span>
           {rule.type === "llm" ? (
-            <span className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 bg-fuchsia-500/20 text-fuchsia-400 light:bg-fuchsia-100 light:text-fuchsia-700">
+            <span className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-fuchsia-500/20 text-fuchsia-400 light:bg-fuchsia-100 light:text-fuchsia-700">
               LLM
             </span>
           ) : (
-            <span className="text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 bg-blue-500/20 text-blue-400 light:bg-blue-100 light:text-blue-700">
+            <span className="shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 light:bg-blue-100 light:text-blue-700">
               Calculated
             </span>
           )}
         </div>
         {rule.type === "llm" ? (
-          <p className="text-xs text-zinc-300 light:text-slate-700 truncate ml-7">
-            MATCH{" "}
+          <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
+            Match{" "}
             <span className="font-mono text-fuchsia-400 light:text-fuchsia-500">
               &quot;{rule.description}&quot;
             </span>{" "}
-            THEN{" "}
-            <span className="font-medium text-white light:text-slate-900">
-              {rule.route_provider} / {rule.route_model}
+            then route to{" "}
+            <span className="text-zinc-200 light:text-slate-700">
+              {rule.route_provider}/{rule.route_model}
             </span>
           </p>
         ) : (
-          <p className="text-xs text-zinc-300 light:text-slate-700 ml-7">
-            IF{" "}
+          <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
+            If{" "}
             <span className="font-mono text-blue-400 light:text-blue-500">
               {rule.property}
             </span>{" "}
-            <span className="font-medium">{comparatorLabel}</span>{" "}
+            {comparatorLabel}{" "}
             <span className="font-mono text-blue-400 light:text-blue-500">
               &quot;{rule.value}&quot;
             </span>{" "}
-            THEN{" "}
-            <span className="font-medium text-white light:text-slate-900">
-              {rule.route_provider} / {rule.route_model}
+            then route to{" "}
+            <span className="text-zinc-200 light:text-slate-700">
+              {rule.route_provider}/{rule.route_model}
             </span>
           </p>
         )}
       </div>
-      <div className="flex items-center gap-x-3 ml-4 shrink-0">
+      <div className="flex items-center gap-x-3 shrink-0">
         <SimpleToggleSwitch
           enabled={rule.enabled}
           onChange={onToggle}
@@ -93,14 +90,16 @@ export default function RuleRow({
         <button
           onClick={onEdit}
           className="border-none text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
+          aria-label="Edit rule"
         >
-          <PencilSimple className="h-4 w-4" />
+          <PencilSimple size={16} weight="bold" />
         </button>
         <button
           onClick={onDelete}
           className="border-none text-zinc-400 light:text-slate-500 hover:text-red-400 light:hover:text-red-500 transition-colors"
+          aria-label="Delete rule"
         >
-          <Trash className="h-4 w-4" />
+          <Trash size={16} weight="bold" />
         </button>
       </div>
     </div>

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleRow/index.jsx
@@ -3,6 +3,7 @@ import { SimpleToggleSwitch } from "@/components/lib/Toggle";
 
 const COMPARATOR_LABELS = {
   contains: "contains",
+  matches: "matches",
   gt: ">",
   gte: ">=",
   lt: "<",

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/RuleRow/index.jsx
@@ -10,6 +10,7 @@ const COMPARATOR_LABELS = {
   lte: "<=",
   eq: "=",
   neq: "!=",
+  between: "between",
 };
 
 export default function RuleRow({
@@ -20,7 +21,6 @@ export default function RuleRow({
   onToggle,
   dragHandleProps,
 }) {
-  const comparatorLabel = COMPARATOR_LABELS[rule.comparator] || rule.comparator;
   const isDisabled = !rule.enabled;
 
   return (
@@ -55,31 +55,9 @@ export default function RuleRow({
           )}
         </div>
         {rule.type === "llm" ? (
-          <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
-            Match{" "}
-            <span className="font-mono text-fuchsia-400 light:text-fuchsia-500">
-              &quot;{rule.description}&quot;
-            </span>{" "}
-            then route to{" "}
-            <span className="text-zinc-200 light:text-slate-700">
-              {rule.route_provider}/{rule.route_model}
-            </span>
-          </p>
+          <LLMRuleBody rule={rule} />
         ) : (
-          <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
-            If{" "}
-            <span className="font-mono text-blue-400 light:text-blue-500">
-              {rule.property}
-            </span>{" "}
-            {comparatorLabel}{" "}
-            <span className="font-mono text-blue-400 light:text-blue-500">
-              &quot;{rule.value}&quot;
-            </span>{" "}
-            then route to{" "}
-            <span className="text-zinc-200 light:text-slate-700">
-              {rule.route_provider}/{rule.route_model}
-            </span>
-          </p>
+          <CalculatedRuleBody rule={rule} />
         )}
       </div>
       <div className="flex items-center gap-x-3 shrink-0">
@@ -104,5 +82,74 @@ export default function RuleRow({
         </button>
       </div>
     </div>
+  );
+}
+
+function LLMRuleBody({ rule }) {
+  return (
+    <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
+      Match{" "}
+      <span className="font-mono text-fuchsia-400 light:text-fuchsia-500">
+        &quot;{rule.description}&quot;
+      </span>{" "}
+      then route to{" "}
+      <span className="text-zinc-200 light:text-slate-700">
+        {rule.route_provider}/{rule.route_model}
+      </span>
+    </p>
+  );
+}
+
+function CalculatedRuleBody({ rule }) {
+  const conditions = Array.isArray(rule.conditions) ? rule.conditions : [];
+  const routeTo = (
+    <span className="text-zinc-200 light:text-slate-700">
+      {rule.route_provider}/{rule.route_model}
+    </span>
+  );
+
+  if (conditions.length === 0) {
+    return (
+      <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
+        No conditions — route to {routeTo}
+      </p>
+    );
+  }
+
+  if (conditions.length === 1) {
+    return (
+      <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
+        If <ConditionText condition={conditions[0]} /> then route to {routeTo}
+      </p>
+    );
+  }
+
+  const quantifier = rule.condition_logic === "OR" ? "ANY" : "ALL";
+  return (
+    <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 truncate">
+      If {quantifier} of{" "}
+      {conditions.map((c, i) => (
+        <span key={i}>
+          <ConditionText condition={c} />
+          {i < conditions.length - 1 ? ", " : ""}
+        </span>
+      ))}{" "}
+      then route to {routeTo}
+    </p>
+  );
+}
+
+function ConditionText({ condition }) {
+  const label = COMPARATOR_LABELS[condition.comparator] || condition.comparator;
+  return (
+    <>
+      <span className="font-mono text-blue-400 light:text-blue-500">
+        {condition.property}
+      </span>{" "}
+      {label}{" "}
+      <span className="font-mono text-blue-400 light:text-blue-500">
+        &quot;{condition.value}&quot;
+      </span>
+    </>
   );
 }

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/index.jsx
@@ -164,6 +164,7 @@ export default function RuleBuilder({
       )}
 
       <RuleForm
+        key={editingRule?.id ?? "new"}
         isOpen={isOpen}
         closeModal={handleModalClose}
         routerId={routerId}

--- a/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/RuleBuilder/index.jsx
@@ -1,25 +1,35 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { PlusCircle } from "@phosphor-icons/react";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import ModelRouterAPI from "@/models/modelRouter";
+import { useModal } from "@/hooks/useModal";
 import showToast from "@/utils/toast";
 import RuleForm from "./RuleForm";
 import RuleRow from "./RuleRow";
 
-export default function RuleBuilder({ routerId, rules, onRulesChanged }) {
+export default function RuleBuilder({
+  routerId,
+  routerName,
+  rules,
+  onRulesChanged,
+}) {
   const { t } = useTranslation();
-  const [showForm, setShowForm] = useState(false);
+  const { isOpen, openModal, closeModal } = useModal();
   const [editingRule, setEditingRule] = useState(null);
 
-  const handleRuleCreated = () => {
-    setShowForm(false);
-    onRulesChanged();
+  const openCreate = () => {
+    setEditingRule(null);
+    openModal();
   };
 
-  const handleRuleUpdated = () => {
+  const openEdit = (rule) => {
+    setEditingRule(rule);
+    openModal();
+  };
+
+  const handleModalClose = () => {
+    closeModal();
     setEditingRule(null);
-    onRulesChanged();
   };
 
   const handleDelete = async (rule) => {
@@ -69,56 +79,33 @@ export default function RuleBuilder({ routerId, rules, onRulesChanged }) {
     }
   };
 
+  const hasRules = rules && rules.length > 0;
+
   return (
     <div className="mt-8">
-      <div className="flex items-center justify-between pb-4 border-b border-white/20 light:border-slate-300">
-        <div>
-          <p className="text-base font-semibold text-white light:text-slate-900">
-            {t("model-router.rules.title")}
+      <div className="flex items-end justify-between pb-6 border-b border-white/20 light:border-slate-300">
+        <div className="flex flex-col gap-y-2">
+          <p className="text-lg font-semibold leading-7 text-white light:text-slate-900">
+            {routerName
+              ? t("model-router.rules.title-with-name", { name: routerName })
+              : t("model-router.rules.title")}
           </p>
-          <p className="text-xs text-zinc-400 light:text-slate-600 mt-1">
+          <p className="text-xs leading-4 text-zinc-400 light:text-slate-600 max-w-[700px]">
             {t("model-router.rules.description")}
           </p>
         </div>
-        {!showForm && !editingRule && (
+        {hasRules && (
           <button
-            onClick={() => setShowForm(true)}
-            className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200"
+            onClick={openCreate}
+            className="shrink-0 flex items-center justify-center h-9 px-5 py-2.5 rounded-lg bg-slate-50 text-zinc-950 text-sm font-medium leading-5 hover:opacity-90 transition-opacity duration-200"
           >
-            <PlusCircle className="h-4 w-4" weight="bold" />
             {t("model-router.rules.add-rule")}
           </button>
         )}
       </div>
 
-      {showForm && (
-        <div className="mt-4 border border-zinc-700 light:border-slate-200 rounded-xl p-4">
-          <RuleForm
-            routerId={routerId}
-            nextPriority={(rules?.length || 0) + 1}
-            onSaved={handleRuleCreated}
-            onCancel={() => setShowForm(false)}
-          />
-        </div>
-      )}
-
-      {editingRule && (
-        <div className="mt-4 border border-zinc-700 light:border-slate-200 rounded-xl p-4">
-          <RuleForm
-            routerId={routerId}
-            existingRule={editingRule}
-            onSaved={handleRuleUpdated}
-            onCancel={() => setEditingRule(null)}
-          />
-        </div>
-      )}
-
-      <div className="mt-4">
-        {(!rules || rules.length === 0) && !showForm ? (
-          <p className="text-sm text-zinc-400 light:text-slate-500 py-4 text-center">
-            {t("model-router.rules.no-rules")}
-          </p>
-        ) : (
+      {hasRules ? (
+        <div className="mt-6">
           <DragDropContext onDragEnd={onDragEnd}>
             <Droppable droppableId="rules">
               {(provided) => (
@@ -127,7 +114,7 @@ export default function RuleBuilder({ routerId, rules, onRulesChanged }) {
                   {...provided.droppableProps}
                   className="flex flex-col gap-y-2"
                 >
-                  {rules?.map((rule, index) => (
+                  {rules.map((rule, index) => (
                     <Draggable
                       key={rule.id}
                       draggableId={rule.id.toString()}
@@ -142,10 +129,7 @@ export default function RuleBuilder({ routerId, rules, onRulesChanged }) {
                           <RuleRow
                             rule={rule}
                             isEditing={editingRule?.id === rule.id}
-                            onEdit={() => {
-                              setShowForm(false);
-                              setEditingRule(rule);
-                            }}
+                            onEdit={() => openEdit(rule)}
                             onDelete={() => handleDelete(rule)}
                             onToggle={() => handleToggle(rule)}
                             dragHandleProps={provided.dragHandleProps}
@@ -159,8 +143,34 @@ export default function RuleBuilder({ routerId, rules, onRulesChanged }) {
               )}
             </Droppable>
           </DragDropContext>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-8 py-28">
+          <div className="flex flex-col items-center gap-1.5 text-center">
+            <p className="text-base font-semibold leading-6 text-zinc-50 light:text-slate-900">
+              {t("model-router.rules.no-rules")}
+            </p>
+            <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 max-w-[370px]">
+              {t("model-router.rules.empty-description")}
+            </p>
+          </div>
+          <button
+            onClick={openCreate}
+            className="flex items-center justify-center h-9 px-5 py-2.5 rounded-lg bg-slate-50 text-zinc-950 text-sm font-medium leading-5 hover:opacity-90 transition-opacity duration-200"
+          >
+            {t("model-router.rules.new-rule-button")}
+          </button>
+        </div>
+      )}
+
+      <RuleForm
+        isOpen={isOpen}
+        closeModal={handleModalClose}
+        routerId={routerId}
+        existingRule={editingRule}
+        nextPriority={(rules?.length || 0) + 1}
+        onSaved={onRulesChanged}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/GeneralSettings/ModelRouters/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/index.jsx
@@ -3,12 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Sidebar from "@/components/SettingsSidebar";
 import { isMobile } from "react-device-detect";
-import {
-  CircleNotch,
-  PlusCircle,
-  Trash,
-  PencilSimple,
-} from "@phosphor-icons/react";
+import { CircleNotch, PencilSimple, X } from "@phosphor-icons/react";
 import ModelRouter from "@/models/modelRouter";
 import { useModal } from "@/hooks/useModal";
 import showToast from "@/utils/toast";
@@ -20,6 +15,22 @@ export default function ModelRouters() {
   const { isOpen, openModal, closeModal } = useModal();
   const [loading, setLoading] = useState(true);
   const [routers, setRouters] = useState([]);
+  const [editingRouter, setEditingRouter] = useState(null);
+
+  const openCreateModal = () => {
+    setEditingRouter(null);
+    openModal();
+  };
+
+  const openEditModal = (router) => {
+    setEditingRouter(router);
+    openModal();
+  };
+
+  const handleModalClose = () => {
+    closeModal();
+    setEditingRouter(null);
+  };
 
   const fetchRouters = async () => {
     const results = await ModelRouter.getAll();
@@ -35,6 +46,8 @@ export default function ModelRouters() {
     setRouters((prev) => prev.filter((r) => r.id !== id));
   };
 
+  const isEmpty = !loading && routers.length === 0;
+
   return (
     <div className="w-screen h-screen overflow-hidden bg-zinc-950 light:bg-slate-50 flex md:mt-0 mt-6">
       <Sidebar />
@@ -42,89 +55,95 @@ export default function ModelRouters() {
         style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
         className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-2xl bg-zinc-900 light:bg-white light:border light:border-slate-300 w-full h-full overflow-y-scroll p-4 md:p-0"
       >
-        <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-          <div className="w-full flex flex-col gap-y-2 pb-6 border-b border-white/20 light:border-slate-300">
-            <p className="text-lg font-semibold leading-7 text-white light:text-slate-900">
-              {t("model-router.title")}
-            </p>
-            <p className="text-xs leading-4 text-zinc-400 light:text-slate-600 max-w-[700px]">
-              {t("model-router.description")}
-            </p>
+        <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-0 py-16">
+          <div className="flex items-end justify-between pr-8 py-6 border-b border-white/20 light:border-slate-300">
+            <div className="flex flex-col gap-y-2">
+              <p className="text-lg font-semibold leading-7 text-white light:text-slate-900">
+                {t("model-router.title")}
+              </p>
+              <p className="text-xs leading-4 text-zinc-400 light:text-slate-600 max-w-[700px]">
+                {t("model-router.description")}
+              </p>
+            </div>
+            {!isEmpty && (
+              <button
+                onClick={openCreateModal}
+                className="shrink-0 flex items-center justify-center h-9 px-5 py-2.5 rounded-lg bg-slate-50 text-zinc-950 text-sm font-medium leading-5 hover:opacity-90 transition-opacity duration-200"
+              >
+                {t("model-router.new-router-button")}
+              </button>
+            )}
           </div>
-          <div className="w-full justify-end flex mt-4">
-            <button
-              onClick={openModal}
-              className="flex items-center gap-x-1.5 text-sm font-medium bg-zinc-50 light:bg-slate-900 text-zinc-900 light:text-white rounded-lg h-9 px-5 hover:opacity-90 transition-opacity duration-200"
-            >
-              <PlusCircle className="h-4 w-4" weight="bold" />
-              {t("model-router.create-router")}
-            </button>
-          </div>
-          <div className="overflow-x-auto mt-6">
+
+          <div className="mt-8 flex flex-col">
+            <div className="grid grid-cols-[2fr_2fr_1fr_1fr_88px] gap-x-4 px-4 text-sm font-semibold uppercase tracking-[1.4px] text-zinc-500 light:text-slate-500 leading-5">
+              <span>{t("model-router.table.name")}</span>
+              <span>{t("model-router.table.fallback")}</span>
+              <span>{t("model-router.table.rules")}</span>
+              <span>{t("model-router.table.workspaces")}</span>
+              <span aria-hidden="true" />
+            </div>
+            <div className="mt-[18px] border-t border-white/20 light:border-slate-300" />
+
             {loading ? (
               <div className="flex items-center justify-center py-20">
-                <CircleNotch className="h-8 w-8 text-zinc-400 light:text-slate-400 animate-spin" />
+                <CircleNotch className="h-8 w-8 text-zinc-400 animate-spin" />
               </div>
+            ) : isEmpty ? (
+              <EmptyState onAction={openCreateModal} t={t} />
             ) : (
-              <table className="w-full text-xs text-left rounded-lg min-w-[640px] border-spacing-0">
-                <thead className="text-zinc-400 light:text-slate-500 text-xs leading-[18px] font-bold uppercase border-b border-zinc-700 light:border-slate-200">
-                  <tr>
-                    <th scope="col" className="px-6 py-3 rounded-tl-lg">
-                      {t("model-router.table.name")}
-                    </th>
-                    <th scope="col" className="px-6 py-3">
-                      {t("model-router.table.fallback")}
-                    </th>
-                    <th scope="col" className="px-6 py-3">
-                      {t("model-router.table.rules")}
-                    </th>
-                    <th scope="col" className="px-6 py-3">
-                      {t("model-router.table.workspaces")}
-                    </th>
-                    <th scope="col" className="px-6 py-3 rounded-tr-lg">
-                      {" "}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {routers.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan="5"
-                        className="px-6 py-4 text-center text-sm text-zinc-400 light:text-slate-500"
-                      >
-                        {t("model-router.no-routers")}
-                      </td>
-                    </tr>
-                  ) : (
-                    routers.map((router) => (
-                      <RouterRow
-                        key={router.id}
-                        router={router}
-                        removeRouter={removeRouter}
-                      />
-                    ))
-                  )}
-                </tbody>
-              </table>
+              <div className="flex flex-col">
+                {routers.map((router, idx) => (
+                  <RouterRow
+                    key={router.id}
+                    router={router}
+                    removeRouter={removeRouter}
+                    onEdit={() => openEditModal(router)}
+                    showDivider={idx < routers.length - 1}
+                  />
+                ))}
+              </div>
             )}
           </div>
         </div>
         <NewRouterModal
           isOpen={isOpen}
-          closeModal={closeModal}
+          closeModal={handleModalClose}
           onSuccess={fetchRouters}
+          router={editingRouter}
         />
       </div>
     </div>
   );
 }
 
-function RouterRow({ router, removeRouter }) {
+function EmptyState({ onAction, t }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 py-28">
+      <div className="flex flex-col items-center gap-1.5 text-center">
+        <p className="text-base font-semibold leading-6 text-zinc-50 light:text-slate-900">
+          {t("model-router.no-routers")}
+        </p>
+        <p className="text-sm font-medium leading-5 text-zinc-400 light:text-slate-500 max-w-[370px]">
+          {t("model-router.empty-description")}
+        </p>
+      </div>
+      <button
+        onClick={onAction}
+        className="flex items-center justify-center h-9 px-5 py-2.5 rounded-lg bg-slate-50 text-zinc-950 text-sm font-medium leading-5 hover:opacity-90 transition-opacity duration-200"
+      >
+        {t("model-router.new-router-button")}
+      </button>
+    </div>
+  );
+}
+
+function RouterRow({ router, removeRouter, onEdit, showDivider }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const handleDelete = async () => {
+  const handleDelete = async (e) => {
+    e.stopPropagation();
     if (
       !window.confirm(t("model-router.delete-confirm", { name: router.name }))
     )
@@ -139,53 +158,59 @@ function RouterRow({ router, removeRouter }) {
     }
   };
 
+  const goToRules = () => navigate(paths.settings.modelRouterEdit(router.id));
+
+  const handleEditClick = (e) => {
+    e.stopPropagation();
+    onEdit();
+  };
+
   return (
-    <tr className="text-sm border-b border-zinc-700 light:border-slate-200 h-10">
-      <td className="px-6 py-3 whitespace-nowrap">
-        <div className="flex flex-col">
-          <span className="font-semibold text-white light:text-slate-900">
-            {router.name}
-          </span>
-          {router.description && (
-            <span className="text-zinc-400 light:text-slate-500 text-[10px]">
-              {router.description}
-            </span>
-          )}
-        </div>
-      </td>
-      <td className="px-6 py-3 text-zinc-300 light:text-slate-700">
-        {router.fallback_provider} / {router.fallback_model}
-      </td>
-      <td className="px-6 py-3 text-zinc-300 light:text-slate-700">
-        {router.ruleCount || 0}
-      </td>
-      <td className="px-6 py-3">
+    <>
+      <div
+        onClick={goToRules}
+        className="group grid grid-cols-[2fr_2fr_1fr_1fr_88px] gap-x-4 items-center h-9 px-4 rounded-lg cursor-pointer hover:bg-white/5 light:hover:bg-slate-100 transition-colors"
+      >
+        <span className="text-sm font-medium leading-5 text-white light:text-slate-900 truncate">
+          {router.name}
+        </span>
+        <span className="text-sm font-normal leading-5 text-zinc-400 light:text-slate-500 truncate">
+          {router.fallback_provider}/{router.fallback_model}
+        </span>
+        <span className="text-sm font-normal leading-5 text-zinc-400 light:text-slate-500">
+          {router.ruleCount || 0}
+        </span>
         <span
-          className={
+          className={`text-sm font-normal leading-5 ${
             router.workspaceCount > 0
               ? "text-green-400 light:text-green-600"
               : "text-zinc-400 light:text-slate-500"
-          }
+          }`}
         >
           {router.workspaceCount || 0}
         </span>
-      </td>
-      <td className="px-6 py-3">
-        <div className="flex items-center gap-x-4">
-          <button
-            onClick={() => navigate(paths.settings.modelRouterEdit(router.id))}
-            className="text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
-          >
-            <PencilSimple className="h-5 w-5" />
-          </button>
+        <div className="flex items-center justify-end gap-[14px]">
           <button
             onClick={handleDelete}
+            aria-label={t("model-router.toast-deleted")}
             className="text-zinc-400 light:text-slate-500 hover:text-red-400 light:hover:text-red-500 transition-colors"
           >
-            <Trash className="h-5 w-5" />
+            <X size={16} weight="bold" />
+          </button>
+          <button
+            onClick={handleEditClick}
+            aria-label={t("model-router.edit-router.title", {
+              name: router.name,
+            })}
+            className="text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900 transition-colors"
+          >
+            <PencilSimple size={16} weight="bold" />
           </button>
         </div>
-      </td>
-    </tr>
+      </div>
+      {showDivider && (
+        <div className="border-t border-white/10 light:border-slate-200" />
+      )}
+    </>
   );
 }

--- a/server/models/modelRouter.js
+++ b/server/models/modelRouter.js
@@ -1,5 +1,6 @@
 const { Prisma } = require("@prisma/client");
 const prisma = require("../utils/prisma");
+const { ModelRouterRule } = require("./modelRouterRule");
 
 const ModelRouter = {
   validations: {
@@ -94,7 +95,8 @@ const ModelRouter = {
           },
         },
       });
-      return router || null;
+      if (!router) return null;
+      return { ...router, rules: router.rules.map(ModelRouterRule._hydrate) };
     } catch (error) {
       console.error(error.message);
       return null;
@@ -115,8 +117,12 @@ const ModelRouter = {
         },
       });
       if (!router) return null;
-      const { _count, ...rest } = router;
-      return { ...rest, workspaceCount: _count.workspaces };
+      const { _count, rules, ...rest } = router;
+      return {
+        ...rest,
+        rules: rules.map(ModelRouterRule._hydrate),
+        workspaceCount: _count.workspaces,
+      };
     } catch (error) {
       console.error(error.message);
       return null;

--- a/server/models/modelRouterRule.js
+++ b/server/models/modelRouterRule.js
@@ -11,6 +11,7 @@ const VALID_PROPERTIES = [
 ];
 const VALID_COMPARATORS = [
   "contains",
+  "matches",
   "gt",
   "gte",
   "lt",

--- a/server/models/modelRouterRule.js
+++ b/server/models/modelRouterRule.js
@@ -20,12 +20,14 @@ const VALID_COMPARATORS = [
   "neq",
   "between",
 ];
+const VALID_CONDITION_LOGIC = ["AND", "OR"];
 const TITLE_REGEX = /^[a-z0-9_]+$/;
 
 const ModelRouterRule = {
   VALID_TYPES,
   VALID_PROPERTIES,
   VALID_COMPARATORS,
+  VALID_CONDITION_LOGIC,
 
   create: async function (routerId, data = {}, creatorId = null) {
     if (!routerId) return { rule: null, error: "Router ID is required." };
@@ -45,22 +47,17 @@ const ModelRouterRule = {
         message: `Type must be one of: ${VALID_TYPES.join(", ")}`,
       };
 
+    let conditionLogic = null;
+    let serializedConditions = null;
+
     if (type === "calculated") {
-      if (!VALID_PROPERTIES.includes(data.property))
-        return {
-          rule: null,
-          message: `Property must be one of: ${VALID_PROPERTIES.join(", ")}`,
-        };
-      if (!VALID_COMPARATORS.includes(data.comparator))
-        return {
-          rule: null,
-          message: `Comparator must be one of: ${VALID_COMPARATORS.join(", ")}`,
-        };
-      if (data.value === undefined || data.value === null || data.value === "")
-        return {
-          rule: null,
-          message: "Value is required for calculated rules.",
-        };
+      const validated = this._validateConditions(
+        data.condition_logic,
+        data.conditions
+      );
+      if (validated.error) return { rule: null, message: validated.error };
+      conditionLogic = validated.condition_logic;
+      serializedConditions = validated.serialized;
     }
 
     if (type === "llm") {
@@ -87,15 +84,14 @@ const ModelRouterRule = {
           type,
           title,
           description: data.description || null,
-          property: data.property || null,
-          comparator: data.comparator || null,
-          value: data.value != null ? String(data.value) : null,
+          condition_logic: conditionLogic,
+          conditions: serializedConditions,
           route_provider: String(data.route_provider),
           route_model: String(data.route_model),
           created_by: creatorId ? Number(creatorId) : null,
         },
       });
-      return { rule, error: null };
+      return { rule: this._hydrate(rule), error: null };
     } catch (error) {
       console.error(error.message);
       // P2002 is the unique constraint violation error code
@@ -125,7 +121,7 @@ const ModelRouterRule = {
       const rule = await prisma.model_router_rules.findFirst({
         where: clause,
       });
-      return rule || null;
+      return this._hydrate(rule);
     } catch (error) {
       console.error(error.message);
       return null;
@@ -139,7 +135,7 @@ const ModelRouterRule = {
         ...(limit !== null ? { take: limit } : {}),
         ...(orderBy !== null ? { orderBy } : {}),
       });
-      return results;
+      return results.map((r) => this._hydrate(r));
     } catch (error) {
       console.error(error.message);
       return [];
@@ -152,7 +148,7 @@ const ModelRouterRule = {
         where: { router_id: Number(routerId) },
         orderBy: { priority: "asc" },
       });
-      return rules;
+      return rules.map((r) => this._hydrate(r));
     } catch (error) {
       console.error(error.message);
       return [];
@@ -178,7 +174,6 @@ const ModelRouterRule = {
       ["enabled", (v) => Boolean(v)],
       ["priority", (v) => Number(v)],
       ["description", (v) => v || null],
-      ["value", (v) => (v != null ? String(v) : null)],
       ["route_provider", (v) => String(v)],
       ["route_model", (v) => String(v)],
     ];
@@ -186,23 +181,27 @@ const ModelRouterRule = {
       if (data[key] !== undefined) updates[key] = map(data[key]);
     }
 
-    const enumErr =
-      assignEnum(updates, data, "type", VALID_TYPES, "Type") ||
-      assignEnumOrNull(
-        updates,
-        data,
-        "property",
-        VALID_PROPERTIES,
-        "Property"
-      ) ||
-      assignEnumOrNull(
-        updates,
-        data,
-        "comparator",
-        VALID_COMPARATORS,
-        "Comparator"
-      );
-    if (enumErr) return enumErr;
+    const typeErr = assignEnum(updates, data, "type", VALID_TYPES, "Type");
+    if (typeErr) return typeErr;
+
+    // Conditions are only meaningful for calculated rules. When either
+    // condition_logic or conditions is provided we revalidate the pair
+    // together so we never persist a half-updated rule.
+    if (data.condition_logic !== undefined || data.conditions !== undefined) {
+      const effectiveType = updates.type || data.type;
+      if (effectiveType === "llm") {
+        updates.condition_logic = null;
+        updates.conditions = null;
+      } else {
+        const validated = this._validateConditions(
+          data.condition_logic,
+          data.conditions
+        );
+        if (validated.error) return { rule: null, error: validated.error };
+        updates.condition_logic = validated.condition_logic;
+        updates.conditions = validated.serialized;
+      }
+    }
 
     if (Object.keys(updates).length === 0)
       return { rule: { id }, error: "No valid fields to update." };
@@ -212,7 +211,7 @@ const ModelRouterRule = {
         where: { id: Number(id) },
         data: updates,
       });
-      return { rule, error: null };
+      return { rule: this._hydrate(rule), error: null };
     } catch (error) {
       console.error(error.message);
       // P2002 is the unique constraint violation error code
@@ -277,6 +276,62 @@ const ModelRouterRule = {
     if (!TITLE_REGEX.test(cleaned)) return null;
     return cleaned;
   },
+
+  /**
+   * Validate a (condition_logic, conditions[]) pair for calculated rules.
+   * Returns either `{ error }` or `{ condition_logic, serialized }`.
+   */
+  _validateConditions: function (logic, conditions) {
+    if (!VALID_CONDITION_LOGIC.includes(logic))
+      return {
+        error: `Condition logic must be one of: ${VALID_CONDITION_LOGIC.join(", ")}`,
+      };
+    if (!Array.isArray(conditions) || conditions.length === 0)
+      return { error: "At least one condition is required." };
+
+    const normalized = [];
+    for (let i = 0; i < conditions.length; i++) {
+      const c = conditions[i] || {};
+      if (!VALID_PROPERTIES.includes(c.property))
+        return {
+          error: `Condition ${i + 1}: property must be one of: ${VALID_PROPERTIES.join(", ")}`,
+        };
+      if (!VALID_COMPARATORS.includes(c.comparator))
+        return {
+          error: `Condition ${i + 1}: comparator must be one of: ${VALID_COMPARATORS.join(", ")}`,
+        };
+      if (c.value === undefined || c.value === null || String(c.value) === "")
+        return { error: `Condition ${i + 1}: value is required.` };
+      normalized.push({
+        property: c.property,
+        comparator: c.comparator,
+        value: String(c.value),
+      });
+    }
+
+    return {
+      condition_logic: logic,
+      serialized: JSON.stringify(normalized),
+    };
+  },
+
+  /**
+   * Parse the stored JSON `conditions` string into an array so every consumer
+   * (API responses, evaluator, UI) works with the same shape. Safe on null and
+   * on rule types that don't use conditions.
+   */
+  _hydrate: function (rule) {
+    if (!rule) return null;
+    if (!rule.conditions) return { ...rule, conditions: null };
+    try {
+      return { ...rule, conditions: JSON.parse(rule.conditions) };
+    } catch (error) {
+      console.error(
+        `Failed to parse conditions for rule ${rule.id}: ${error.message}`
+      );
+      return { ...rule, conditions: null };
+    }
+  },
 };
 
 function assignEnum(updates, data, key, validList, label) {
@@ -287,18 +342,6 @@ function assignEnum(updates, data, key, validList, label) {
       error: `${label} must be one of: ${validList.join(", ")}`,
     };
   updates[key] = data[key];
-  return null;
-}
-
-function assignEnumOrNull(updates, data, key, validList, label) {
-  if (data[key] === undefined) return null;
-  const v = data[key];
-  if (v && !validList.includes(v))
-    return {
-      rule: null,
-      error: `${label} must be one of: ${validList.join(", ")}`,
-    };
-  updates[key] = v || null;
   return null;
 }
 

--- a/server/prisma/migrations/20260417000000_router_rules_multi_condition/migration.sql
+++ b/server/prisma/migrations/20260417000000_router_rules_multi_condition/migration.sql
@@ -1,0 +1,56 @@
+-- Multi-condition calculated rules. Swap single (property, comparator, value)
+-- columns for a JSON `conditions` array plus a top-level `condition_logic`
+-- operator. Existing calculated rules are migrated to a one-element array.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_model_router_rules" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "router_id" INTEGER NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "priority" INTEGER NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'calculated',
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "condition_logic" TEXT,
+    "conditions" TEXT,
+    "route_provider" TEXT NOT NULL,
+    "route_model" TEXT NOT NULL,
+    "created_by" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUpdatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "model_router_rules_router_id_fkey" FOREIGN KEY ("router_id") REFERENCES "model_routers" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO "new_model_router_rules" (
+    "id", "router_id", "enabled", "priority", "type", "title", "description",
+    "condition_logic", "conditions",
+    "route_provider", "route_model", "created_by", "createdAt", "lastUpdatedAt"
+)
+SELECT
+    "id", "router_id", "enabled", "priority", "type", "title", "description",
+    CASE
+        WHEN "type" = 'calculated' AND "property" IS NOT NULL THEN 'AND'
+        ELSE NULL
+    END AS "condition_logic",
+    CASE
+        WHEN "type" = 'calculated' AND "property" IS NOT NULL
+            THEN json_array(json_object(
+                'property', "property",
+                'comparator', "comparator",
+                'value', "value"
+            ))
+        ELSE NULL
+    END AS "conditions",
+    "route_provider", "route_model", "created_by", "createdAt", "lastUpdatedAt"
+FROM "model_router_rules";
+
+DROP TABLE "model_router_rules";
+ALTER TABLE "new_model_router_rules" RENAME TO "model_router_rules";
+
+CREATE INDEX "model_router_rules_router_id_idx" ON "model_router_rules"("router_id");
+CREATE INDEX "model_router_rules_router_id_enabled_priority_idx" ON "model_router_rules"("router_id", "enabled", "priority");
+CREATE UNIQUE INDEX "model_router_rules_router_id_title_key" ON "model_router_rules"("router_id", "title");
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -413,22 +413,28 @@ model model_routers {
 }
 
 model model_router_rules {
-  id             Int           @id @default(autoincrement())
-  router_id      Int
-  enabled        Boolean       @default(true)
-  priority       Int
-  type           String        @default("calculated")
-  title          String
-  description    String?
-  property       String?
-  comparator     String?
-  value          String?
-  route_provider String
-  route_model    String
-  created_by     Int?
-  createdAt      DateTime      @default(now())
-  lastUpdatedAt  DateTime      @default(now())
-  router         model_routers @relation(fields: [router_id], references: [id], onDelete: Cascade)
+  id               Int           @id @default(autoincrement())
+  router_id        Int
+  enabled          Boolean       @default(true)
+  priority         Int
+  type             String        @default("calculated")
+  title            String
+  description      String?
+  // For `calculated` rules: the boolean operator joining `conditions` — "AND"
+  // (all must match) or "OR" (any must match). Null for `llm` rules.
+  condition_logic  String?
+  // For `calculated` rules: JSON-stringified array of condition objects, each
+  // shaped as { property: string, comparator: string, value: string } where
+  // `property` ∈ VALID_PROPERTIES and `comparator` ∈ VALID_COMPARATORS (see
+  // server/models/modelRouterRule.js). `value` is always stored as a string;
+  // numeric comparators parse it at evaluation time. Null for `llm` rules.
+  conditions       String?
+  route_provider   String
+  route_model      String
+  created_by       Int?
+  createdAt        DateTime      @default(now())
+  lastUpdatedAt    DateTime      @default(now())
+  router           model_routers @relation(fields: [router_id], references: [id], onDelete: Cascade)
 
   @@unique([router_id, title])
   @@index([router_id])

--- a/server/utils/router/deterministic.js
+++ b/server/utils/router/deterministic.js
@@ -105,8 +105,20 @@ function matchesRegex(input, value) {
 
 function evaluateNumericCondition(contextValue, comparator, value) {
   const numContext = Number(contextValue);
+  if (isNaN(numContext)) return false;
+
+  // `between` takes a "min,max" pair, not a single number — parse it before
+  // the scalar-numeric coercion below so `Number("9,17") → NaN` doesn't
+  // short-circuit the whole evaluation.
+  if (comparator === "between") {
+    const parts = String(value).split(",").map(Number);
+    if (parts.length !== 2 || parts.some(isNaN)) return false;
+    const [min, max] = parts;
+    return numContext >= min && numContext <= max;
+  }
+
   const numValue = Number(value);
-  if (isNaN(numContext) || isNaN(numValue)) return false;
+  if (isNaN(numValue)) return false;
 
   switch (comparator) {
     case "gt":
@@ -121,11 +133,6 @@ function evaluateNumericCondition(contextValue, comparator, value) {
       return numContext === numValue;
     case "neq":
       return numContext !== numValue;
-    case "between": {
-      const parts = String(value).split(",").map(Number);
-      if (parts.length !== 2 || parts.some(isNaN)) return false;
-      return numContext >= parts[0] && numContext <= parts[1];
-    }
     default:
       return false;
   }

--- a/server/utils/router/deterministic.js
+++ b/server/utils/router/deterministic.js
@@ -49,6 +49,10 @@ function getContextValue(property, context) {
   }
 }
 
+// Cap the input scanned by regex to mitigate catastrophic backtracking on
+// pathological patterns + huge prompts. 10k chars is plenty for routing.
+const REGEX_INPUT_CAP = 10_000;
+
 function evaluateStringCondition(contextValue, comparator, value) {
   switch (comparator) {
     case "contains":
@@ -59,12 +63,36 @@ function evaluateStringCondition(contextValue, comparator, value) {
         .some((keyword) =>
           String(contextValue).toLowerCase().includes(keyword)
         );
+    case "matches":
+      return matchesRegex(String(contextValue), String(value));
     case "eq":
       return String(contextValue).toLowerCase() === String(value).toLowerCase();
     case "neq":
       return String(contextValue).toLowerCase() !== String(value).toLowerCase();
     default:
       return false;
+  }
+}
+
+/**
+ * Test `input` against a user-provided regex. Accepts either a bare pattern
+ * ("foo.*bar", defaults to case-insensitive) or `/pattern/flags` syntax.
+ * Invalid patterns and runtime errors return false rather than throwing so a
+ * broken rule never crashes routing.
+ */
+function matchesRegex(input, value) {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  const delimited = trimmed.match(/^\/(.+)\/([gimsuy]*)$/);
+  const pattern = delimited ? delimited[1] : trimmed;
+  const flags = delimited ? delimited[2] || "i" : "i";
+
+  try {
+    const regex = new RegExp(pattern, flags);
+    return regex.test(input.slice(0, REGEX_INPUT_CAP));
+  } catch {
+    return false;
   }
 }
 

--- a/server/utils/router/deterministic.js
+++ b/server/utils/router/deterministic.js
@@ -1,21 +1,28 @@
 /**
- * Evaluate a single calculated rule against the given context.
- * @param {Object} rule - A model_router_rules record
+ * Evaluate a calculated rule against the given context. A rule holds one or
+ * more conditions joined by `condition_logic` ("AND" or "OR"). An empty
+ * conditions list never matches.
+ * @param {Object} rule - A hydrated model_router_rules record (conditions parsed)
  * @param {Object} context - { prompt, conversationHistory, conversationTokenCount }
  * @returns {boolean}
  */
 function evaluateRule(rule, context) {
   if (rule.type !== "calculated") return false;
-  if (!rule.property || !rule.comparator || rule.value == null) return false;
-  return evaluateCondition(rule.property, rule.comparator, rule.value, context);
+  const { conditions, condition_logic: logic } = rule;
+  if (!Array.isArray(conditions) || conditions.length === 0) return false;
+
+  const method = logic === "OR" ? "some" : "every";
+  return conditions[method]((c) =>
+    evaluateCondition(c.property, c.comparator, c.value, context)
+  );
 }
 
 /**
  * Evaluate a single condition against the context.
- * @param {string} property - "promptContent" | "conversationTokenCount" | "conversationMessageCount" | "currentHour"
- * @param {string} comparator - "contains" | "gt" | "gte" | "lt" | "lte" | "eq" | "neq"
+ * @param {string} property - "promptContent" | "conversationTokenCount" | "conversationMessageCount" | "currentHour" | "hasImageAttachment"
+ * @param {string} comparator - "contains" | "matches" | "gt" | "gte" | "lt" | "lte" | "eq" | "neq" | "between"
  * @param {string} value - The comparison value (stored as string in DB)
- * @param {Object} context - { prompt, conversationHistory, conversationTokenCount, conversationMessageCount }
+ * @param {Object} context - { prompt, conversationHistory, conversationTokenCount, conversationMessageCount, attachments }
  * @returns {boolean}
  */
 function evaluateCondition(property, comparator, value, context) {


### PR DESCRIPTION
To be merged into #5324 

## Summary
- **Multi-condition calculated rules** — Rules now support multiple conditions joined by AND/OR logic, replacing the single property/comparator/value model. Includes a DB migration that converts existing single-condition rules into the new JSON array format.
- **`matches` (regex) comparator** — New string comparator for prompt content with `/pattern/flags` syntax support and input cap to guard against catastrophic backtracking.
- **`between` comparator fix** — Moved `between` handling before scalar `Number()` coercion so `"9,17"` no longer parses as `NaN`.
- **UI redesign** — Router list page swapped from `<table>` to a grid layout with proper empty states, clickable rows, and inline edit/delete. Rule builder now uses modals (via `ModalWrapper`) for both create and edit instead of inline forms. Rule rows show multi-condition summaries with AND/ANY quantifiers.
- **Router edit via modal** — `NewRouterModal` now doubles as an edit modal (accepts optional `router` prop), removing the duplicated form from `RouterForm`. The detail page now only renders the `RuleBuilder`.
- **Condition UI** — `CalculatedFields` rewritten as a dynamic condition list with add/remove rows, an AND/OR logic toggle, comparator-aware value placeholders, and contextual help text.
- **Server hydration layer** — `_hydrate()` on `ModelRouterRule` parses the stored JSON `conditions` string everywhere rules are returned (create, update, get, list), so the API always returns parsed arrays.