### PR TITLE
feat: MCP system prompt variable substitution

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx
@@ -132,7 +132,7 @@ export default function ChatPromptSettings({
           <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
             {t("chat.prompt.description")}
           </p>
-          <p className="text-white text-opacity-60 text-xs font-medium mb-2">
+          <p className="text-white text-opacity-60 text-xs font-medium mb-1">
             You can insert{" "}
             <Link
               to={paths.settings.systemPromptVariables()}
@@ -157,6 +157,17 @@ export default function ChatPromptSettings({
                 +{availableVariables.length - 3} more...
               </Link>
             )}
+          </p>
+          <p className="text-white text-opacity-60 text-xs font-medium mb-2">
+            Call any running MCP server tool with{" "}
+            <span className="bg-theme-settings-input-bg px-1 py-0.5 rounded font-mono">
+              {"{mcp.<server>.<tool>}"}
+            </span>
+            {" "}— e.g.{" "}
+            <span className="bg-theme-settings-input-bg px-1 py-0.5 rounded font-mono">
+              {"{mcp.weather.get_forecast}"}
+            </span>
+            . Results are cached for 30 seconds.
           </p>
         </div>
 

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx
@@ -163,9 +163,13 @@ export default function ChatPromptSettings({
             <span className="bg-theme-settings-input-bg px-1 py-0.5 rounded font-mono">
               {"{mcp.<server>.<tool>}"}
             </span>
-            {" "}— e.g.{" "}
+            {" "}or pass arguments with{" "}
             <span className="bg-theme-settings-input-bg px-1 py-0.5 rounded font-mono">
-              {"{mcp.weather.get_forecast}"}
+              {"{mcp.<server>.<tool>:arg1,arg2}"}
+            </span>
+            {" "}— args can be literals or other variable keys like{" "}
+            <span className="bg-theme-settings-input-bg px-1 py-0.5 rounded font-mono">
+              {"workspace.name"}
             </span>
             . Results are cached for 30 seconds.
           </p>

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -33,3 +33,7 @@ yarn-error.log
 
 # Local SSL Certs for HTTPS
 sslcert
+
+# Test-generated cache files (defaults.test.js sets STORAGE_DIR=__dirname,
+# which causes ContextWindowFinder to materialize its cache here.)
+__tests__/utils/agents/models/

--- a/server/__tests__/models/systemPromptVariables.test.js
+++ b/server/__tests__/models/systemPromptVariables.test.js
@@ -2,10 +2,10 @@ const { SystemPromptVariables } = require("../../models/systemPromptVariables");
 const prisma = require("../../utils/prisma");
 
 // Mock the MCP compatibility layer so tests don't need a running MCP server.
-// The callTool mocks are defined in the factory closure (not per-instance) so
-// that every `new MCPCompatibilityLayer()` returns objects sharing the SAME
-// callTool jest.fn() — this lets us assert call counts across resolutions,
-// which is required to verify TTL-cache behavior.
+// Both callTool and listTools mocks live in the factory closure (not per-instance)
+// so every `new MCPCompatibilityLayer()` returns objects sharing the SAME jest.fn()s.
+// This is required to assert call counts across resolutions (TTL-cache tests) and
+// to verify that schema lookups are cached separately from variable results.
 jest.mock("../../utils/MCP", () => {
   const callToolMocks = {
     "test-server": jest.fn().mockResolvedValue({
@@ -30,17 +30,58 @@ jest.mock("../../utils/MCP", () => {
     "dotted-server": jest.fn().mockResolvedValue({
       content: [{ type: "text", text: "dotted-result" }],
     }),
+    // Used for all positional-arg and nested-variable tests.
+    "args-server": jest.fn().mockResolvedValue({
+      content: [{ type: "text", text: "args-result" }],
+    }),
   };
+
+  // listTools mocks: only args-server needs a real schema; all others return empty.
+  // "schema_check" is a distinct tool name used exclusively by the schema-cache test
+  // so that earlier tests (which use "lookup") never pre-populate its schema cache entry.
+  const listToolsMocks = {
+    "args-server": jest.fn().mockResolvedValue({
+      tools: [
+        {
+          name: "lookup",
+          inputSchema: {
+            type: "object",
+            properties: {
+              location: { type: "string" },
+              days: { type: "string" },
+            },
+            required: ["location", "days"],
+          },
+        },
+        {
+          name: "schema_check",
+          inputSchema: {
+            type: "object",
+            properties: {
+              city: { type: "string" },
+              count: { type: "string" },
+            },
+            required: ["city", "count"],
+          },
+        },
+      ],
+    }),
+  };
+
   const MockConstructor = jest.fn().mockImplementation(() => ({
     bootMCPServers: jest.fn().mockResolvedValue({}),
     mcps: Object.fromEntries(
       Object.entries(callToolMocks).map(([name, callTool]) => [
         name,
-        { callTool },
+        {
+          callTool,
+          listTools: listToolsMocks[name] ?? jest.fn().mockResolvedValue({ tools: [] }),
+        },
       ])
     ),
   }));
   MockConstructor.__callToolMocks = callToolMocks;
+  MockConstructor.__listToolsMocks = listToolsMocks;
   return MockConstructor;
 });
 
@@ -223,6 +264,128 @@ describe("SystemPromptVariables.expandSystemPromptVariables - MCP variables", ()
     expect(callTool).toHaveBeenCalledWith({
       name: "namespace.deep_tool",
       arguments: {},
+    });
+  });
+});
+
+describe("SystemPromptVariables.expandSystemPromptVariables - MCP variables with args", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.system_prompt_variables.findMany = jest.fn().mockResolvedValue([]);
+    prisma.workspaces.findUnique = jest.fn().mockResolvedValue(null);
+    prisma.users.findUnique = jest.fn().mockResolvedValue(null);
+  });
+
+  it("should pass a single literal arg mapped to the first required schema param", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["args-server"];
+    callTool.mockClear();
+
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Result: {mcp.args-server.lookup:Paris}"
+    );
+    expect(result).toBe("Result: args-result");
+    expect(callTool).toHaveBeenCalledWith({
+      name: "lookup",
+      arguments: { location: "Paris" },
+    });
+  });
+
+  it("should pass multiple literal args mapped positionally to required schema params", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["args-server"];
+    callTool.mockClear();
+
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "Result: {mcp.args-server.lookup:New York,7}"
+    );
+    expect(callTool).toHaveBeenCalledWith({
+      name: "lookup",
+      arguments: { location: "New York", days: "7" },
+    });
+  });
+
+  it("should resolve a workspace variable reference used as an arg", async () => {
+    prisma.workspaces.findUnique.mockResolvedValue({ name: "London" });
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["args-server"];
+    callTool.mockClear();
+
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "Result: {mcp.args-server.lookup:workspace.name,3}",
+      null,
+      1
+    );
+    // workspace.name resolves to "London" before the tool is called.
+    expect(callTool).toHaveBeenCalledWith({
+      name: "lookup",
+      arguments: { location: "London", days: "3" },
+    });
+  });
+
+  it("should resolve a user variable reference used as an arg", async () => {
+    prisma.users.findUnique.mockResolvedValue({ username: "alice", bio: "" });
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["args-server"];
+    callTool.mockClear();
+
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "Result: {mcp.args-server.lookup:user.name,5}",
+      1,
+      null
+    );
+    expect(callTool).toHaveBeenCalledWith({
+      name: "lookup",
+      arguments: { location: "alice", days: "5" },
+    });
+  });
+
+  it("should cache schema lookups so listTools is called at most once per tool", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const listTools = MCPCompatibilityLayer.__listToolsMocks["args-server"];
+    listTools.mockClear();
+
+    // "schema_check" is used here exclusively so its schema cache key is fresh —
+    // earlier tests pre-populate the "lookup" key, which would make listTools
+    // appear to be called 0 times if we reused that name.
+    // Two calls with DIFFERENT args → different variable-cache entries, but the
+    // schema for "schema_check" is fetched once and reused for the second call.
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "{mcp.args-server.schema_check:Berlin,1}"
+    );
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "{mcp.args-server.schema_check:Vienna,2}"
+    );
+    expect(listTools).toHaveBeenCalledTimes(1);
+  });
+
+  it("should create separate cache entries for different arg values", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["args-server"];
+    callTool.mockClear();
+
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "{mcp.args-server.lookup:Madrid,4}"
+    );
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "{mcp.args-server.lookup:Rome,4}"
+    );
+    // Different args → different cache keys → two distinct tool calls.
+    expect(callTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not resolve a nested mcp variable reference as an arg (no recursion)", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["args-server"];
+    callTool.mockClear();
+
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "{mcp.args-server.lookup:mcp.other-server.tool,5}"
+    );
+    // "mcp.other-server.tool" is passed as a literal string, not resolved.
+    expect(callTool).toHaveBeenCalledWith({
+      name: "lookup",
+      arguments: { location: "mcp.other-server.tool", days: "5" },
     });
   });
 });

