### PR TITLE
fix: preserve reasoning_content through agent loop for DeepSeek thinking models

### DIFF
--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -734,6 +734,11 @@ ${this.getHistory({ to: route.to })
         content: c.content,
         role: c.from === route.to ? "user" : "assistant",
       };
+      // Preserve reasoning_content from previous DeepSeek thinking-model responses
+      // so it can be passed back to the API in subsequent agent turns.
+      if (c.reasoningContent) {
+        message.reasoningContent = c.reasoningContent;
+      }
       // Pass attachments through for user messages that have them
       if (
         c.attachments &&
@@ -818,31 +823,44 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     provider.attachHandlerProps(this.handlerProps);
 
     let content;
+    let reasoningContent = "";
     if (provider.supportsAgentStreaming) {
       this.handlerProps.log?.(
         "[DEBUG] Provider supports agent streaming - will use async execution!"
       );
-      content = await this.handleAsyncExecution(
+      const result = await this.handleAsyncExecution(
         provider,
         messages,
         functions,
         route.from
       );
+      content =
+        typeof result === "string" ? result : (result?.textResponse ?? "");
+      reasoningContent =
+        typeof result === "string" ? "" : (result?.reasoningContent || "");
     } else {
       this.handlerProps.log?.(
         "[DEBUG] Provider does not support agent streaming - will use synchronous execution!"
       );
-      content = await this.handleExecution(
+      const result = await this.handleExecution(
         provider,
         messages,
         functions,
         route.from
       );
+      content =
+        typeof result === "string" ? result : (result?.textResponse ?? "");
+      reasoningContent =
+        typeof result === "string" ? "" : (result?.reasoningContent || "");
     }
 
     // Store the active provider so plugins can access usage metrics
     this.provider = provider;
-    this.newMessage({ ...route, content });
+    this.newMessage({
+      ...route,
+      content,
+      ...(reasoningContent ? { reasoningContent } : {}),
+    });
     return content;
   }
 
@@ -915,7 +933,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
               name,
               role: "function",
               content: `Function "${name}" not found. Try again.`,
-              originalFunctionCall: completionStream.functionCall,
+              originalFunctionCall: {
+                ...completionStream.functionCall,
+                reasoningContent: completionStream.reasoningContent || "",
+              },
             },
           ],
           reachedToolLimit ? [] : functions,
@@ -972,7 +993,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
         });
         this?.flushCitations?.(directOutputUUID);
         this?.emitChatId?.(directOutputUUID);
-        return result;
+        return { textResponse: result, reasoningContent: "" };
       }
 
       const toolAttachments = this.collectToolAttachments();
@@ -982,7 +1003,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
           name,
           role: "function",
           content: result,
-          originalFunctionCall: completionStream.functionCall,
+          originalFunctionCall: {
+            ...completionStream.functionCall,
+            reasoningContent: completionStream.reasoningContent || "",
+          },
         },
       ];
 
@@ -1014,7 +1038,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     });
     this?.flushCitations?.(responseUuid);
     this?.emitChatId?.(responseUuid);
