### PR TITLE
fix(agent): keep streamed tool call real ids

### DIFF
--- a/server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js
@@ -1,0 +1,70 @@
+jest.mock("uuid", () => ({ v4: () => "fallback_uuid" }), { virtual: true });
+jest.mock("../../../../../../utils/http", () => ({
+  safeJsonParse: (jsonString, fallback = null) => {
+    try {
+      return JSON.parse(jsonString);
+    } catch {
+      return fallback;
+    }
+  },
+}));
+
+const { tooledStream } = require("../../../../../../utils/agents/aibitat/providers/helpers/tooled");
+
+describe("tooledStream", () => {
+  it("replaces a generated fallback tool call id when the stream later provides the real id", async () => {
+    async function* streamChunks() {
+      yield {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: null,
+                  function: { name: "lookup", arguments: "{\"query\"" },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      yield {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_real_123",
+                  function: { arguments: ":\"weather\"}" },
+                },
+              ],
+            },
+          },
+        ],
+      };
+    }
+
+    const client = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue(streamChunks()),
+        },
+      },
+    };
+
+    const result = await tooledStream(
+      client,
+      "test-model",
+      [{ role: "user", content: "Use the lookup tool" }],
+      [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }]
+    );
+
+    expect(result.functionCall).toEqual({
+      id: "call_real_123",
+      name: "lookup",
+      arguments: { query: "weather" },
+    });
+  });
+});

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -237,7 +237,7 @@ async function tooledStream(
           };
         } else {
           // Update existing entry with streamed data
-          if (toolCall.id && !toolCallsByIndex[idx].id.startsWith("call_")) {
+          if (toolCall.id && toolCallsByIndex[idx].id.startsWith("call_")) {
             toolCallsByIndex[idx].id = toolCall.id;
           }
           if (toolCall.function?.name) {


### PR DESCRIPTION
## Summary
- let native streaming tool-call assembly replace a generated fallback `call_*` id when a later chunk provides the real provider id
- add a focused regression test for streams that start with `id: null` and later emit the real tool-call id

## Why
This is part of the native OpenAI-compatible tool/function calling work tracked in #4181. In streaming mode, some OpenAI-compatible providers can start a tool call with a null id and send the real id in a later chunk. The current condition only overwrites ids that are **not** generated fallbacks, so the final `functionCall.id` can remain the synthetic fallback instead of the provider's real id.

Keeping the real id matters for the following assistant-tool result pairing (`tool_call_id`) as this native tool-calling path continues moving toward OpenAI spec tool calling + streaming.

## Linked issue
- Supports #4181

## Tests
- `npx jest server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js --runInBand`