--- a/server/__tests__/models/systemPromptVariables.test.js
+++ b/server/__tests__/models/systemPromptVariables.test.js
@@ -1,6 +1,49 @@
 const { SystemPromptVariables } = require("../../models/systemPromptVariables");
 const prisma = require("../../utils/prisma");
 
+// Mock the MCP compatibility layer so tests don't need a running MCP server.
+// The callTool mocks are defined in the factory closure (not per-instance) so
+// that every `new MCPCompatibilityLayer()` returns objects sharing the SAME
+// callTool jest.fn() — this lets us assert call counts across resolutions,
+// which is required to verify TTL-cache behavior.
+jest.mock("../../utils/MCP", () => {
+  const callToolMocks = {
+    "test-server": jest.fn().mockResolvedValue({
+      content: [{ type: "text", text: "Artist — Track Title" }],
+    }),
+    "json-server": jest.fn().mockResolvedValue({ result: 42 }),
+    "slow-server": jest
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 10_000))
+      ),
+    "error-server": jest.fn().mockRejectedValue(new Error("Tool call failed")),
+    "combo-server": jest.fn().mockResolvedValue({
+      content: [{ type: "text", text: "combo-text" }],
+    }),
+    "cache-server": jest.fn().mockResolvedValue({
+      content: [{ type: "text", text: "cache-result" }],
+    }),
+    "cache-fail-server": jest
+      .fn()
+      .mockRejectedValue(new Error("Permanent failure")),
+    "dotted-server": jest.fn().mockResolvedValue({
+      content: [{ type: "text", text: "dotted-result" }],
+    }),
+  };
+  const MockConstructor = jest.fn().mockImplementation(() => ({
+    bootMCPServers: jest.fn().mockResolvedValue({}),
+    mcps: Object.fromEntries(
+      Object.entries(callToolMocks).map(([name, callTool]) => [
+        name,
+        { callTool },
+      ])
+    ),
+  }));
+  MockConstructor.__callToolMocks = callToolMocks;
+  return MockConstructor;
+});
+
 const mockUser = {
   id: 1,
   username: "john.doe",
@@ -57,5 +100,129 @@ describe("SystemPromptVariables.expandSystemPromptVariables", () => {
     // Undefined sub-fields on valid classes are push to a placeholder [Class prop]. This is expected behavior.
     const variables = await SystemPromptVariables.expandSystemPromptVariables("Hello {invalid.variable} {user.password} the current user is {user.name} on workspace id #{workspace.id}", null, null);
     expect(variables).toBe("Hello {invalid.variable} [User password] the current user is [User name] on workspace id #[Workspace ID]");
+  });
+});
+
+describe("SystemPromptVariables.expandSystemPromptVariables - MCP variables", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.system_prompt_variables.findMany = jest.fn().mockResolvedValue([]);
+    prisma.workspaces.findUnique = jest.fn().mockResolvedValue(null);
+    prisma.users.findUnique = jest.fn().mockResolvedValue(null);
+
+    // Clear the module-level TTL cache between tests so results don't bleed across.
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    MCPCompatibilityLayer.mockClear();
+  });
+
+  it("should expand an {mcp.<server>.<tool>} variable using text content blocks", async () => {
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Now playing: {mcp.test-server.get_now_playing}"
+    );
+    expect(result).toBe("Now playing: Artist — Track Title");
+  });
+
+  it("should fall back to JSON when MCP result has no text content blocks", async () => {
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Answer: {mcp.json-server.compute}"
+    );
+    expect(result).toBe('Answer: {"result":42}');
+  });
+
+  it("should return empty string when the MCP server is not running", async () => {
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Status: {mcp.unknown-server.ping}"
+    );
+    expect(result).toBe("Status: ");
+  });
+
+  it("should return empty string when the MCP tool call throws", async () => {
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Info: {mcp.error-server.bad_tool}"
+    );
+    expect(result).toBe("Info: ");
+  });
+
+  it("should return empty string when the MCP tool call times out", async () => {
+    jest.useFakeTimers();
+    const promise = SystemPromptVariables.expandSystemPromptVariables(
+      "Loading: {mcp.slow-server.slow_tool}"
+    );
+    await jest.advanceTimersByTimeAsync(4_000);
+    const result = await promise;
+    jest.useRealTimers();
+    expect(result).toBe("Loading: ");
+  });
+
+  it("should return empty string for a malformed mcp variable with no tool segment", async () => {
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Bad: {mcp.only-server}"
+    );
+    expect(result).toBe("Bad: ");
+  });
+
+  it("should expand mcp variables alongside static and workspace variables", async () => {
+    prisma.workspaces.findUnique.mockResolvedValue({ name: "My Workspace" });
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Workspace: {workspace.name}. Status: {mcp.combo-server.combo_tool}",
+      null,
+      1
+    );
+    expect(result).toBe("Workspace: My Workspace. Status: combo-text");
+  });
+
+  it("should cache successful MCP variable results within the TTL", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["cache-server"];
+    callTool.mockClear();
+
+    // Same variable used twice in one prompt plus a follow-up prompt: three
+    // resolutions total but only one underlying tool call is allowed.
+    const first = await SystemPromptVariables.expandSystemPromptVariables(
+      "{mcp.cache-server.cached_tool} and again {mcp.cache-server.cached_tool}"
+    );
+    const second = await SystemPromptVariables.expandSystemPromptVariables(
+      "still {mcp.cache-server.cached_tool}"
+    );
+
+    expect(first).toBe("cache-result and again cache-result");
+    expect(second).toBe("still cache-result");
+    expect(callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("should negatively cache failures so a broken tool isn't re-called every turn", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["cache-fail-server"];
+    callTool.mockClear();
+
+    // Three resolutions of a permanently-failing tool should hit the upstream
+    // exactly once; the rest must be served from the negative cache.
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "x {mcp.cache-fail-server.bad_tool}"
+    );
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "y {mcp.cache-fail-server.bad_tool}"
+    );
+    await SystemPromptVariables.expandSystemPromptVariables(
+      "z {mcp.cache-fail-server.bad_tool}"
+    );
+
+    expect(callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("should preserve dots inside the tool name segment", async () => {
+    const MCPCompatibilityLayer = require("../../utils/MCP");
+    const callTool = MCPCompatibilityLayer.__callToolMocks["dotted-server"];
+    callTool.mockClear();
+
+    const result = await SystemPromptVariables.expandSystemPromptVariables(
+      "Got: {mcp.dotted-server.namespace.deep_tool}"
+    );
+    expect(result).toBe("Got: dotted-result");
+    // Only the first dot splits server from tool — the rest stays in the tool name.
+    expect(callTool).toHaveBeenCalledWith({
+      name: "namespace.deep_tool",
+      arguments: {},
+    });
   });
 });

