### PR TITLE
Support reasoning content in v2 stream handler

### DIFF
--- a/server/utils/AiProviders/deepseek/index.js
+++ b/server/utils/AiProviders/deepseek/index.js
@@ -2,11 +2,9 @@ const { NativeEmbedder } = require("../../EmbeddingEngines/native");
 const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
-const { v4: uuidv4 } = require("uuid");
 const { MODEL_MAP } = require("../modelMap");
 const {
-  writeResponseChunk,
-  clientAbortedHandler,
+  handleDefaultStreamResponseV2,
 } = require("../../helpers/chat/responses");
 
 class DeepSeekLLM {
@@ -159,143 +157,8 @@ class DeepSeekLLM {
     return measuredStreamRequest;
   }
 
-  // TODO: This is a copy of the generic handleStream function in responses.js
-  // to specifically handle the DeepSeek reasoning model `reasoning_content` field.
-  // When or if ever possible, we should refactor this to be in the generic function.
   handleStream(response, stream, responseProps) {
-    const { uuid = uuidv4(), sources = [] } = responseProps;
-    let hasUsageMetrics = false;
-    let usage = {
-      completion_tokens: 0,
-    };
-
-    return new Promise(async (resolve) => {
-      let fullText = "";
-      let reasoningText = "";
-
-      // Establish listener to early-abort a streaming response
-      // in case things go sideways or the user does not like the response.
-      // We preserve the generated text but continue as if chat was completed
-      // to preserve previously generated content.
-      const handleAbort = () => {
-        stream?.endMeasurement(usage);
-        clientAbortedHandler(resolve, fullText);
-      };
-      response.on("close", handleAbort);
-
-      try {
-        for await (const chunk of stream) {
-          const message = chunk?.choices?.[0];
-          const token = message?.delta?.content;
-          const reasoningToken = message?.delta?.reasoning_content;
-
-          if (
-            chunk.hasOwnProperty("usage") && // exists
-            !!chunk.usage && // is not null
-            Object.values(chunk.usage).length > 0 // has values
-          ) {
-            if (chunk.usage.hasOwnProperty("prompt_tokens")) {
-              usage.prompt_tokens = Number(chunk.usage.prompt_tokens);
-            }
-
-            if (chunk.usage.hasOwnProperty("completion_tokens")) {
-              hasUsageMetrics = true; // to stop estimating counter
-              usage.completion_tokens = Number(chunk.usage.completion_tokens);
-            }
-          }
-
-          // Reasoning models will always return the reasoning text before the token text.
-          if (reasoningToken) {
-            // If the reasoning text is empty (''), we need to initialize it
-            // and send the first chunk of reasoning text.
-            if (reasoningText.length === 0) {
-              writeResponseChunk(response, {
-                uuid,
-                sources: [],
-                type: "textResponseChunk",
-                textResponse: `<think>${reasoningToken}`,
-                close: false,
-                error: false,
-              });
-              reasoningText += `<think>${reasoningToken}`;
-              continue;
-            } else {
-              writeResponseChunk(response, {
-                uuid,
-                sources: [],
-                type: "textResponseChunk",
-                textResponse: reasoningToken,
-                close: false,
-                error: false,
-              });
-              reasoningText += reasoningToken;
-            }
-          }
-
-          // If the reasoning text is not empty, but the reasoning token is empty
-          // and the token text is not empty we need to close the reasoning text and begin sending the token text.
-          if (!!reasoningText && !reasoningToken && token) {
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: `</think>`,
-              close: false,
-              error: false,
-            });
-            fullText += `${reasoningText}</think>`;
-            reasoningText = "";
-          }
-
-          if (token) {
-            fullText += token;
-            // If we never saw a usage metric, we can estimate them by number of completion chunks
-            if (!hasUsageMetrics) usage.completion_tokens++;
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: token,
-              close: false,
-              error: false,
-            });
-          }
-
-          // LocalAi returns '' and others return null on chunks - the last chunk is not "" or null.
-          // Either way, the key `finish_reason` must be present to determine ending chunk.
-          if (
-            message?.hasOwnProperty("finish_reason") && // Got valid message and it is an object with finish_reason
-            message.finish_reason !== "" &&
-            message.finish_reason !== null
-          ) {
-            writeResponseChunk(response, {
-              uuid,
-              sources,
-              type: "textResponseChunk",
-              textResponse: "",
-              close: true,
-              error: false,
-            });
-            response.removeListener("close", handleAbort);
-            stream?.endMeasurement(usage);
-            resolve(fullText);
-            break; // Break streaming when a valid finish_reason is first encountered
-          }
-        }
-      } catch (e) {
-        console.log(`\x1b[43m\x1b[34m[STREAMING ERROR]\x1b[0m ${e.message}`);
-        writeResponseChunk(response, {
-          uuid,
-          type: "abort",
-          textResponse: null,
-          sources: [],
-          close: true,
-          error: e.message,
-        });
-        stream?.endMeasurement(usage);
-        resolve(fullText); // Return what we currently have - if anything.
-      }
-    });
+    return handleDefaultStreamResponseV2(response, stream, responseProps);
   }
 
   async embedTextInput(textInput) {

--- a/server/utils/AiProviders/giteeai/index.js
+++ b/server/utils/AiProviders/giteeai/index.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const { v4: uuidv4 } = require("uuid");
 const { safeJsonParse, toValidNumber } = require("../../http");
 const LEGACY_MODEL_MAP = require("../modelMap/legacy");
 const { NativeEmbedder } = require("../../EmbeddingEngines/native");
@@ -8,8 +7,7 @@ const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
 const {
-  writeResponseChunk,
-  clientAbortedHandler,
+  handleDefaultStreamResponseV2,
 } = require("../../helpers/chat/responses");
 const cacheFolder = path.resolve(
   process.env.STORAGE_DIR
@@ -174,143 +172,8 @@ class GiteeAILLM {
     return measuredStreamRequest;
   }
 
-  // TODO: This is a copy of the generic handleStream function in responses.js
-  // to specifically handle the GiteeAI reasoning model `reasoning_content` field.
-  // When or if ever possible, we should refactor this to be in the generic function.
   handleStream(response, stream, responseProps) {
-    const { uuid = uuidv4(), sources = [] } = responseProps;
-    let hasUsageMetrics = false;
-    let usage = {
-      completion_tokens: 0,
-    };
-
-    return new Promise(async (resolve) => {
-      let fullText = "";
-      let reasoningText = "";
-
-      // Establish listener to early-abort a streaming response
-      // in case things go sideways or the user does not like the response.
-      // We preserve the generated text but continue as if chat was completed
-      // to preserve previously generated content.
-      const handleAbort = () => {
-        stream?.endMeasurement(usage);
-        clientAbortedHandler(resolve, fullText);
-      };
-      response.on("close", handleAbort);
-
-      try {
-        for await (const chunk of stream) {
-          const message = chunk?.choices?.[0];
-          const token = message?.delta?.content;
-          const reasoningToken = message?.delta?.reasoning_content;
-
-          if (
-            chunk.hasOwnProperty("usage") && // exists
-            !!chunk.usage && // is not null
-            Object.values(chunk.usage).length > 0 // has values
-          ) {
-            if (chunk.usage.hasOwnProperty("prompt_tokens")) {
-              usage.prompt_tokens = Number(chunk.usage.prompt_tokens);
-            }
-
-            if (chunk.usage.hasOwnProperty("completion_tokens")) {
-              hasUsageMetrics = true; // to stop estimating counter
-              usage.completion_tokens = Number(chunk.usage.completion_tokens);
-            }
-          }
-
-          // Reasoning models will always return the reasoning text before the token text.
-          if (reasoningToken) {
-            // If the reasoning text is empty (''), we need to initialize it
-            // and send the first chunk of reasoning text.
-            if (reasoningText.length === 0) {
-              writeResponseChunk(response, {
-                uuid,
-                sources: [],
-                type: "textResponseChunk",
-                textResponse: `<think>${reasoningToken}`,
-                close: false,
-                error: false,
-              });
-              reasoningText += `<think>${reasoningToken}`;
-              continue;
-            } else {
-              writeResponseChunk(response, {
-                uuid,
-                sources: [],
-                type: "textResponseChunk",
-                textResponse: reasoningToken,
-                close: false,
-                error: false,
-              });
-              reasoningText += reasoningToken;
-            }
-          }
-
-          // If the reasoning text is not empty, but the reasoning token is empty
-          // and the token text is not empty we need to close the reasoning text and begin sending the token text.
-          if (!!reasoningText && !reasoningToken && token) {
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: `</think>`,
-              close: false,
-              error: false,
-            });
-            fullText += `${reasoningText}</think>`;
-            reasoningText = "";
-          }
-
-          if (token) {
-            fullText += token;
-            // If we never saw a usage metric, we can estimate them by number of completion chunks
-            if (!hasUsageMetrics) usage.completion_tokens++;
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: token,
-              close: false,
-              error: false,
-            });
-          }
-
-          // LocalAi returns '' and others return null on chunks - the last chunk is not "" or null.
-          // Either way, the key `finish_reason` must be present to determine ending chunk.
-          if (
-            message?.hasOwnProperty("finish_reason") && // Got valid message and it is an object with finish_reason
-            message.finish_reason !== "" &&
-            message.finish_reason !== null
-          ) {
-            writeResponseChunk(response, {
-              uuid,
-              sources,
-              type: "textResponseChunk",
-              textResponse: "",
-              close: true,
-              error: false,
-            });
-            response.removeListener("close", handleAbort);
-            stream?.endMeasurement(usage);
-            resolve(fullText);
-            break; // Break streaming when a valid finish_reason is first encountered
-          }
-        }
-      } catch (e) {
-        console.log(`\x1b[43m\x1b[34m[STREAMING ERROR]\x1b[0m ${e.message}`);
-        writeResponseChunk(response, {
-          uuid,
-          type: "abort",
-          textResponse: null,
-          sources: [],
-          close: true,
-          error: e.message,
-        });
-        stream?.endMeasurement(usage);
-        resolve(fullText); // Return what we currently have - if anything.
-      }
-    });
+    return handleDefaultStreamResponseV2(response, stream, responseProps);
   }
 
   async embedTextInput(textInput) {

--- a/server/utils/AiProviders/lemonade/index.js
+++ b/server/utils/AiProviders/lemonade/index.js
@@ -136,6 +136,22 @@ class LemonadeLLM {
     ];
   }
 
