### PR TITLE
Auto-rename thread in agent mode

### DIFF
--- a/frontend/src/utils/chat/agent.js
+++ b/frontend/src/utils/chat/agent.js
@@ -2,6 +2,7 @@ import { v4 } from "uuid";
 import { safeJsonParse } from "../request";
 import { API_BASE } from "../constants";
 import { useEffect, useState } from "react";
+import { THREAD_RENAME_EVENT } from "@/components/Sidebar/ActiveWorkspaces/ThreadContainer";
 
 export const AGENT_SESSION_START = "agentSessionStart";
 export const AGENT_SESSION_END = "agentSessionEnd";
@@ -25,6 +26,19 @@ export function websocketURI() {
 export default function handleSocketResponse(socket, event, setChatHistory) {
   const data = safeJsonParse(event.data, null);
   if (data === null) return;
+
+  // Handle thread rename
+  if (data.type === "rename_thread") {
+    const { slug, name } = data.content || {};
+    if (slug && name) {
+      window.dispatchEvent(
+        new CustomEvent(THREAD_RENAME_EVENT, {
+          detail: { threadSlug: slug, newName: name },
+        })
+      );
+    }
+    return;
+  }
 
   // No message type is defined then this is a generic message
   // that we need to print to the user as a system response

--- a/server/endpoints/chat.js
+++ b/server/endpoints/chat.js
@@ -15,7 +15,6 @@ const {
 const { writeResponseChunk } = require("../utils/helpers/chat/responses");
 const { WorkspaceThread } = require("../models/workspaceThread");
 const { User } = require("../models/user");
-const truncate = require("truncate");
 const { getModelTag } = require("./utils");
 
 function chatEndpoints(app) {
@@ -162,7 +161,7 @@ function chatEndpoints(app) {
           thread,
           workspace,
           user,
-          newName: truncate(message, 22),
+          prompt: message,
           onRename: (thread) => {
             writeResponseChunk(response, {
               action: "rename_thread",

--- a/server/models/workspaceThread.js
+++ b/server/models/workspaceThread.js
@@ -1,6 +1,7 @@
 const prisma = require("../utils/prisma");
 const slugifyModule = require("slugify");
 const { v4: uuidv4 } = require("uuid");
+const truncate = require("truncate");
 
 const WorkspaceThread = {
   defaultName: "Thread",
@@ -120,15 +121,15 @@ const WorkspaceThread = {
     }
   },
 
-  // Will fire on first message (included or not) for a thread and rename the thread with the newName prop.
+  // Will fire on first message (included or not) for a thread and rename the thread based on the prompt.
   autoRenameThread: async function ({
     workspace = null,
     thread = null,
     user = null,
-    newName = null,
+    prompt = null,
     onRename = null,
   }) {
-    if (!workspace || !thread || !newName) return false;
+    if (!workspace || !thread || !prompt) return false;
     if (thread.name !== this.defaultName) return false; // don't rename if already named.
 
     const { WorkspaceChats } = require("./workspaceChats");
@@ -139,7 +140,7 @@ const WorkspaceThread = {
     });
     if (chatCount !== 1) return { renamed: false, thread };
     const { thread: updatedThread } = await this.update(thread, {
-      name: newName,
+      name: truncate(prompt, 22),
     });
 
     onRename?.(updatedThread);

--- a/server/utils/agents/aibitat/plugins/chat-history.js
+++ b/server/utils/agents/aibitat/plugins/chat-history.js
@@ -1,4 +1,5 @@
 const { WorkspaceChats } = require("../../../../models/workspaceChats");
+const { WorkspaceThread } = require("../../../../models/workspaceThread");
 
 /**
  * Plugin to save chat history to AnythingLLM DB.
@@ -116,6 +117,13 @@ const chatHistory = {
           threadId: invocation?.thread_id || null,
           include: true,
         });
+
+        if (!aibitat._threadRenamed) {
+          aibitat._threadRenamed = await this._autoRenameThread(
+            aibitat,
+            prompt
+          );
+        }
         this._cleanup(aibitat);
       },
       _storeSpecial: async function (
@@ -146,8 +154,41 @@ const chatHistory = {
           threadId: invocation?.thread_id || null,
           include: true,
         });
+
+        if (!aibitat._threadRenamed) {
+          aibitat._threadRenamed = await this._autoRenameThread(
+            aibitat,
+            prompt
+          );
+        }
         options?.postSave();
         this._cleanup(aibitat);
+      },
+
+      _autoRenameThread: async function (aibitat, prompt) {
+        const invocation = aibitat.handlerProps.invocation;
+        if (!invocation?.thread_id) return true;
+
+        const thread = await WorkspaceThread.get({ id: invocation.thread_id });
+        if (!thread) return true;
+
+        const { Workspace } = require("../../../../models/workspace");
+        const workspace = await Workspace.get({ id: invocation.workspace_id });
+        if (!workspace) return true;
+
+        await WorkspaceThread.autoRenameThread({
+          thread,
+          workspace,
+          user: invocation.user_id ? { id: invocation.user_id } : null,
+          prompt,
+          onRename: (updatedThread) => {
+            aibitat.socket?.send("rename_thread", {
+              slug: updatedThread.slug,
+              name: updatedThread.name,
+            });
+          },
+        });
+        return true;
       },
 
       _cleanup: function (aibitat) {


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5546

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- Fixes bug where auto-thread renaming was not working in agent/auto modes
- Refactored truncation logic to be put directly in the thread model for logic reuse
- Reuses `rename_thread` event to rename the thread in the frontend

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