--- a/server/models/systemPromptVariables.js
+++ b/server/models/systemPromptVariables.js
@@ -1,6 +1,112 @@
 const prisma = require("../utils/prisma");
 const moment = require("moment");
 
+// TTL cache for MCP variable results to avoid hammering MCP servers on every message.
+// Failures are cached at a shorter TTL so a broken variable doesn't spam logs every turn.
+const _mcpVariableCache = new Map();
+const MCP_VARIABLE_TTL_MS = 30_000;
+const MCP_VARIABLE_FAILURE_TTL_MS = 10_000;
+const MCP_VARIABLE_TIMEOUT_MS = 3_000;
+
+/**
+ * Parse and resolve an {mcp.<server>.<tool>} variable, with a TTL cache and hard timeout.
+ * Returns empty string on any failure so a broken MCP server never 500s a chat request.
+ * @param {string} key - e.g. "mcp.lastfm.lastfm_get_now_playing"
+ * @returns {Promise<string>}
+ */
+async function _resolveMcpVariable(key) {
+  const cached = _mcpVariableCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  // key format: "mcp.<serverName>.<toolName>"
+  const withoutPrefix = key.substring(4); // strip "mcp."
+  const dotIndex = withoutPrefix.indexOf(".");
+  if (dotIndex === -1) return "";
+
+  const serverName = withoutPrefix.substring(0, dotIndex);
+  const toolName = withoutPrefix.substring(dotIndex + 1);
+  if (!serverName || !toolName) return "";
+
+  try {
+    // Lazy require avoids circular dependency issues at module load time.
+    const MCPCompatibilityLayer = require("../utils/MCP");
+    const mcpLayer = new MCPCompatibilityLayer();
+    // Boot is idempotent — early-returns when servers are already running — but is
+    // required for the cold-start case where the user has an mcp variable but has
+    // never invoked an agent or opened the MCP admin page.
+    await mcpLayer.bootMCPServers();
+    const mcp = mcpLayer.mcps[serverName];
+    if (!mcp) {
+      console.warn(
+        `[MCP Variable] Server "${serverName}" not found or not running`
+      );
+      _mcpVariableCache.set(key, {
+        value: "",
+        expiresAt: Date.now() + MCP_VARIABLE_FAILURE_TTL_MS,
+      });
+      return "";
+    }
+
+    // Race the tool call against a hard timeout. Clearing the timer on the
+    // success path matters: otherwise each successful resolution leaves a
+    // 3-second dangling setTimeout that keeps the event loop alive (which
+    // surfaces as "Jest did not exit" in tests and as wasted timer slots
+    // under chat load in production).
+    let timeoutHandle;
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutHandle = setTimeout(
+        () => reject(new Error("MCP variable resolver timed out")),
+        MCP_VARIABLE_TIMEOUT_MS
+      );
+    });
+    let result;
+    try {
+      result = await Promise.race([
+        mcp.callTool({ name: toolName, arguments: {} }),
+        timeoutPromise,
+      ]);
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+
+    const value = _extractMcpText(result);
+    _mcpVariableCache.set(key, {
+      value,
+      expiresAt: Date.now() + MCP_VARIABLE_TTL_MS,
+    });
+    return value;
+  } catch (error) {
+    console.warn(`[MCP Variable] Failed to resolve {${key}}:`, error.message);
+    _mcpVariableCache.set(key, {
+      value: "",
+      expiresAt: Date.now() + MCP_VARIABLE_FAILURE_TTL_MS,
+    });
+    return "";
+  }
+}
+
+/**
+ * Extract a human-readable string from an MCP callTool result.
+ * Prefers concatenated text content blocks; falls back to JSON.
+ * @param {*} result
+ * @returns {string}
+ */
+function _extractMcpText(result) {
+  if (!result) return "";
+  if (typeof result === "string") return result;
+  if (Array.isArray(result?.content)) {
+    const parts = result.content
+      .filter((item) => item?.type === "text" && typeof item.text === "string")
+      .map((item) => item.text);
+    if (parts.length > 0) return parts.join("\n");
+  }
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return "";
+  }
+}
+
 /**
  * @typedef {Object} SystemPromptVariable
  * @property {number} id
@@ -245,6 +351,13 @@ const SystemPromptVariables = {
         const isWorkspaceOrUserVariable = ["workspace.", "user."].some(
           (prefix) => key.startsWith(prefix)
         );
+
+        // Handle MCP server variables: {mcp.<serverName>.<toolName>}
+        if (key.startsWith("mcp.")) {
+          const value = await _resolveMcpVariable(key);
+          result = result.replace(match, value);
+          continue;
+        }
 
         // Handle class-based variables with current workspace's or user's data
         if (isWorkspaceOrUserVariable) {

--- a/server/models/systemPromptVariables.js
+++ b/server/models/systemPromptVariables.js
@@ -4,28 +4,138 @@ const moment = require("moment");
 // TTL cache for MCP variable results to avoid hammering MCP servers on every message.
 // Failures are cached at a shorter TTL so a broken variable doesn't spam logs every turn.
 const _mcpVariableCache = new Map();
+// Schema cache for MCP tool inputSchemas, used to map positional args to named parameters.
+const _mcpSchemaCache = new Map();
 const MCP_VARIABLE_TTL_MS = 30_000;
 const MCP_VARIABLE_FAILURE_TTL_MS = 10_000;
+const MCP_SCHEMA_TTL_MS = 5 * 60_000; // schemas change rarely; 5-minute TTL is fine
 const MCP_VARIABLE_TIMEOUT_MS = 3_000;
 
 /**
- * Parse and resolve an {mcp.<server>.<tool>} variable, with a TTL cache and hard timeout.
- * Returns empty string on any failure so a broken MCP server never 500s a chat request.
- * @param {string} key - e.g. "mcp.lastfm.lastfm_get_now_playing"
+ * Resolve a single arg token from an MCP variable expression.
+ * If the token matches a key in allVariables it is resolved like any other
+ * prompt variable; otherwise it is treated as a literal string.
+ * MCP variable keys ("mcp.*") are intentionally excluded to prevent recursion.
+ * @param {string} rawArg
+ * @param {import('./systemPromptVariables').SystemPromptVariable[]} allVariables
+ * @param {number|null} userId
+ * @param {number|null} workspaceId
  * @returns {Promise<string>}
  */
