### PR TITLE
fix: show outlook client secret on desktop for org account setup

### DIFF
--- a/frontend/src/pages/Admin/Agents/OutlookSkillPanel/index.jsx
+++ b/frontend/src/pages/Admin/Agents/OutlookSkillPanel/index.jsx
@@ -304,7 +304,7 @@ function ConfigurationSection({
   const showTenantId = authType === "organization";
 
   return (
-    <div className="border border-theme-sidebar-border/50 rounded-lg overflow-hidden mt-2">
+    <div className="border border-theme-sidebar-border/50 rounded-lg mt-2">
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
@@ -401,6 +401,37 @@ function ConfigurationSection({
             />
           </div>
 
+          <div className="flex flex-col gap-y-2">
+            <div className="flex items-center gap-x-2">
+              <label className="text-theme-text-primary text-sm font-medium">
+                {t("agent.skill.outlook.clientSecret")}
+              </label>
+              <Info
+                data-tooltip-id="client-secret-tooltip"
+                size={16}
+                className="text-theme-text-secondary"
+              />
+              <Tooltip
+                id="client-secret-tooltip"
+                place="top"
+                delayShow={300}
+                className="tooltip !text-xs !opacity-100"
+              >
+                {t("agent.skill.outlook.clientSecretHelp")}
+              </Tooltip>
+            </div>
+            <input
+              type="password"
+              value={clientSecret}
+              onChange={(e) => {
+                setClientSecret(e.target.value);
+                setHasChanges(true);
+              }}
+              placeholder="Your client secret..."
+              className="w-full px-3 py-2 bg-theme-bg-primary border border-theme-sidebar-border rounded-lg text-theme-text-primary text-sm placeholder:text-theme-text-secondary/50"
+            />
+          </div>
+
           {showTenantId && (
             <div className="flex flex-col gap-y-2">
               <div className="flex items-center gap-x-2">
@@ -433,37 +464,6 @@ function ConfigurationSection({
               />
             </div>
           )}
-
-          <div className="flex flex-col gap-y-2">
-            <div className="flex items-center gap-x-2">
-              <label className="text-theme-text-primary text-sm font-medium">
-                {t("agent.skill.outlook.clientSecret")}
-              </label>
-              <Info
-                data-tooltip-id="client-secret-tooltip"
-                size={16}
-                className="text-theme-text-secondary"
-              />
-              <Tooltip
-                id="client-secret-tooltip"
-                place="top"
-                delayShow={300}
-                className="tooltip !text-xs !opacity-100"
-              >
-                {t("agent.skill.outlook.clientSecretHelp")}
-              </Tooltip>
-            </div>
-            <input
-              type="password"
-              value={clientSecret}
-              onChange={(e) => {
-                setClientSecret(e.target.value);
-                setHasChanges(true);
-              }}
-              placeholder="Your client secret..."
-              className="w-full px-3 py-2 bg-theme-bg-primary border border-theme-sidebar-border rounded-lg text-theme-text-primary text-sm placeholder:text-theme-text-secondary/50"
-            />
-          </div>
 
           {!hasCredentials && (
             <div className="flex items-center gap-x-2 p-3 bg-orange-500/10 border border-orange-500/30 rounded-lg">

--- a/frontend/src/pages/Admin/Agents/index.jsx
+++ b/frontend/src/pages/Admin/Agents/index.jsx
@@ -570,7 +570,7 @@ export default function AdminAgents() {
           if (!selectedSkill?.imported && !selectedFlow) setHasChanges(true);
         }}
         ref={formEl}
-        className="flex-1 flex gap-x-6 p-4 mt-10"
+        className="flex-1 flex gap-x-6 p-4 mt-10 min-h-0 overflow-hidden"
       >
         <input
           name="system::default_agent_skills"
@@ -689,8 +689,8 @@ export default function AdminAgents() {
         </div>
 
         {/* Selected agent skill setting panel */}
-        <div className="flex-[2] flex flex-col gap-y-[18px] mt-10">
-          <div className="bg-theme-bg-secondary text-white rounded-xl flex-1 p-4 overflow-y-scroll overflow-x-visible no-scroll">
+        <div className="flex-[2] flex flex-col gap-y-[18px] mt-10 min-h-0 overflow-hidden">
+          <div className="bg-theme-bg-secondary text-white rounded-xl flex-1 min-h-0 p-4 overflow-y-auto overflow-x-visible no-scroll">
             {SelectedSkillComponent ? (
               <>
                 {selectedMcpServer ? (
@@ -783,7 +783,7 @@ function SkillLayout({ children, hasChanges, handleSubmit, handleCancel }) {
       <Sidebar />
       <div
         style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
-        className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-[16px] w-full h-full flex"
+        className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-[16px] w-full h-full flex min-h-0"
       >
         {children}
         <ContextualSaveBar


### PR DESCRIPTION
#### pull Request Type

- [x] fix (Bug fix)

#### Relevant Issues

- resolves #5659

#### Description

- Desktop Outlook setup hid the Client Secret field when using organization accounts. Reordered fields (Client ID → Client - Secret → Tenant ID), removed config overflow clipping, and fixed agent panel scrolling so the secret input stays visible.

#### Visuals (if applicable)
N/A

#### Additional Information

- frontend/src/pages/Admin/Agents/OutlookSkillPanel/index.jsx
- frontend/src/pages/Admin/Agents/index.jsx

#### Developer Validations

- [ ] yarn lint
- [ ] Tested Outlook org config on desktop
- [ ] Docker build succeeds locally

#### Test plan

- Enable Outlook → Organization accounts only.
- Confirm Client Secret shows between Client ID and Tenant ID.
- Fill all three fields → warning clears.
- Authenticate with Microsoft works with valid credentials.