+  /**
+   * Parses and prepends reasoning from the response and returns the full text response.
+   * Used for getChatCompletions to render thinking text if present in full response.
+   * @param {Object} message - The message object from the Lemonade response.
+   * @returns {string}
+   */
+  #parseReasoningFromResponse({ message }) {
+    let textResponse = message?.content ?? "";
+    if (
+      !!message?.reasoning_content &&
+      message.reasoning_content.trim().length > 0
+    )
+      textResponse = `<think>${message.reasoning_content}</think>${textResponse}`;
+    return textResponse;
+  }
+
   async getChatCompletion(messages = null, { temperature = 0.7 }) {
     await LemonadeLLM.loadModel(this.model);
     const result = await LLMPerformanceMonitor.measureAsyncFunction(
@@ -153,7 +169,7 @@ class LemonadeLLM {
       return null;
 
     return {
-      textResponse: result.output.choices[0].message.content,
+      textResponse: this.#parseReasoningFromResponse(result.output.choices[0]),
       metrics: {
         prompt_tokens: result.output.usage?.prompt_tokens || 0,
         completion_tokens: result.output.usage?.completion_tokens || 0,

--- a/server/utils/AiProviders/lmStudio/index.js
+++ b/server/utils/AiProviders/lmStudio/index.js
@@ -212,6 +212,22 @@ class LMStudioLLM {
     ];
   }
 
+  /**
+   * Parses and prepends reasoning from the response and returns the full text response.
+   * Used for getChatCompletions to render thinking text if present in full response.
+   * @param {Object} message - The message object from the LMStudio response.
+   * @returns {string}
+   */
+  #parseReasoningFromResponse({ message }) {
+    let textResponse = message?.content ?? "";
+    if (
+      !!message?.reasoning_content &&
+      message.reasoning_content.trim().length > 0
+    )
+      textResponse = `<think>${message.reasoning_content}</think>${textResponse}`;
+    return textResponse;
+  }
+
   async getChatCompletion(messages = null, { temperature = 0.7 }) {
     if (!this.model)
       throw new Error(
@@ -233,7 +249,7 @@ class LMStudioLLM {
       return null;
 
     return {
-      textResponse: result.output.choices[0].message.content,
+      textResponse: this.#parseReasoningFromResponse(result.output.choices[0]),
       metrics: {
         prompt_tokens: result.output.usage?.prompt_tokens || 0,
         completion_tokens: result.output.usage?.completion_tokens || 0,

--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -34,6 +34,7 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
 
   return new Promise(async (resolve) => {
     let fullText = "";
+    let reasoningText = "";
 
     // Establish listener to early-abort a streaming response
     // in case things go sideways or the user does not like the response.
@@ -50,6 +51,7 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
       for await (const chunk of stream) {
         const message = chunk?.choices?.[0];
         const token = message?.delta?.content;
+        const reasoningToken = message?.delta?.reasoning_content;
 
         // If we see usage metrics in the chunk, we can use them directly
         // instead of estimating them, but we only want to assign values if
@@ -67,6 +69,49 @@ function handleDefaultStreamResponseV2(response, stream, responseProps) {
             hasUsageMetrics = true; // to stop estimating counter
             usage.completion_tokens = Number(chunk.usage.completion_tokens);
           }
+        }
+
+        // Reasoning models will always return the reasoning text before the token text.
+        if (reasoningToken) {
+          // If the reasoning text is empty (''), we need to initialize it
+          // and send the first chunk of reasoning text.
+          if (reasoningText.length === 0) {
+            writeResponseChunk(response, {
+              uuid,
+              sources: [],
+              type: "textResponseChunk",
+              textResponse: `<think>${reasoningToken}`,
+              close: false,
+              error: false,
+            });
+            reasoningText += `<think>${reasoningToken}`;
+            continue;
+          } else {
+            writeResponseChunk(response, {
+              uuid,
+              sources: [],
+              type: "textResponseChunk",
+              textResponse: reasoningToken,
+              close: false,
+              error: false,
+            });
+            reasoningText += reasoningToken;
+          }
+        }
+
+        // If the reasoning text is not empty, but the reasoning token is empty
+        // and the token text is not empty we need to close the reasoning text and begin sending the token text.
+        if (!!reasoningText && !reasoningToken && token) {
+          writeResponseChunk(response, {
+            uuid,
+            sources: [],
+            type: "textResponseChunk",
+            textResponse: `</think>`,
+            close: false,
+            error: false,
+          });
+          fullText += `${reasoningText}</think>`;
+          reasoningText = "";
         }
 
         if (token) {


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [x] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

closes #5584
resolves #5583
resolves #5585

### Description

Adds option-chained `resoning_content` to the responseHandlerStreamV2 function that can optional preprend thinking blocks to the output for `Lemonade` and `LMStudio` runtimes with reasoning models.

Migrated `deepseek` and `giteeAI` to use this same stream handler as well since they are exact same code now.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
