### PR TITLE
fix: keep chat lookups scoped for null users

### DIFF
--- a/server/__tests__/utils/helpers/chat/userScopedChatClause.test.js
+++ b/server/__tests__/utils/helpers/chat/userScopedChatClause.test.js
@@ -1,0 +1,50 @@
+const {
+  userScopedChatClause,
+} = require("../../../../utils/helpers/chat/userScopedChatClause");
+
+describe("userScopedChatClause", () => {
+  it("uses the signed-in user id when present", () => {
+    expect(userScopedChatClause({ workspaceId: 1 }, { id: 7 })).toEqual({
+      workspaceId: 1,
+      user_id: 7,
+    });
+  });
+
+  it("keeps chat lookups scoped to null-user chats when the session has no user", () => {
+    expect(userScopedChatClause({ workspaceId: 1 }, null)).toEqual({
+      workspaceId: 1,
+      user_id: null,
+    });
+  });
+
+  it("does not allow undefined to override the chat ownership filter", () => {
+    expect(userScopedChatClause({ workspaceId: 1 }, {})).toEqual({
+      workspaceId: 1,
+      user_id: null,
+    });
+  });
+
+  it("preserves thread filters while normalizing missing users to null", () => {
+    expect(
+      userScopedChatClause({ workspaceId: 1, thread_id: 3 }, undefined)
+    ).toEqual({
+      workspaceId: 1,
+      thread_id: 3,
+      user_id: null,
+    });
+  });
+
+  it("preserves fork filters while normalizing missing users to null", () => {
+    expect(
+      userScopedChatClause(
+        { workspaceId: 1, include: true, api_session_id: null },
+        null
+      )
+    ).toEqual({
+      workspaceId: 1,
+      include: true,
+      api_session_id: null,
+      user_id: null,
+    });
+  });
+});

--- a/server/endpoints/workspaceThreads.js
+++ b/server/endpoints/workspaceThreads.js
@@ -17,6 +17,9 @@ const {
   validWorkspaceAndThreadSlug,
 } = require("../utils/middleware/validWorkspace");
 const { WorkspaceChats } = require("../models/workspaceChats");
+const {
+  userScopedChatClause,
+} = require("../utils/helpers/chat/userScopedChatClause");
 const { convertToChatHistory } = require("../utils/helpers/chat/responses");
 const { getModelTag } = require("./utils");
 
