### PR TITLE
feat(PromptInput): restore user message to textarea after provider errors

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,101 @@
+# AnythingLLM — Upgrade & Maintenance Runbook
+
+Config root: `~/.openclaw/anythingllm/`  
+Web UI: http://localhost:3001  
+Source fork: https://github.com/janet-e4/anything-llm (branch: `feature/message-draft-autosave`)
+
+---
+
+## Standard image upgrade
+
+1. Stop the container:
+   ```bash
+   cd ~/.openclaw/anythingllm
+   docker compose down
+   ```
+
+2. Update the image tag in `docker-compose.yml`:
+   ```yaml
+   image: mintplexlabs/anythingllm:<new-version>
+   ```
+
+3. Pull and restart:
+   ```bash
+   docker compose pull
+   docker compose up -d
+   docker compose logs -f anythingllm
+   ```
+
+4. Verify the UI loads at http://localhost:3001 and a test message works.
+
+---
+
+## Upgrading from the local fork (autosave feature)
+
+When the image tag is replaced with a build from the local fork:
+
+1. Fetch upstream changes:
+   ```bash
+   cd ~/Projects/anything-llm
+   git fetch upstream
+   ```
+
+2. Rebase the feature branch:
+   ```bash
+   git checkout feature/message-draft-autosave
+   git rebase upstream/master
+   ```
+   Conflicts will only be in:
+   - `frontend/src/hooks/useDraftMessage.js` (new file — no conflict)
+   - `frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx`
+
+3. Rebuild and restart:
+   ```bash
+   cd ~/.openclaw/anythingllm
+   docker compose up -d --build --no-cache
+   docker compose logs -f anythingllm
+   ```
+
+4. Verify autosave works: type a message, refresh, confirm draft is restored.
+
+---
+
+## Re-embedding after embedding engine change
+
+**Context:** The embedding engine was switched from `ollama/nomic-embed-text` (768-dim)
+to `native` (384-dim). Existing Qdrant vectors are incompatible and must be regenerated.
+
+**Steps:**
+
+1. In the AnythingLLM UI → go to each Workspace → Documents tab.
+2. Remove (un-embed) all currently embedded documents.
+3. Re-add them. AnythingLLM will re-embed using the native engine.
+4. Verify search/RAG works in a test message.
+
+Affected documents (as of 2026-05-14):
+- `test-zhealth-doc.txt` (custom-documents)
+- Files in `direct-uploads/` (ZHealth emails, newsletter drafts, option docs)
+
+The ZHealth custom agent skill (`zhealth-knowledge-query`) queries Qdrant collection
+`zhealth_mcp_memory` — that collection is managed by the MCP server (fastembed,
+sentence-transformers/all-MiniLM-L6-v2, 384-dim) and is **not affected** by this change.
+
+---
+
+## Custom overrides preserved across upgrades
+
+| What | Host path | Container path |
+|---|---|---|
+| Storage (DB, docs, plugins) | `./storage/` | `/app/server/storage` |
+| Custom Qdrant provider | `./qdrant-provider.js` | `/app/server/utils/vectorDbProviders/qdrant/index.js` |
+
+These are bind-mounted — they survive any image upgrade automatically.
+
+---
+
+## LLM provider
+
+AnythingLLM uses OpenClaw (port 18789) as its LLM backend via the generic-openai provider.
+All provider config lives in `.env` (gitignored). Never hard-code keys in `docker-compose.yml`.
+
+Health check: `curl http://localhost:18789/health` → `{"ok":true,"status":"live"}`

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -25,7 +25,10 @@ import { ChatTooltips } from "./ChatTooltips";
 import { MetricsProvider } from "./ChatHistory/HistoricalMessage/Actions/RenderMetrics";
 import useChatContainerQuickScroll from "@/hooks/useChatContainerQuickScroll";
 import { PENDING_HOME_MESSAGE } from "@/utils/constants";
-import { clearPromptInputDraft } from "@/hooks/usePromptInputStorage";
+import {
+  clearPromptInputDraft,
+  savePromptInputDraft,
+} from "@/hooks/usePromptInputStorage";
 import { safeJsonParse } from "@/utils/request";
 import { useTranslation } from "react-i18next";
 import paths from "@/utils/paths";
