### PR TITLE
fix(tts): strip Markdown syntax before sending text to TTS engines

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/native.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/native.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { SpeakerHigh, PauseCircle } from "@phosphor-icons/react";
+import messageToSpeech from "@/utils/chat/messageToSpeech";
 
 export default function NativeTTSMessage({ chatId, message }) {
   const [speaking, setSpeaking] = useState(false);
@@ -25,7 +26,7 @@ export default function NativeTTSMessage({ chatId, message }) {
     }
 
     if (window.speechSynthesis.speaking && !speaking) return;
-    const utterance = new SpeechSynthesisUtterance(message);
+    const utterance = new SpeechSynthesisUtterance(messageToSpeech(message));
     utterance.addEventListener("end", endSpeechUtterance);
     window.speechSynthesis.speak(utterance);
     setSpeaking(true);

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/piperTTS.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/piperTTS.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import { SpeakerHigh, PauseCircle, CircleNotch } from "@phosphor-icons/react";
 import PiperTTSClient from "@/utils/piperTTS";
+import messageToSpeech from "@/utils/chat/messageToSpeech";
 
 export default function PiperTTS({ chatId, voiceId = null, message }) {
   const playerRef = useRef(null);
@@ -19,7 +20,7 @@ export default function PiperTTS({ chatId, voiceId = null, message }) {
       if (!audioSrc) {
         setLoading(true);
         const client = new PiperTTSClient({ voiceId });
-        const blobUrl = await client.getAudioBlobForText(message);
+        const blobUrl = await client.getAudioBlobForText(messageToSpeech(message));
         setAudioSrc(blobUrl);
         setLoading(false);
       } else {

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/piperTTS.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/TTSButton/piperTTS.jsx
@@ -20,7 +20,9 @@ export default function PiperTTS({ chatId, voiceId = null, message }) {
       if (!audioSrc) {
         setLoading(true);
         const client = new PiperTTSClient({ voiceId });
-        const blobUrl = await client.getAudioBlobForText(messageToSpeech(message));
+        const blobUrl = await client.getAudioBlobForText(
+          messageToSpeech(message)
+        );
         setAudioSrc(blobUrl);
         setLoading(false);
       } else {

--- a/frontend/src/utils/chat/messageToSpeech.js
+++ b/frontend/src/utils/chat/messageToSpeech.js
@@ -1,0 +1,81 @@
+/**
+ * Convert a chat message string to plain text suitable for text-to-speech.
+ *
+ * The chat history we render is Markdown — when we hand that text directly to
+ * a TTS engine (Piper, ElevenLabs, OpenAI, the browser's `SpeechSynthesis`,
+ * etc.) the engine reads every special character literally:
+ *   - `**bold**` becomes "asterisk asterisk bold asterisk asterisk"
+ *   - `_italic_` becomes "underscore italic underscore"
+ *   - inline code/code fences are read verbatim with backticks
+ *   - bullet lists become "hyphen item" / "asterisk item"
+ *   - links become "open bracket label close bracket open paren url close paren"
+ *
+ * This helper strips the most common Markdown syntax while preserving the
+ * underlying spoken content. It is intentionally regex-based (no extra
+ * dependency) so it can be safely used both on the client and inside the
+ * native browser TTS path which has no access to the server's markdown-it
+ * tokenizer.
+ *
+ * Tracking issue: https://github.com/Mintplex-Labs/anything-llm/issues/5557
+ *
+ * @param {string} message - The raw markdown message body.
+ * @returns {string} A plain-text string suitable for TTS.
+ */
+export default function messageToSpeech(message = "") {
+  if (typeof message !== "string" || message.length === 0) return "";
+
+  let text = message;
+
+  // 1. Remove fenced code blocks entirely — reading code aloud is rarely
+  //    useful and produces a long stream of unintelligible characters.
+  text = text.replace(/```[\s\S]*?```/g, " ");
+  text = text.replace(/~~~[\s\S]*?~~~/g, " ");
+
+  // 2. Strip inline code wrappers but keep the text inside.
+  text = text.replace(/`([^`]*)`/g, "$1");
+
+  // 3. Images: drop entirely — there's nothing useful to speak.
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
+
+  // 4. Links: keep the visible label, drop the URL.
+  //    `[label](url)` -> `label`
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // 5. Reference-style link definitions: drop the URL line entirely.
+  text = text.replace(/^\s*\[[^\]]+\]:\s*\S+.*$/gm, "");
+
+  // 6. Heading markers (`#`, `##`, ...): keep the heading text only.
+  text = text.replace(/^\s{0,3}#{1,6}\s+/gm, "");
+
+  // 7. Blockquote markers (`>`): drop the leading marker.
+  text = text.replace(/^\s{0,3}>\s?/gm, "");
+
+  // 8. Unordered list markers (`-`, `*`, `+`) and ordered list markers
+  //    (`1.`, `12)`): drop the marker, keep the item text.
+  text = text.replace(/^\s*[-*+]\s+/gm, "");
+  text = text.replace(/^\s*\d+[.)]\s+/gm, "");
+
+  // 9. Horizontal rules: drop entirely.
+  text = text.replace(/^\s{0,3}(?:[-*_]\s*){3,}\s*$/gm, " ");
+
+  // 10. Bold / italic / strikethrough emphasis. Order matters — handle the
+  //     longer markers (`***`, `___`, `**`, `__`, `~~`) before the singletons
+  //     so "asterisk" is never read aloud.
+  text = text.replace(/(\*\*\*|___)([^*_]+)\1/g, "$2");
+  text = text.replace(/(\*\*|__)([^*_]+)\1/g, "$2");
+  text = text.replace(/(\*|_)([^*_\n]+)\1/g, "$2");
+  text = text.replace(/~~([^~]+)~~/g, "$1");
+
+  // 11. Tables: convert pipe separators to commas so rows read naturally,
+  //     and drop the alignment row (`---|---|---`).
+  text = text.replace(/^\s*\|?\s*[:\-\s|]+\|[:\-\s|]+\s*$/gm, "");
+  text = text.replace(/\|/g, ", ");
+
+  // 12. HTML tags: strip but keep their text content.
+  text = text.replace(/<\/?[^>]+>/g, " ");
+
+  // 13. Collapse repeated whitespace (newlines and spaces) to single spaces.
+  text = text.replace(/\s+/g, " ").trim();
+
+  return text;
+}

--- a/frontend/src/utils/chat/messageToSpeech.js
+++ b/frontend/src/utils/chat/messageToSpeech.js
@@ -2,7 +2,7 @@
  * Convert a chat message string to plain text suitable for text-to-speech.
  *
  * The chat history we render is Markdown — when we hand that text directly to
- * a TTS engine (Piper, ElevenLabs, OpenAI, the browser's `SpeechSynthesis`,
+ * a TTS engine (Piper, the browser's `SpeechSynthesis`,
  * etc.) the engine reads every special character literally:
  *   - `**bold**` becomes "asterisk asterisk bold asterisk asterisk"
  *   - `_italic_` becomes "underscore italic underscore"
@@ -14,9 +14,8 @@
  * underlying spoken content. It is intentionally regex-based (no extra
  * dependency) so it can be safely used both on the client and inside the
  * native browser TTS path which has no access to the server's markdown-it
- * tokenizer.
- *
- * Tracking issue: https://github.com/Mintplex-Labs/anything-llm/issues/5557
+ * tokenizer. AsyncTTS does not use this helper as the cloud based TTS engines
+ * do not need this cleanup and seem to handle the Markdown syntax just fine.
  *
  * @param {string} message - The raw markdown message body.
  * @returns {string} A plain-text string suitable for TTS.

--- a/frontend/src/utils/chat/messageToSpeech.js
+++ b/frontend/src/utils/chat/messageToSpeech.js
@@ -25,55 +25,65 @@ export default function messageToSpeech(message = "") {
 
   let text = message;
 
-  // 1. Remove fenced code blocks entirely — reading code aloud is rarely
-  //    useful and produces a long stream of unintelligible characters.
+  /*
+   * Remove fenced code blocks entirely — reading code aloud is rarely
+   * useful and produces a long stream of unintelligible characters.
+   */
   text = text.replace(/```[\s\S]*?```/g, " ");
   text = text.replace(/~~~[\s\S]*?~~~/g, " ");
 
-  // 2. Strip inline code wrappers but keep the text inside.
+  // Strip inline code wrappers but keep the text inside.
   text = text.replace(/`([^`]*)`/g, "$1");
 
-  // 3. Images: drop entirely — there's nothing useful to speak.
+  // Images: drop entirely — there's nothing useful to speak.
   text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
 
-  // 4. Links: keep the visible label, drop the URL.
-  //    `[label](url)` -> `label`
+  /*
+   * Links: keep the visible label, drop the URL.
+   * `[label](url)` -> `label`
+   */
   text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
 
-  // 5. Reference-style link definitions: drop the URL line entirely.
+  // Reference-style link definitions: drop the URL line entirely.
   text = text.replace(/^\s*\[[^\]]+\]:\s*\S+.*$/gm, "");
 
-  // 6. Heading markers (`#`, `##`, ...): keep the heading text only.
+  // Heading markers (`#`, `##`, ...): keep the heading text only.
   text = text.replace(/^\s{0,3}#{1,6}\s+/gm, "");
 
-  // 7. Blockquote markers (`>`): drop the leading marker.
+  // Blockquote markers (`>`): drop the leading marker.
   text = text.replace(/^\s{0,3}>\s?/gm, "");
 
-  // 8. Unordered list markers (`-`, `*`, `+`) and ordered list markers
-  //    (`1.`, `12)`): drop the marker, keep the item text.
+  /*
+   * Unordered list markers (`-`, `*`, `+`) and ordered list markers
+   * (`1.`, `12)`): drop the marker, keep the item text.
+   */
   text = text.replace(/^\s*[-*+]\s+/gm, "");
   text = text.replace(/^\s*\d+[.)]\s+/gm, "");
 
-  // 9. Horizontal rules: drop entirely.
+  // Horizontal rules: drop entirely.
   text = text.replace(/^\s{0,3}(?:[-*_]\s*){3,}\s*$/gm, " ");
 
-  // 10. Bold / italic / strikethrough emphasis. Order matters — handle the
-  //     longer markers (`***`, `___`, `**`, `__`, `~~`) before the singletons
-  //     so "asterisk" is never read aloud.
+  /*
+   * Bold / italic / strikethrough emphasis. Order matters — handle the
+   * longer markers (`***`, `___`, `**`, `__`, `~~`) before the singletons
+   * so "asterisk" is never read aloud.
+   */
   text = text.replace(/(\*\*\*|___)([^*_]+)\1/g, "$2");
   text = text.replace(/(\*\*|__)([^*_]+)\1/g, "$2");
   text = text.replace(/(\*|_)([^*_\n]+)\1/g, "$2");
   text = text.replace(/~~([^~]+)~~/g, "$1");
 
-  // 11. Tables: convert pipe separators to commas so rows read naturally,
-  //     and drop the alignment row (`---|---|---`).
+  /*
+   * Tables: convert pipe separators to commas so rows read naturally,
+   * and drop the alignment row (`---|---|---`).
+   */
   text = text.replace(/^\s*\|?\s*[:\-\s|]+\|[:\-\s|]+\s*$/gm, "");
   text = text.replace(/\|/g, ", ");
 
-  // 12. HTML tags: strip but keep their text content.
+  // HTML tags: strip but keep their text content.
   text = text.replace(/<\/?[^>]+>/g, " ");
 
-  // 13. Collapse repeated whitespace (newlines and spaces) to single spaces.
+  // Collapse repeated whitespace (newlines and spaces) to single spaces.
   text = text.replace(/\s+/g, " ").trim();
 
   return text;


### PR DESCRIPTION
## Bug

Chat responses are rendered as Markdown, but the TTS components in
\`WorkspaceChat/.../TTSButton/\` pipe the raw response straight into Piper
and the browser's \`SpeechSynthesis\` API. The synthesizer reads every
special character literally:

- \`**bold**\` -> "asterisk asterisk bold asterisk asterisk"
- \`# Heading\` -> "pound heading"
- code fences are read backtick-by-backtick
- \`- item\` is read as "hyphen item"
- \`[label](url)\` is read as "open bracket label close bracket open paren u r l close paren"

The result is effectively unusable whenever the assistant includes any
formatting, which is most of the time. The reporter on #5557 explicitly
called out hearing "asterix" repeatedly.

## Fix

Add a small \`messageToSpeech\` helper in
\`frontend/src/utils/chat/messageToSpeech.js\` that converts a Markdown
message body to plain text suitable for TTS:

| Markdown | Treatment |
|---|---|
| Fenced code blocks (\`\`\`...\`\`\` and \`~~~...~~~\`) | dropped (nothing useful to read aloud) |
| Inline code (\`\`...\`\`) | keep text, drop backticks |
| Images \`![alt](url)\` | dropped |
| Links \`[label](url)\` | keep label, drop URL |
| Reference link definitions | dropped |
| Headings (\`#\` ... \`######\`) | keep text, drop markers |
| Blockquote markers (\`>\`) | keep text, drop marker |
| List markers (\`-\`, \`*\`, \`+\`, \`1.\`, \`12)\`) | keep text, drop marker |
| Horizontal rules | dropped |
| Bold / italic / strikethrough emphasis | keep text, drop markers |
| Tables | pipes become commas, alignment row dropped |
| HTML tags | strip tags, keep content |
| Repeated whitespace | collapsed to single spaces |

The helper is regex-based — no new dependency. It is wired into both the
native (\`SpeechSynthesis\`) and Piper TTS components.

## Test

A standalone Node script verifies 18 cases (bold, italic, struck,
heading, list, code fence, link, image, blockquote, table, HTML, plain
text, etc.) all map to the expected spoken text. There is no existing
\`frontend\` test infrastructure in this repo, so I did not add a Jest /
Vitest spec — happy to add one if maintainers want to bring up that
framework alongside this change.

resolves #5557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)