### PR TITLE
fix: gate generic OpenAI tool stream usage reporting

### DIFF
--- a/server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js
@@ -1,0 +1,55 @@
+jest.mock("uuid", () => ({ v4: jest.fn(() => "test-uuid") }), { virtual: true });
+jest.mock("../../../../../../utils/http", () => ({
+  safeJsonParse: (value, fallback) => {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  },
+}));
+
+const { tooledStream } = require("../../../../../../utils/agents/aibitat/providers/helpers/tooled");
+
+function makeClient(calls) {
+  return {
+    chat: {
+      completions: {
+        create: jest.fn(async (payload) => {
+          calls.push(payload);
+          return (async function* stream() {
+            yield {
+              choices: [
+                {
+                  delta: { content: "ok" },
+                },
+              ],
+            };
+          })();
+        }),
+      },
+    },
+  };
+}
+
+describe("tooledStream stream_options", () => {
+  it("includes usage reporting by default", async () => {
+    const calls = [];
+    const client = makeClient(calls);
+
+    await tooledStream(client, "test-model", [{ role: "user", content: "hi" }]);
+
+    expect(calls[0].stream_options).toEqual({ include_usage: true });
+  });
+
+  it("omits stream_options when a provider disables them", async () => {
+    const calls = [];
+    const client = makeClient(calls);
+
+    await tooledStream(client, "test-model", [{ role: "user", content: "hi" }], [], null, {
+      streamOptions: false,
+    });
+
+    expect(calls[0]).not.toHaveProperty("stream_options");
+  });
+});

--- a/server/utils/agents/aibitat/providers/genericOpenAi.js
+++ b/server/utils/agents/aibitat/providers/genericOpenAi.js
@@ -102,6 +102,12 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
     });
   }
 
+  #includeStreamOptionsUsage() {
+    if (!("GENERIC_OPEN_AI_REPORT_USAGE" in process.env)) return false;
+    if (process.env.GENERIC_OPEN_AI_REPORT_USAGE !== "true") return false;
+    return { include_usage: true };
+  }
+
   /**
    * Stream a chat completion with tool calling support.
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
@@ -131,7 +137,10 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
         messages,
         functions,
         eventHandler,
-        { provider: this }
+        {
+          provider: this,
+          streamOptions: this.#includeStreamOptionsUsage(),
+        }
       );
     } catch (error) {
       console.error(error.message, error);

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -164,8 +164,9 @@ function formatMessagesForTools(messages, options = {}) {
  * @param {Array} messages - Raw aibitat message history
  * @param {Array} functions - Aibitat function definitions
  * @param {function|null} eventHandler - Stream event handler
- * @param {{injectReasoningContent?: boolean, provider?: object}} options - Provider-specific options
+ * @param {{injectReasoningContent?: boolean, provider?: object, streamOptions?: object|false}} options - Provider-specific options
  *   - provider: If passed, automatically handles usage tracking via provider.resetUsage()/recordUsage()
+ *   - streamOptions: OpenAI stream_options to send. Set false to omit for providers that reject it.
  * @returns {Promise<{textResponse: string, functionCall: object|null, uuid: string, usage: object|null}>}
  */
 async function tooledStream(
@@ -176,7 +177,11 @@ async function tooledStream(
   eventHandler = null,
   options = {}
 ) {
-  const { provider, ...formatOptions } = options;
+  const {
+    provider,
+    streamOptions = { include_usage: true },
+    ...formatOptions
+  } = options;
 
   // Auto-reset usage if provider is passed
   if (provider?.resetUsage) {
@@ -192,7 +197,7 @@ async function tooledStream(
   const stream = await client.chat.completions.create({
     model,
     stream: true,
-    stream_options: { include_usage: true },
+    ...(streamOptions ? { stream_options: streamOptions } : {}),
     messages: formattedMessages,
     ...(tools.length > 0 ? { tools } : {}),
   });


### PR DESCRIPTION
## Summary
- let `tooledStream` omit `stream_options` when a provider explicitly disables them
- make the Generic OpenAI native tool-calling stream path honor `GENERIC_OPEN_AI_REPORT_USAGE` before sending `include_usage`
- add a focused regression test for default usage reporting and provider-disabled stream options

## Tests
- `node -c server/utils/agents/aibitat/providers/helpers/tooled.js`
- `node -c server/utils/agents/aibitat/providers/genericOpenAi.js`
- `npx jest server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js --runInBand`
- `git diff --check`

Note: targeted `npx eslint ...` could not run in this checkout because the local install is missing ESLint config dependencies (`@eslint/js`).