@@ -192,12 +195,16 @@ function workspaceThreadEndpoints(app) {
         const workspace = response.locals.workspace;
         const thread = response.locals.thread;
 
-        await WorkspaceChats.delete({
-          workspaceId: Number(workspace.id),
-          thread_id: Number(thread.id),
-          user_id: user?.id,
-          id: { gte: Number(startingId) },
-        });
+        await WorkspaceChats.delete(
+          userScopedChatClause(
+            {
+              workspaceId: Number(workspace.id),
+              thread_id: Number(thread.id),
+              id: { gte: Number(startingId) },
+            },
+            user
+          )
+        );
 
         response.sendStatus(200).end();
       } catch (e) {
@@ -223,12 +230,16 @@ function workspaceThreadEndpoints(app) {
         const user = await userFromSession(request, response);
         const workspace = response.locals.workspace;
         const thread = response.locals.thread;
-        const existingChat = await WorkspaceChats.get({
-          workspaceId: workspace.id,
-          thread_id: thread.id,
-          user_id: user?.id,
-          id: Number(chatId),
-        });
+        const existingChat = await WorkspaceChats.get(
+          userScopedChatClause(
+            {
+              workspaceId: workspace.id,
+              thread_id: thread.id,
+              id: Number(chatId),
+            },
+            user
+          )
+        );
         if (!existingChat) throw new Error("Invalid chat.");
 
         if (role === "user") {

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -32,6 +32,9 @@ const {
 } = require("../utils/files/pfp");
 const { getTTSProvider } = require("../utils/TextToSpeech");
 const { WorkspaceThread } = require("../models/workspaceThread");
+const {
+  userScopedChatClause,
+} = require("../utils/helpers/chat/userScopedChatClause");
 
 const truncate = require("truncate");
 const { purgeDocument } = require("../utils/files/purgeDocument");
@@ -456,12 +459,16 @@ function workspaceEndpoints(app) {
         const user = await userFromSession(request, response);
         const workspace = response.locals.workspace;
 
-        await WorkspaceChats.delete({
-          workspaceId: workspace.id,
-          thread_id: null,
-          user_id: user?.id,
-          id: { gte: Number(startingId) },
-        });
+        await WorkspaceChats.delete(
+          userScopedChatClause(
+            {
+              workspaceId: workspace.id,
+              thread_id: null,
+              id: { gte: Number(startingId) },
+            },
+            user
+          )
+        );
 
         response.sendStatus(200).end();
       } catch (e) {
@@ -482,12 +489,16 @@ function workspaceEndpoints(app) {
 
         const user = await userFromSession(request, response);
         const workspace = response.locals.workspace;
-        const existingChat = await WorkspaceChats.get({
-          workspaceId: workspace.id,
-          thread_id: null,
-          user_id: user?.id,
-          id: Number(chatId),
-        });
+        const existingChat = await WorkspaceChats.get(
+          userScopedChatClause(
+            {
+              workspaceId: workspace.id,
+              thread_id: null,
+              id: Number(chatId),
+            },
+            user
+          )
+        );
         if (!existingChat) throw new Error("Invalid chat.");
 
         if (role === "user") {
@@ -521,11 +532,15 @@ function workspaceEndpoints(app) {
         const { chatId } = request.params;
         const { feedback = null } = reqBody(request);
         const user = await userFromSession(request, response);
-        const existingChat = await WorkspaceChats.get({
-          id: Number(chatId),
-          workspaceId: response.locals.workspace.id,
-          user_id: user?.id,
-        });
+        const existingChat = await WorkspaceChats.get(
+          userScopedChatClause(
+            {
+              id: Number(chatId),
+              workspaceId: response.locals.workspace.id,
+            },
+            user
+          )
+        );
 
         if (!existingChat) return response.status(404).json({ success: false });
         await WorkspaceChats.updateFeedbackScore(chatId, feedback);
@@ -620,11 +635,15 @@ function workspaceEndpoints(app) {
         const workspace = response.locals.workspace;
         const user = await userFromSession(request, response);
         const cacheKey = `${workspace.slug}:${chatId}`;
-        const wsChat = await WorkspaceChats.get({
-          id: Number(chatId),
-          workspaceId: workspace.id,
-          user_id: user?.id,
-        });
+        const wsChat = await WorkspaceChats.get(
+          userScopedChatClause(
+            {
+              id: Number(chatId),
+              workspaceId: workspace.id,
+            },
+            user
+          )
+        );
 
         if (!wsChat) return response.sendStatus(404);
         const cachedResponse = responseCache.get(cacheKey);
@@ -815,14 +834,16 @@ function workspaceEndpoints(app) {
             )?.id ?? null
           : null;
         const chatsToFork = await WorkspaceChats.where(
-          {
-            workspaceId: workspace.id,
-            user_id: user?.id,
-            include: true, // only duplicate visible chats
-            thread_id: threadId,
-            api_session_id: null, // Do not include API session chats.
-            id: { lte: Number(chatId) },
-          },
+          userScopedChatClause(
+            {
+              workspaceId: workspace.id,
+              include: true, // only duplicate visible chats
+              thread_id: threadId,
+              api_session_id: null, // Do not include API session chats.
+              id: { lte: Number(chatId) },
+            },
+            user
+          ),
           null,
           { id: "asc" }
         );
@@ -841,7 +862,7 @@ function workspaceEndpoints(app) {
             workspaceId: workspace.id,
             prompt: chat.prompt,
             response: JSON.stringify(chatResponse),
-            user_id: user?.id,
+            user_id: user?.id ?? null,
             thread_id: newThread.id,
           };
         });

--- a/server/utils/helpers/chat/userScopedChatClause.js
+++ b/server/utils/helpers/chat/userScopedChatClause.js
@@ -1,0 +1,8 @@
+function userScopedChatClause(clause = {}, user = null) {
+  return {
+    ...clause,
+    user_id: user?.id ?? null,
+  };
+}
+
+module.exports = { userScopedChatClause };


### PR DESCRIPTION
## Summary
- add a shared helper for workspace chat ownership filters so null-user sessions are scoped as `user_id: null`
- use that helper for workspace and thread chat delete/edit/fork/feedback/TTS lookup paths
- add focused Jest coverage to prevent `undefined` from dropping the user ownership filter, including thread and fork filters

## Why
Some workspace chat routes built Prisma `where` clauses with `user_id: user?.id`. When `user` is missing, that value becomes `undefined`, which can be omitted from the query filter instead of matching only null-user chats. This keeps those routes scoped to the intended null-user chat records.

## Tests
- `yarn test server/__tests__/utils/helpers/chat/userScopedChatClause.test.js --runInBand`
- `node -c server/endpoints/workspaces.js && node -c server/endpoints/workspaceThreads.js && node -c server/utils/helpers/chat/userScopedChatClause.js && node -c server/__tests__/utils/helpers/chat/userScopedChatClause.test.js`
- `git diff --check origin/master...HEAD`

## Local notes
- `yarn --cwd server lint:check --quiet` could not run in this checkout because `server/node_modules` is absent and `eslint` is not installed locally.
