### PR TITLE
fix(docker): bump NodeSource repo to node_20.x to unblock remote MCP servers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         xdg-utils git build-essential ffmpeg && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     # Install node and yarn
     apt-get install -yq --no-install-recommends nodejs && \
@@ -91,7 +91,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         xdg-utils git build-essential ffmpeg && \
     mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     # Install node and yarn
     apt-get install -yq --no-install-recommends nodejs && \


### PR DESCRIPTION
## What

Bumps the NodeSource apt repo in `docker/Dockerfile` from `node_18.x` to `node_20.x`. Two-line change, both occurrences (the main image stage and the ARM stage).

## Why

Remote MCP servers reached through the documented `mcp-remote` bridge (Linear, hosted Anthropic MCPs, custom Streamable HTTP / SSE endpoints) crash immediately inside the Docker image:

```
/app/.npm/_npx/.../node_modules/undici/lib/web/webidl/index.js:537
webidl.is.File = webidl.util.MakeTypeAssertion(File)
                                                ^
ReferenceError: File is not defined
Node.js v18.20.8
```

Root cause chain:

1. The image installs Node.js from the NodeSource `node_18.x` apt repo.
2. `mcp-remote@0.1.38` (the bridge package recommended in the AnythingLLM docs for remote MCP servers) depends on `undici@^7.12.0`.
3. `undici@7.x` declares `"engines": { "node": ">=20.18.1" }` and references the `File` global at module-load time.
4. The `File` global only exists in Node 20+; on Node 18 it is `undefined`, so the import itself throws before any AnythingLLM code can run.

In the `MCPHypervisor` logs this surfaces as `Transport closed` / `MCP error -32000: Connection closed` for every remote MCP entry, making the entire remote-MCP feature surface unusable in Docker. Local stdio MCPs (`npx @modelcontextprotocol/server-X`, `uvx ...`) still work because they don't transitively pull undici 7.x — which is why the breakage was invisible until users tried a remote MCP.

Node 18 is also past End-of-Life (2025-04-30), and Node 20 is Active LTS, so the existing pin is unsupported regardless of this specific bug.

## Changes

- `docker/Dockerfile` (lines 25 & 94): `node_18.x` → `node_20.x` in both NodeSource apt source lines.

## Testing

Reproduced inside the published `mintplexlabs/anythingllm:1.12.1` image (Node 18.20.8) with:

```
docker exec <container> sh -c 'npx -y mcp-remote https://mcp.linear.app/mcp'
```

→ crashes with the stacktrace above. After rebuilding with `node_20.x` the same command succeeds, the MCP server starts, and `MCPHypervisor` shows the connection as live.

## Related

- #5051 — "remote mcp server support for docker AnythingLLM". That request is actually a symptom of this same root cause, not a separate feature: remote MCP via `mcp-remote` was supposed to work, it just crashed at module-load due to the Node version pin.

Closes #5619

---
<sub>Co-authored-by: nik464 &lt;nikhil18chaudhary@gmail.com&gt;</sub>