@@ -260,11 +263,16 @@ export default function ChatContainer({
       const attachments = promptMessage?.attachments ?? parseAttachments();
       window.dispatchEvent(new CustomEvent(CLEAR_ATTACHMENTS_EVENT));
 
+      // Track whether the stream ended with an error so we can restore the
+      // user's message. clearPromptInputDraft() already fired in handleSubmit
+      // before the API call, so on abort we must save the draft back manually.
+      let responseHadError = false;
       await Workspace.multiplexStream({
         workspaceSlug: workspace.slug,
         threadSlug,
         prompt: promptMessage.userMessage,
-        chatHandler: (chatResult) =>
+        chatHandler: (chatResult) => {
+          if (chatResult.type === "abort") responseHadError = true;
           handleChat(
             chatResult,
             setLoadingResponse,
@@ -272,9 +280,18 @@ export default function ChatContainer({
             remHistory,
             _chatHistory,
             setSocketId
-          ),
+          );
+        },
         attachments,
       });
+
+      // Restore the user's typed message into the textarea and draft storage
+      // so they can retry without re-typing after a provider error.
+      if (responseHadError) {
+        const storageKey = threadSlug ?? workspace.slug;
+        setMessageEmit(promptMessage.userMessage);
+        savePromptInputDraft(storageKey, promptMessage.userMessage);
+      }
       return;
     }
     loadingResponse === true && fetchReply();

--- a/frontend/src/hooks/usePromptInputStorage.js
+++ b/frontend/src/hooks/usePromptInputStorage.js
@@ -38,6 +38,21 @@ export function clearPromptInputDraft(storageKey) {
   } catch {}
 }
 
+/**
+ * Immediately saves a draft value for a given thread/workspace key.
+ * Used to restore a user's message after a provider error so they don't
+ * lose their typed text when the LLM backend returns an abort/error response.
+ * @param {string} storageKey - thread slug or workspace slug
+ * @param {string} value - the message text to save as a draft
+ */
+export function savePromptInputDraft(storageKey, value) {
+  try {
+    const map = safeJsonParse(localStorage.getItem(USER_PROMPT_INPUT_MAP), {});
+    map[storageKey] = value;
+    localStorage.setItem(USER_PROMPT_INPUT_MAP, JSON.stringify(map));
+  } catch {}
+}
+
 export default function usePromptInputStorage({ promptInput, setPromptInput }) {
   const { threadSlug = null, slug: workspaceSlug } = useParams();
   useEffect(() => {


### PR DESCRIPTION
## Problem

When the LLM backend returns an error response (e.g. the provider is unreachable), the user's typed message is silently lost. This happens because:

1. `clearPromptInputDraft()` fires in `handleSubmit` **before** the API call
2. `setMessageEmit("")` clears the textarea immediately after
3. The stream error arrives asynchronously — by then both the textarea and the localStorage draft are already wiped

The user sees "Could not respond to message" with an empty input box and must re-type their entire message to retry.

## Solution

Added `savePromptInputDraft(storageKey, value)` to `usePromptInputStorage` — a counterpart to the existing `clearPromptInputDraft`. In `ChatContainer`, the `chatHandler` passed to `multiplexStream` now tracks whether the stream ended with `type: "abort"`. If it did, after `multiplexStream` resolves:

- `setMessageEmit(promptMessage.userMessage)` restores the text to the textarea
- `savePromptInputDraft(storageKey, message)` writes it back to localStorage

The user's message reappears in the input ready to retry — no re-typing needed.

## Changes

- `frontend/src/hooks/usePromptInputStorage.js` — add exported `savePromptInputDraft(storageKey, value)` (mirrors existing `clearPromptInputDraft`, 15 lines)
- `frontend/src/components/WorkspaceChat/ChatContainer/index.jsx` — import `savePromptInputDraft`; wrap `chatHandler` in `fetchReply` to detect `type: "abort"`; restore message after stream resolves on error (14 lines)

**No new dependencies. No changes to existing autosave/restore behavior (page-refresh drafts, debounced writes, thread/workspace scoping).**

## Test steps

1. Open any workspace in chat mode
2. Type a message
3. Temporarily break the LLM provider (e.g. set an invalid API key or base URL in Settings)
4. Submit the message
5. ✅ "Could not respond to message" error appears in chat history
6. ✅ The typed message reappears in the textarea
7. ✅ On page refresh, the draft is also still there
8. Restore the correct provider config
9. Resubmit — message sends successfully
10. ✅ Textarea clears, draft is gone, response appears

## Affected providers

Provider-agnostic — triggers on any `type: "abort"` stream response regardless of which LLM backend is configured.