-    return completionStream?.textResponse;
+    return {
+      textResponse: completionStream?.textResponse,
+      reasoningContent: completionStream?.reasoningContent || "",
+    };
   }
 
   /**
@@ -1072,7 +1099,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
               name,
               role: "function",
               content: `Function "${name}" not found. Try again.`,
-              originalFunctionCall: completion.functionCall,
+              originalFunctionCall: {
+                ...completion.functionCall,
+                reasoningContent: completion.reasoningContent || "",
+              },
             },
           ],
           reachedToolLimit ? [] : functions,
@@ -1117,7 +1147,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
           metrics: provider.getUsage(),
         });
         this?.flushCitations?.(msgUUID);
-        return result;
+        return { textResponse: result, reasoningContent: "" };
       }
 
       const toolAttachments = this.collectToolAttachments();
@@ -1127,7 +1157,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
           name,
           role: "function",
           content: result,
-          originalFunctionCall: completion.functionCall,
+          originalFunctionCall: {
+            ...completion.functionCall,
+            reasoningContent: completion.reasoningContent || "",
+          },
         },
       ];
 
@@ -1159,7 +1192,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     });
     this?.flushCitations?.(msgUUID);
     this?.emitChatId?.(msgUUID);
-    return completion?.textResponse;
+    return {
+      textResponse: completion?.textResponse,
+      reasoningContent: completion?.reasoningContent || "",
+    };
   }
 
   /**

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -85,10 +85,14 @@ function formatMessagesForTools(messages, options = {}) {
       if (message.originalFunctionCall?.id) {
         const prevMsg = formattedMessages[formattedMessages.length - 1];
         if (!prevMsg || prevMsg.role !== "assistant" || !prevMsg.tool_calls) {
+          const fnReasoningContent =
+            message.originalFunctionCall.reasoningContent || "";
           formattedMessages.push({
             role: "assistant",
             content: null,
-            ...(injectReasoningContent ? { reasoning_content: "" } : {}),
+            ...(injectReasoningContent
+              ? { reasoning_content: fnReasoningContent }
+              : {}),
             tool_calls: [
               {
                 id: message.originalFunctionCall.id,
@@ -138,13 +142,16 @@ function formatMessagesForTools(messages, options = {}) {
               : JSON.stringify(message.content),
         });
       }
-    } else if (
-      injectReasoningContent &&
-      message.role === "assistant" &&
-      !("reasoning_content" in message)
-    ) {
+    } else if (injectReasoningContent && message.role === "assistant") {
+      // Ensure every assistant message has a reasoning_content field
+      // (required by DeepSeek thinking-mode models).
+      // Preserve reasoning_content if already present (snake_case from API),
+      // or migrate reasoningContent (camelCase from chat history).
+      let rc =
+        message.reasoning_content || message.reasoningContent || "";
+      delete message.reasoningContent;
       formattedMessages.push(
-        formatMessageWithAttachments({ ...message, reasoning_content: "" })
+        formatMessageWithAttachments({ ...message, reasoning_content: rc })
       );
     } else {
       formattedMessages.push(formatMessageWithAttachments(message));
@@ -200,6 +207,7 @@ async function tooledStream(
   const result = {
     functionCall: null,
     textResponse: "",
+    reasoningContent: "",
   };
 
   const toolCallsByIndex = {};
@@ -213,6 +221,10 @@ async function tooledStream(
 
     if (!chunk?.choices?.[0]) continue;
     const choice = chunk.choices[0];
+
+    if (choice.delta?.reasoning_content) {
+      result.reasoningContent += choice.delta.reasoning_content;
+    }
 
     if (choice.delta?.content) {
       result.textResponse += choice.delta.content;
@@ -278,6 +290,7 @@ async function tooledStream(
 
   return {
     textResponse: result.textResponse,
+    reasoningContent: result.reasoningContent,
     functionCall: result.functionCall,
     uuid: msgUUID,
     usage,
@@ -325,6 +338,7 @@ async function tooledComplete(
   });
 
   const completion = response.choices[0].message;
+  const reasoningContent = completion.reasoning_content || "";
   const cost = getCostFn(response.usage);
   const usage = response.usage || null;
 
@@ -342,6 +356,7 @@ async function tooledComplete(
     if (functionArgs === null) {
       return {
         textResponse: null,
+        reasoningContent,
         retryWithError: {
           role: "function",
           name: toolCall.function.name,
@@ -359,6 +374,7 @@ async function tooledComplete(
 
     return {
       textResponse: null,
+      reasoningContent,
       functionCall: {
         id: toolCall.id,
         name: toolCall.function.name,
@@ -371,6 +387,7 @@ async function tooledComplete(
 
   return {
     textResponse: completion.content,
+    reasoningContent,
     cost,
     usage,
   };


### PR DESCRIPTION
## Summary

This is a follow-up to #5527 which correctly added `deepseek-v4-flash` and `deepseek-v4-pro` to the `#isThinkingModel` list, enabling the `injectReasoningContent` flag. However, #5527 only addressed the detection of thinking models - the actual `reasoning_content` passthrough through the agent loop remained broken.

**The bug**: DeepSeek thinking models require the `reasoning_content` field from previous assistant responses to be passed back verbatim in subsequent API calls. The agent loop was:

1. Not capturing `reasoning_content` from API streaming/non-streaming responses
2. Not preserving it through tool call metadata (`originalFunctionCall`)
3. Not storing it in chat history for multi-turn conversations
4. Using an empty string `""` as reasoning_content for all assistant messages, which DeepSeek rejects when the original response had actual reasoning content

**The fix**: Captures `reasoning_content` at each stage of the agent pipeline and threads it through:

- `tooled.js`: `tooledStream()` and `tooledComplete()` now capture and return `reasoningContent` from API responses
- `tooled.js`: `formatMessagesForTools()` uses actual reasoningContent from `originalFunctionCall` metadata, and correctly handles camelCase/snake_case conversion from chat history
- `aibitat/index.js`: `getOrFormatNodeChatHistory()` preserves `reasoningContent` from stored chat messages
- `aibitat/index.js`: `handleAsyncExecution()`/`handleExecution()` store reasoningContent in `originalFunctionCall` on each tool-call iteration
- `aibitat/index.js`: `reply()` stores reasoningContent in the chat message for multi-turn preservation

## Scope

This fix **only affects DeepSeek thinking models** (`deepseek-reasoner`, `deepseek-v4-flash`, `deepseek-v4-pro`). The `injectReasoningContent` flag is gated behind the `#isThinkingModel` getter in `deepseek.js`. No other provider is impacted.

## Related

- Resolves #5570
- Follow-up to #5527
- Related: #5509, #5525, #5523

## Test plan

- [ ] Run `@agent` with DeepSeek `deepseek-v4-pro` model - agent should complete multi-turn tool calls without 400 errors
- [ ] Run `@agent` with DeepSeek `deepseek-v4-flash` model - same verification
- [ ] Run `@agent` with DeepSeek `deepseek-reasoner` model - same verification
- [ ] Run `@agent` with a non-DeepSeek provider (e.g., OpenAI) - verify no regression
- [ ] Run `@agent` with DeepSeek `deepseek-chat` (non-thinking model) - verify no regression
- [ ] Verify standard (non-agent) chat continues to work with all DeepSeek models