-async function _resolveMcpVariable(key) {
-  const cached = _mcpVariableCache.get(key);
-  if (cached && cached.expiresAt > Date.now()) return cached.value;
+async function _resolveArg(rawArg, allVariables, userId, workspaceId) {
+  if (rawArg.startsWith("mcp.")) return rawArg; // no recursion
+  const variable = allVariables.find((v) => v.key === rawArg);
+  if (!variable) return rawArg; // literal
 
-  // key format: "mcp.<serverName>.<toolName>"
+  if (typeof variable.value !== "function") return String(variable.value ?? "");
+
+  try {
+    if (rawArg.startsWith("workspace."))
+      return String((await variable.value(workspaceId)) ?? "");
+    if (rawArg.startsWith("user."))
+      return String((await variable.value(userId)) ?? "");
+    // system variables: time, date, datetime
+    const val =
+      variable.value.constructor.name === "AsyncFunction"
+        ? await variable.value()
+        : variable.value();
+    return String(val ?? "");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Map positional arg values to named parameters using the tool's inputSchema.
+ * Results are cached at MCP_SCHEMA_TTL_MS to avoid repeated listTools calls.
+ * All arg values are strings; MCP servers are expected to coerce types if needed.
+ * @param {object} mcp - MCP client instance
+ * @param {string} serverName
+ * @param {string} toolName
+ * @param {string[]} positionalArgs - already-resolved arg values
+ * @returns {Promise<Record<string, string>>}
+ */
+async function _buildMcpToolArguments(
+  mcp,
+  serverName,
+  toolName,
+  positionalArgs
+) {
+  if (!positionalArgs.length) return {};
+
+  const cacheKey = `${serverName}:${toolName}`;
+  let schemaEntry = _mcpSchemaCache.get(cacheKey);
+  if (!schemaEntry || schemaEntry.expiresAt <= Date.now()) {
+    const { tools } = await mcp.listTools();
+    const tool = tools.find((t) => t.name === toolName);
+    const schema = tool?.inputSchema ?? {};
+    schemaEntry = { schema, expiresAt: Date.now() + MCP_SCHEMA_TTL_MS };
+    _mcpSchemaCache.set(cacheKey, schemaEntry);
+  }
+
+  const { schema } = schemaEntry;
+  const paramNames =
+    Array.isArray(schema.required) && schema.required.length
+      ? schema.required
+      : Object.keys(schema.properties ?? {});
+
+  const args = {};
+  positionalArgs.forEach((val, i) => {
+    if (paramNames[i]) args[paramNames[i]] = val;
+  });
+  return args;
+}
+
+/**
+ * Parse and resolve an {mcp.<server>.<tool>[:<arg1>,<arg2>,...]} variable.
+ * Args are either literal strings or other variable keys (e.g. "workspace.city",
+ * "user.id") resolved before the tool is called. The cache key includes resolved
+ * arg values plus userId/workspaceId so different contexts don't share stale entries.
+ * Returns empty string on any failure so a broken MCP server never 500s a chat request.
+ * @param {string} key - e.g. "mcp.lastfm.get_now_playing" or "mcp.weather.forecast:workspace.city,7"
+ * @param {{ userId: number|null, workspaceId: number|null, allVariables: object[] }} context
+ * @returns {Promise<string>}
+ */
+async function _resolveMcpVariable(key, context = {}) {
+  const { userId = null, workspaceId = null, allVariables = [] } = context;
+
+  // Parse "mcp.<serverName>.<toolName>[:<rawArg1>,<rawArg2>,...]"
   const withoutPrefix = key.substring(4); // strip "mcp."
-  const dotIndex = withoutPrefix.indexOf(".");
-  if (dotIndex === -1) return "";
+  const colonIndex = withoutPrefix.indexOf(":");
+  const toolPath =
+    colonIndex === -1 ? withoutPrefix : withoutPrefix.substring(0, colonIndex);
+  const rawArgsString =
+    colonIndex === -1 ? "" : withoutPrefix.substring(colonIndex + 1);
 
-  const serverName = withoutPrefix.substring(0, dotIndex);
-  const toolName = withoutPrefix.substring(dotIndex + 1);
+  const dotIndex = toolPath.indexOf(".");
+  if (dotIndex === -1) return "";
+  const serverName = toolPath.substring(0, dotIndex);
+  const toolName = toolPath.substring(dotIndex + 1);
   if (!serverName || !toolName) return "";
+
+  const rawArgs = rawArgsString
+    ? rawArgsString
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+  // Resolve any variable-reference args before building the cache key so that
+  // "workspace.city" → "Paris" is what ends up in the key (context-specific).
+  const resolvedArgs = rawArgs.length
+    ? await Promise.all(
+        rawArgs.map((a) => _resolveArg(a, allVariables, userId, workspaceId))
+      )
+    : [];
+
+  // Cache key: tool path + resolved args + user/workspace context (only when args
+  // are present, since zero-arg tools have no user/workspace dependency).
+  const cacheKey = resolvedArgs.length
+    ? `${toolPath}:${resolvedArgs.join(",")}:u=${userId ?? ""}:w=${workspaceId ?? ""}`
+    : toolPath;
+
+  const cached = _mcpVariableCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
 
   try {
     // Lazy require avoids circular dependency issues at module load time.
@@ -40,7 +150,7 @@ async function _resolveMcpVariable(key) {
       console.warn(
         `[MCP Variable] Server "${serverName}" not found or not running`
       );
-      _mcpVariableCache.set(key, {
+      _mcpVariableCache.set(cacheKey, {
         value: "",
         expiresAt: Date.now() + MCP_VARIABLE_FAILURE_TTL_MS,
       });
@@ -62,7 +172,15 @@ async function _resolveMcpVariable(key) {
     let result;
     try {
       result = await Promise.race([
-        mcp.callTool({ name: toolName, arguments: {} }),
+        (async () => {
+          const args = await _buildMcpToolArguments(
+            mcp,
+            serverName,
+            toolName,
+            resolvedArgs
+          );
+          return mcp.callTool({ name: toolName, arguments: args });
+        })(),
         timeoutPromise,
       ]);
     } finally {
@@ -70,14 +188,14 @@ async function _resolveMcpVariable(key) {
     }
 
     const value = _extractMcpText(result);
-    _mcpVariableCache.set(key, {
+    _mcpVariableCache.set(cacheKey, {
       value,
       expiresAt: Date.now() + MCP_VARIABLE_TTL_MS,
     });
     return value;
   } catch (error) {
     console.warn(`[MCP Variable] Failed to resolve {${key}}:`, error.message);
-    _mcpVariableCache.set(key, {
+    _mcpVariableCache.set(cacheKey, {
       value: "",
       expiresAt: Date.now() + MCP_VARIABLE_FAILURE_TTL_MS,
     });
@@ -352,9 +470,13 @@ const SystemPromptVariables = {
           (prefix) => key.startsWith(prefix)
         );
 
-        // Handle MCP server variables: {mcp.<serverName>.<toolName>}
+        // Handle MCP server variables: {mcp.<serverName>.<toolName>[:<arg1>,<arg2>,...]}
         if (key.startsWith("mcp.")) {
-          const value = await _resolveMcpVariable(key);
+          const value = await _resolveMcpVariable(key, {
+            userId,
+            workspaceId,
+            allVariables,
+          });
           result = result.replace(match, value);
           continue;
         }

--- a/server/models/systemPromptVariables.js
+++ b/server/models/systemPromptVariables.js
@@ -1,226 +1,165 @@
 const prisma = require("../utils/prisma");
 const moment = require("moment");
 
-// TTL cache for MCP variable results to avoid hammering MCP servers on every message.
-// Failures are cached at a shorter TTL so a broken variable doesn't spam logs every turn.
-const _mcpVariableCache = new Map();
-// Schema cache for MCP tool inputSchemas, used to map positional args to named parameters.
-const _mcpSchemaCache = new Map();
-const MCP_VARIABLE_TTL_MS = 30_000;
-const MCP_VARIABLE_FAILURE_TTL_MS = 10_000;
-const MCP_SCHEMA_TTL_MS = 5 * 60_000; // schemas change rarely; 5-minute TTL is fine
-const MCP_VARIABLE_TIMEOUT_MS = 3_000;
+// MCP variable substitution. All values in ms. Tuned for chat-loop usage:
+//   - success: long enough to absorb burst messages, short enough to feel live.
+//   - failure: shorter so a recovered server resumes quickly, non-zero so a
+//              permanently-broken variable doesn't spam logs every turn.
+//   - schema:  long because tool schemas only change on server restart.
+//   - timeout: short enough not to stall a chat turn, long enough for a healthy roundtrip.
+const MCP_TTL = {
+  success: 30_000,
+  failure: 10_000,
+  schema: 5 * 60_000,
+  timeout: 3_000,
+};
 
-/**
- * Resolve a single arg token from an MCP variable expression.
- * If the token matches a key in allVariables it is resolved like any other
- * prompt variable; otherwise it is treated as a literal string.
- * MCP variable keys ("mcp.*") are intentionally excluded to prevent recursion.
- * @param {string} rawArg
- * @param {import('./systemPromptVariables').SystemPromptVariable[]} allVariables
- * @param {number|null} userId
- * @param {number|null} workspaceId
- * @returns {Promise<string>}
- */
-async function _resolveArg(rawArg, allVariables, userId, workspaceId) {
-  if (rawArg.startsWith("mcp.")) return rawArg; // no recursion
-  const variable = allVariables.find((v) => v.key === rawArg);
-  if (!variable) return rawArg; // literal
+const _mcpCache = new Map(); // cacheKey -> { value, expiresAt }
+const _mcpSchemas = new Map(); // "server:tool" -> { value: inputSchema, expiresAt }
 
-  if (typeof variable.value !== "function") return String(variable.value ?? "");
+const _cacheHit = (map, key) => {
+  const entry = map.get(key);
+  return entry && entry.expiresAt > Date.now() ? entry : null;
+};
+const _cacheSet = (map, key, value, ttl) =>
+  map.set(key, { value, expiresAt: Date.now() + ttl });
 
+// Race a promise against a hard timeout; the loser timer is always cleared
+// so successful resolutions don't leak setTimeouts into the event loop.
+async function _withTimeout(fn, ms, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
   try {
-    if (rawArg.startsWith("workspace."))
-      return String((await variable.value(workspaceId)) ?? "");
-    if (rawArg.startsWith("user."))
-      return String((await variable.value(userId)) ?? "");
-    // system variables: time, date, datetime
-    const val =
-      variable.value.constructor.name === "AsyncFunction"
-        ? await variable.value()
-        : variable.value();
-    return String(val ?? "");
+    return await Promise.race([fn(), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Resolve a single MCP arg: either a literal string or the key of another
+// prompt variable. mcp.* keys are passed through as literals (no recursion).
+async function _resolveArg(arg, allVariables, userId, workspaceId) {
+  if (arg.startsWith("mcp.")) return arg;
+  const v = allVariables.find((x) => x.key === arg);
+  if (!v) return arg;
+  if (typeof v.value !== "function") return String(v.value ?? "");
+  const ctx = arg.startsWith("workspace.")
+    ? workspaceId
+    : arg.startsWith("user.")
+      ? userId
+      : undefined;
+  try {
+    return String((await v.value(ctx)) ?? "");
+  } catch {
+    return "";
+  }
+}
+
+// Map positional arg values to the tool's required (or first declared)
+// parameter names. Schemas cached per server+tool at MCP_TTL.schema.
+async function _mapArgs(mcp, server, tool, args) {
+  if (!args.length) return {};
+  const key = `${server}:${tool}`;
+  let entry = _cacheHit(_mcpSchemas, key);
+  if (!entry) {
+    const { tools } = await mcp.listTools();
+    const schema = tools.find((t) => t.name === tool)?.inputSchema ?? {};
+    _cacheSet(_mcpSchemas, key, schema, MCP_TTL.schema);
+    entry = { value: schema };
+  }
+  const names = entry.value.required?.length
+    ? entry.value.required
+    : Object.keys(entry.value.properties ?? {});
+  return Object.fromEntries(
+    args.map((v, i) => [names[i], v]).filter(([n]) => n)
+  );
+}
+
+// Extract a readable string from an MCP callTool result.
+function _extractMcpText(result) {
+  if (!result) return "";
+  if (typeof result === "string") return result;
+  const text = Array.isArray(result.content)
+    ? result.content
+        .filter((c) => c?.type === "text" && typeof c.text === "string")
+        .map((c) => c.text)
+        .join("\n")
+    : "";
+  if (text) return text;
+  try {
+    return JSON.stringify(result);
   } catch {
     return "";
   }
 }
 
 /**
- * Map positional arg values to named parameters using the tool's inputSchema.
- * Results are cached at MCP_SCHEMA_TTL_MS to avoid repeated listTools calls.
- * All arg values are strings; MCP servers are expected to coerce types if needed.
- * @param {object} mcp - MCP client instance
- * @param {string} serverName
- * @param {string} toolName
- * @param {string[]} positionalArgs - already-resolved arg values
- * @returns {Promise<Record<string, string>>}
- */
-async function _buildMcpToolArguments(
-  mcp,
-  serverName,
-  toolName,
-  positionalArgs
-) {
-  if (!positionalArgs.length) return {};
-
-  const cacheKey = `${serverName}:${toolName}`;
-  let schemaEntry = _mcpSchemaCache.get(cacheKey);
-  if (!schemaEntry || schemaEntry.expiresAt <= Date.now()) {
-    const { tools } = await mcp.listTools();
-    const tool = tools.find((t) => t.name === toolName);
-    const schema = tool?.inputSchema ?? {};
-    schemaEntry = { schema, expiresAt: Date.now() + MCP_SCHEMA_TTL_MS };
-    _mcpSchemaCache.set(cacheKey, schemaEntry);
-  }
-
-  const { schema } = schemaEntry;
-  const paramNames =
-    Array.isArray(schema.required) && schema.required.length
-      ? schema.required
-      : Object.keys(schema.properties ?? {});
-
-  const args = {};
-  positionalArgs.forEach((val, i) => {
-    if (paramNames[i]) args[paramNames[i]] = val;
-  });
-  return args;
-}
-
-/**
- * Parse and resolve an {mcp.<server>.<tool>[:<arg1>,<arg2>,...]} variable.
- * Args are either literal strings or other variable keys (e.g. "workspace.city",
- * "user.id") resolved before the tool is called. The cache key includes resolved
- * arg values plus userId/workspaceId so different contexts don't share stale entries.
- * Returns empty string on any failure so a broken MCP server never 500s a chat request.
- * @param {string} key - e.g. "mcp.lastfm.get_now_playing" or "mcp.weather.forecast:workspace.city,7"
- * @param {{ userId: number|null, workspaceId: number|null, allVariables: object[] }} context
- * @returns {Promise<string>}
+ * Resolve {mcp.<server>.<tool>[:<arg1>,<arg2>,...]}.
+ * Each arg is a literal or another variable key (resolved before the call).
+ * Returns "" on any failure so a broken MCP variable can never block a chat.
  */
 async function _resolveMcpVariable(key, context = {}) {
   const { userId = null, workspaceId = null, allVariables = [] } = context;
 
-  // Parse "mcp.<serverName>.<toolName>[:<rawArg1>,<rawArg2>,...]"
-  const withoutPrefix = key.substring(4); // strip "mcp."
-  const colonIndex = withoutPrefix.indexOf(":");
-  const toolPath =
-    colonIndex === -1 ? withoutPrefix : withoutPrefix.substring(0, colonIndex);
-  const rawArgsString =
-    colonIndex === -1 ? "" : withoutPrefix.substring(colonIndex + 1);
+  const sub = key.substring(4); // strip "mcp."
+  const colon = sub.indexOf(":");
+  const path = colon === -1 ? sub : sub.substring(0, colon);
+  const rawArgs = colon === -1 ? "" : sub.substring(colon + 1);
 
-  const dotIndex = toolPath.indexOf(".");
-  if (dotIndex === -1) return "";
-  const serverName = toolPath.substring(0, dotIndex);
-  const toolName = toolPath.substring(dotIndex + 1);
-  if (!serverName || !toolName) return "";
+  const dot = path.indexOf(".");
+  if (dot === -1) return "";
+  const server = path.substring(0, dot);
+  const tool = path.substring(dot + 1);
+  if (!server || !tool) return "";
 
-  const rawArgs = rawArgsString
-    ? rawArgsString
+  const args = rawArgs
+    ? rawArgs
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean)
     : [];
-
-  // Resolve any variable-reference args before building the cache key so that
-  // "workspace.city" → "Paris" is what ends up in the key (context-specific).
-  const resolvedArgs = rawArgs.length
+  const resolved = args.length
     ? await Promise.all(
-        rawArgs.map((a) => _resolveArg(a, allVariables, userId, workspaceId))
+        args.map((a) => _resolveArg(a, allVariables, userId, workspaceId))
       )
     : [];
 
-  // Cache key: tool path + resolved args + user/workspace context (only when args
-  // are present, since zero-arg tools have no user/workspace dependency).
-  const cacheKey = resolvedArgs.length
-    ? `${toolPath}:${resolvedArgs.join(",")}:u=${userId ?? ""}:w=${workspaceId ?? ""}`
-    : toolPath;
-
-  const cached = _mcpVariableCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  // Cache key folds in user/workspace context only when args are present;
+  // zero-arg calls have no context dependency.
+  const cacheKey = resolved.length
+    ? `${path}:${resolved.join(",")}:u=${userId ?? ""}:w=${workspaceId ?? ""}`
+    : path;
+  const hit = _cacheHit(_mcpCache, cacheKey);
+  if (hit) return hit.value;
 
   try {
-    // Lazy require avoids circular dependency issues at module load time.
+    // Lazy-required to avoid a circular dependency at module load.
     const MCPCompatibilityLayer = require("../utils/MCP");
     const mcpLayer = new MCPCompatibilityLayer();
-    // Boot is idempotent — early-returns when servers are already running — but is
-    // required for the cold-start case where the user has an mcp variable but has
-    // never invoked an agent or opened the MCP admin page.
-    await mcpLayer.bootMCPServers();
-    const mcp = mcpLayer.mcps[serverName];
+    await mcpLayer.bootMCPServers(); // idempotent; needed for cold start
+    const mcp = mcpLayer.mcps[server];
     if (!mcp) {
-      console.warn(
-        `[MCP Variable] Server "${serverName}" not found or not running`
-      );
-      _mcpVariableCache.set(cacheKey, {
-        value: "",
-        expiresAt: Date.now() + MCP_VARIABLE_FAILURE_TTL_MS,
-      });
+      console.warn(`[MCP Variable] Server "${server}" not running`);
+      _cacheSet(_mcpCache, cacheKey, "", MCP_TTL.failure);
       return "";
     }
-
-    // Race the tool call against a hard timeout. Clearing the timer on the
-    // success path matters: otherwise each successful resolution leaves a
-    // 3-second dangling setTimeout that keeps the event loop alive (which
-    // surfaces as "Jest did not exit" in tests and as wasted timer slots
-    // under chat load in production).
-    let timeoutHandle;
-    const timeoutPromise = new Promise((_, reject) => {
-      timeoutHandle = setTimeout(
-        () => reject(new Error("MCP variable resolver timed out")),
-        MCP_VARIABLE_TIMEOUT_MS
-      );
-    });
-    let result;
-    try {
-      result = await Promise.race([
-        (async () => {
-          const args = await _buildMcpToolArguments(
-            mcp,
-            serverName,
-            toolName,
-            resolvedArgs
-          );
-          return mcp.callTool({ name: toolName, arguments: args });
-        })(),
-        timeoutPromise,
-      ]);
-    } finally {
-      clearTimeout(timeoutHandle);
-    }
-
+    const result = await _withTimeout(
+      async () =>
+        mcp.callTool({
+          name: tool,
+          arguments: await _mapArgs(mcp, server, tool, resolved),
+        }),
+      MCP_TTL.timeout,
+      "MCP variable resolver timed out"
+    );
     const value = _extractMcpText(result);
-    _mcpVariableCache.set(cacheKey, {
-      value,
-      expiresAt: Date.now() + MCP_VARIABLE_TTL_MS,
-    });
+    _cacheSet(_mcpCache, cacheKey, value, MCP_TTL.success);
     return value;
   } catch (error) {
     console.warn(`[MCP Variable] Failed to resolve {${key}}:`, error.message);
-    _mcpVariableCache.set(cacheKey, {
-      value: "",
-      expiresAt: Date.now() + MCP_VARIABLE_FAILURE_TTL_MS,
-    });
-    return "";
-  }
-}
-
-/**
- * Extract a human-readable string from an MCP callTool result.
- * Prefers concatenated text content blocks; falls back to JSON.
- * @param {*} result
- * @returns {string}
- */
-function _extractMcpText(result) {
-  if (!result) return "";
-  if (typeof result === "string") return result;
-  if (Array.isArray(result?.content)) {
-    const parts = result.content
-      .filter((item) => item?.type === "text" && typeof item.text === "string")
-      .map((item) => item.text);
-    if (parts.length > 0) return parts.join("\n");
-  }
-  try {
-    return JSON.stringify(result);
-  } catch {
+    _cacheSet(_mcpCache, cacheKey, "", MCP_TTL.failure);
     return "";
   }
 }


### PR DESCRIPTION
## Summary

Adds `{mcp.<server>.<tool>}` variable support to workspace system prompts so any running MCP server tool can be called inline at prompt-expansion time. Closes #5646.

* New resolver in `SystemPromptVariables.expandSystemPromptVariables`: parses the key, looks up the MCP client via the existing `MCPCompatibilityLayer` singleton, calls the tool with no arguments, and substitutes the result string.
* Boot-idempotent — calls `bootMCPServers()` lazily so the variable works on cold start even if no agent has been invoked yet.
* TTL cache (30s) on successful results, negative cache (10s) on failures, and a 3s hard timeout per resolution so a broken or slow MCP server can never block or 500 a chat request — failures fall back to an empty string.
* Frontend hint in **Workspace → Chat Settings** explains the new `{mcp.<server>.<tool>}` syntax next to the existing `{time}`, `{date}`, `{datetime}` examples.

## How it works

Example: a workspace system prompt of

```
You are a helpful assistant. The currently playing track is: {mcp.deezer.lastfm\_get\_now\_playing}
```

…will, on every message, call the `lastfm\_get\_now\_playing` tool on the running `deezer` MCP server (configured in `server/storage/plugins/anythingllm\_mcp\_servers.json`) and inline the result before the prompt is sent to the LLM. Tool names that contain dots (e.g. `mcp.foo.namespace.tool`) work — only the first dot splits server from tool name.

The result string is extracted from the MCP `callTool` response by preferring concatenated `text` content blocks, falling back to `JSON.stringify(result)` if no text blocks are present.

## Design notes

* **Lazy require** of `../utils/MCP` avoids a circular dependency at module load.
* **No tool arguments** in this iteration — variable resolution always calls with `arguments: {}`. The intended use case is a parameterless "fetcher" tool whose output the LLM should see verbatim. Parameterised variables are a natural follow-up but out of scope here.
* **Single-pass expansion** — resolved values are not re-scanned for variables, which prevents recursion attacks via MCP-returned strings.
* **Hard timeout** uses `Promise.race` with the loser-timer cleared in `finally` so each successful resolution doesn't leak a 3s `setTimeout` into the event loop.
* **Fail-soft contract**: any error path (server not running, tool throws, timeout, malformed key) resolves to `""`. The user sees an empty substitution rather than a chat error.

## Test plan

Unit tests in `server/\_\_tests\_\_/models/systemPromptVariables.test.js` cover:

* \[x] Text-content extraction for a normal MCP tool result
* \[x] JSON fallback when no text content blocks are returned
* \[x] Empty-string fallback when the MCP server isn't running
* \[x] Empty-string fallback when the tool call throws
* \[x] Empty-string fallback when the tool call exceeds the 3s timeout (verified via `jest.useFakeTimers`)
* \[x] Malformed `{mcp.foo}` (no tool segment) → empty string
* \[x] Mixed expansion alongside `{workspace.name}` and static variables
* \[x] **Cache verification**: three resolutions of the same variable across two `expandSystemPromptVariables` calls result in exactly one underlying `callTool` (TTL cache works)
* \[x] **Negative cache**: three resolutions of a permanently-failing tool result in exactly one underlying `callTool` (failure path is also cached)
* \[x] **Dotted tool names**: `{mcp.dotted-server.namespace.deep\_tool}` calls `callTool({ name: "namespace.deep\_tool", arguments: {} })`

Manual smoke test:

* \[x] Configured a real `deezer` MCP server and verified that `{mcp.deezer.lastfm\_get\_now\_playing}` expands to a JSON `Current track: {...}` string in chat.
* \[x] Confirmed that with the MCP server stopped, the variable resolves to empty and the chat still works.

## Files changed

* `server/models/systemPromptVariables.js` — resolver, cache, timeout, extractor; new `mcp.` branch in `expandSystemPromptVariables`.
* `server/\_\_tests\_\_/models/systemPromptVariables.test.js` — 10 new tests, shared-mock refactor.
* `frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx` — hint line explaining the new syntax.
* `server/.gitignore` — ignore `\_\_tests\_\_/utils/agents/models/` cache files generated by `defaults.test.js`.

