### PR TITLE
Update DeviceTokens to already-admin user on MUM migration

### DIFF
--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -50,6 +50,7 @@ const {
 const { SlashCommandPresets } = require("../models/slashCommandsPresets");
 const { EncryptionManager } = require("../utils/EncryptionManager");
 const { BrowserExtensionApiKey } = require("../models/browserExtensionApiKey");
+const { MobileDevice } = require("../models/mobileDevice");
 const {
   chatHistoryViewable,
 } = require("../utils/middleware/chatHistoryViewable");
@@ -620,6 +621,7 @@ function systemEndpoints(app) {
           multi_user_mode: true,
         });
         await BrowserExtensionApiKey.migrateApiKeysToMultiUser(user.id);
+        await MobileDevice.migrateDevicesToMultiUser(user.id);
         await AgentSkillWhitelist.clearSingleUserWhitelist();
         await updateENV(
           {

--- a/server/models/mobileDevice.js
+++ b/server/models/mobileDevice.js
@@ -225,6 +225,27 @@ const MobileDevice = {
       return [];
     }
   },
+
+  /**
+   * Migrates all mobile devices with null userId to the specified user.
+   * Called during multi-user mode enablement to assign orphaned devices to the new admin.
+   * @param {number} userId - The admin user ID to assign devices to
+   * @returns {Promise<void>}
+   */
+  migrateDevicesToMultiUser: async function (userId) {
+    try {
+      await prisma.desktop_mobile_devices.updateMany({
+        where: { userId: null },
+        data: { userId: userId },
+      });
+      console.log("Successfully migrated mobile devices to multi-user mode");
+    } catch (error) {
+      console.error(
+        "Error migrating mobile devices to multi-user mode:",
+        error
+      );
+    }
+  },
 };
 
 module.exports = { MobileDevice };


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [x] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves GHSA-h349-hp2v-8rhw

### Description

Migrates already approved admin device to be associated with admin account on migration to MUM to be consistent with other sub-services.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
