### PR TITLE
fix: Various Agent Stream Reasoning Bugs & Presentation Refactor

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -57,6 +57,14 @@ const HistoricalMessage = ({
   const isRefusalMessage =
     role === "assistant" && message === chatQueryRefusalResponse(workspace);
 
+  // Agent loop turns that reason and then call a tool emit a message whose
+  // entire content is a `<think>...</think>` block with no visible answer.
+  // Those bubbles have nothing to copy/speak/edit, so suppress the action bar
+  // (otherwise a hover copy button appears under each thought and copies an
+  // empty string once useCopyText strips the reasoning).
+  const hasActionableContent =
+    role !== "assistant" || visibleResponseContent(message).length > 0;
+
   if (completeDelete) return null;
 
   if (!!error) {
@@ -166,25 +174,27 @@ const HistoricalMessage = ({
             <HistoricalOutputs outputs={outputs} />
           </div>
         )}
-        <div className="flex items-start md:items-center gap-x-1">
-          <TTSMessage
-            slug={workspace?.slug}
-            chatId={chatId}
-            message={message}
-          />
-          <Actions
-            message={message}
-            feedbackScore={feedbackScore}
-            chatId={chatId}
-            slug={workspace?.slug}
-            isLastMessage={isLastMessage}
-            regenerateMessage={regenerateMessage}
-            isEditing={isEditing}
-            role={role}
-            forkThread={forkThread}
-            metrics={metrics}
-          />
-        </div>
+        {hasActionableContent && (
+          <div className="flex items-start md:items-center gap-x-1">
+            <TTSMessage
+              slug={workspace?.slug}
+              chatId={chatId}
+              message={message}
+            />
+            <Actions
+              message={message}
+              feedbackScore={feedbackScore}
+              chatId={chatId}
+              slug={workspace?.slug}
+              isLastMessage={isLastMessage}
+              regenerateMessage={regenerateMessage}
+              isEditing={isEditing}
+              role={role}
+              forkThread={forkThread}
+              metrics={metrics}
+            />
+          </div>
+        )}
         {role === "assistant" && <Citations sources={sources} />}
       </div>
     </div>
@@ -290,6 +300,29 @@ function TruncatableContent({ children }) {
       )}
     </>
   );
+}
+
+/**
+ * Returns the visible (non-reasoning) portion of an assistant message — i.e.
+ * what `RenderChatContent` would actually paint as the answer after thought
+ * blocks are collapsed into the ThoughtChainComponent. Used to decide whether
+ * a message is a pure reasoning bubble (no answer) and should skip the action bar.
+ * @param {string} message
+ * @returns {string} the message with `<think>...</think>` blocks removed, trimmed
+ */
+function visibleResponseContent(message = "") {
+  if (!message) return "";
+
+  // Open thought with no matching close = the whole message is reasoning
+  // (mid-stream or aborted), mirroring RenderChatContent's `msgToRender = ""`.
+  if (message.match(THOUGHT_REGEX_OPEN) && !message.match(THOUGHT_REGEX_CLOSE))
+    return "";
+
+  // Strip every complete thought block. The shared THOUGHT_REGEX_COMPLETE has
+  // no `g` flag (and is used with stateful `.match()` elsewhere), so build a
+  // fresh global copy here to catch the multiple-thought agent-loop case too.
+  const completeThoughts = new RegExp(THOUGHT_REGEX_COMPLETE.source, "g");
+  return message.replace(completeThoughts, "").trim();
 }
 
 const RenderChatContent = memo(

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -57,14 +57,6 @@ const HistoricalMessage = ({
   const isRefusalMessage =
     role === "assistant" && message === chatQueryRefusalResponse(workspace);
 
-  // Agent loop turns that reason and then call a tool emit a message whose
-  // entire content is a `<think>...</think>` block with no visible answer.
-  // Those bubbles have nothing to copy/speak/edit, so suppress the action bar
-  // (otherwise a hover copy button appears under each thought and copies an
-  // empty string once useCopyText strips the reasoning).
-  const hasActionableContent =
-    role !== "assistant" || visibleResponseContent(message).length > 0;
-
   if (completeDelete) return null;
 
   if (!!error) {
@@ -174,27 +166,25 @@ const HistoricalMessage = ({
             <HistoricalOutputs outputs={outputs} />
           </div>
         )}
-        {hasActionableContent && (
-          <div className="flex items-start md:items-center gap-x-1">
-            <TTSMessage
-              slug={workspace?.slug}
-              chatId={chatId}
-              message={message}
-            />
-            <Actions
-              message={message}
-              feedbackScore={feedbackScore}
-              chatId={chatId}
-              slug={workspace?.slug}
-              isLastMessage={isLastMessage}
-              regenerateMessage={regenerateMessage}
-              isEditing={isEditing}
-              role={role}
-              forkThread={forkThread}
-              metrics={metrics}
-            />
-          </div>
-        )}
+        <div className="flex items-start md:items-center gap-x-1">
+          <TTSMessage
+            slug={workspace?.slug}
+            chatId={chatId}
+            message={message}
+          />
+          <Actions
+            message={message}
+            feedbackScore={feedbackScore}
+            chatId={chatId}
+            slug={workspace?.slug}
+            isLastMessage={isLastMessage}
+            regenerateMessage={regenerateMessage}
+            isEditing={isEditing}
+            role={role}
+            forkThread={forkThread}
+            metrics={metrics}
+          />
+        </div>
         {role === "assistant" && <Citations sources={sources} />}
       </div>
     </div>
@@ -300,29 +290,6 @@ function TruncatableContent({ children }) {
       )}
     </>
   );
-}
-
-/**
- * Returns the visible (non-reasoning) portion of an assistant message — i.e.
- * what `RenderChatContent` would actually paint as the answer after thought
- * blocks are collapsed into the ThoughtChainComponent. Used to decide whether
- * a message is a pure reasoning bubble (no answer) and should skip the action bar.
- * @param {string} message
- * @returns {string} the message with `<think>...</think>` blocks removed, trimmed
- */
-function visibleResponseContent(message = "") {
-  if (!message) return "";
-
-  // Open thought with no matching close = the whole message is reasoning
-  // (mid-stream or aborted), mirroring RenderChatContent's `msgToRender = ""`.
-  if (message.match(THOUGHT_REGEX_OPEN) && !message.match(THOUGHT_REGEX_CLOSE))
-    return "";
-
-  // Strip every complete thought block. The shared THOUGHT_REGEX_COMPLETE has
-  // no `g` flag (and is used with stateful `.match()` elsewhere), so build a
-  // fresh global copy here to catch the multiple-thought agent-loop case too.
-  const completeThoughts = new RegExp(THOUGHT_REGEX_COMPLETE.source, "g");
-  return message.replace(completeThoughts, "").trim();
 }
 
 const RenderChatContent = memo(

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -24,7 +24,7 @@ import useTextSize from "@/hooks/useTextSize";
 import useChatHistoryScrollHandle from "@/hooks/useChatHistoryScrollHandle";
 import { ThoughtExpansionProvider } from "./ThoughtContainer";
 import { MessageActionsProvider } from "./MessageActionsContext";
-import { useIsAgentSessionActive } from "@/utils/chat/agent";
+import { useIsAgentThinking } from "@/utils/chat/agent";
 
 export default forwardRef(function (
   {
@@ -195,8 +195,10 @@ export default forwardRef(function (
       websocket,
     ]
   );
-  const lastMessageInfo = useMemo(() => getLastMessageInfo(history), [history]);
-  const isAgentSessionActive = useIsAgentSessionActive();
+  // Whether the agent is actively thinking or running a tool right now. Driven
+  // by the live stream events (see useIsAgentThinking), not the last rendered
+  // message - the final answer streaming and the end-of-turn both settle it.
+  const isAgentThinking = useIsAgentThinking();
 
   // Index of the last status group (array entry) in the compiled history. The
   // agent head pulses on this group only - a tool call or the streaming answer
@@ -208,26 +210,17 @@ export default forwardRef(function (
     return -1;
   }, [compiledHistory]);
 
-  // The agent is "working" - and the head should pulse - whenever it is mid-run
-  // and the live tail of the chat is internal activity (reasoning or a tool
-  // call), i.e. status content is still streaming. Once the final answer streams
-  // (a textResponse tail) or the session ends ("Agent session complete."), this
-  // goes false and the head settles to static.
-  const agentIsWorking =
-    isAgentSessionActive &&
-    (lastMessageInfo.isStatusResponse || lastMessageInfo.isToolCallInvocation);
-
   const renderStatusResponse = useCallback(
     (item, index) => {
       return (
         <StatusResponse
           key={`status-group-${index}`}
           messages={item}
-          isThinking={index === lastStatusGroupIndex && agentIsWorking}
+          isThinking={index === lastStatusGroupIndex && isAgentThinking}
         />
       );
     },
-    [lastStatusGroupIndex, agentIsWorking]
+    [lastStatusGroupIndex, isAgentThinking]
   );
 
   return (
@@ -270,15 +263,6 @@ export default forwardRef(function (
     </MessageActionsProvider>
   );
 });
-
-const getLastMessageInfo = (history) => {
-  const lastMessage = history?.[history.length - 1] || {};
-  return {
-    isAnimating: lastMessage?.animate,
-    isStatusResponse: lastMessage?.type === "statusResponse",
-    isToolCallInvocation: lastMessage?.type === "toolCallInvocation",
-  };
-};
 
 /**
  * Builds the history of messages for the chat.

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -24,6 +24,7 @@ import useTextSize from "@/hooks/useTextSize";
 import useChatHistoryScrollHandle from "@/hooks/useChatHistoryScrollHandle";
 import { ThoughtExpansionProvider } from "./ThoughtContainer";
 import { MessageActionsProvider } from "./MessageActionsContext";
+import { useIsAgentSessionActive } from "@/utils/chat/agent";
 
 export default forwardRef(function (
   {
@@ -195,18 +196,38 @@ export default forwardRef(function (
     ]
   );
   const lastMessageInfo = useMemo(() => getLastMessageInfo(history), [history]);
+  const isAgentSessionActive = useIsAgentSessionActive();
+
+  // Index of the last status group (array entry) in the compiled history. The
+  // agent head pulses on this group only - a tool call or the streaming answer
+  // can render below it, so we can't rely on it being the final entry.
+  const lastStatusGroupIndex = useMemo(() => {
+    for (let i = compiledHistory.length - 1; i >= 0; i--) {
+      if (Array.isArray(compiledHistory[i])) return i;
+    }
+    return -1;
+  }, [compiledHistory]);
+
+  // The agent is "working" - and the head should pulse - whenever it is mid-run
+  // and the live tail of the chat is internal activity (reasoning or a tool
+  // call), i.e. status content is still streaming. Once the final answer streams
+  // (a textResponse tail) or the session ends ("Agent session complete."), this
+  // goes false and the head settles to static.
+  const agentIsWorking =
+    isAgentSessionActive &&
+    (lastMessageInfo.isStatusResponse || lastMessageInfo.isToolCallInvocation);
+
   const renderStatusResponse = useCallback(
     (item, index) => {
-      const hasSubsequentMessages = index < compiledHistory.length - 1;
       return (
         <StatusResponse
           key={`status-group-${index}`}
           messages={item}
-          isThinking={!hasSubsequentMessages && lastMessageInfo.isAnimating}
+          isThinking={index === lastStatusGroupIndex && agentIsWorking}
         />
       );
     },
-    [compiledHistory.length, lastMessageInfo]
+    [lastStatusGroupIndex, agentIsWorking]
   );
 
   return (
@@ -255,6 +276,7 @@ const getLastMessageInfo = (history) => {
   return {
     isAnimating: lastMessage?.animate,
     isStatusResponse: lastMessage?.type === "statusResponse",
+    isToolCallInvocation: lastMessage?.type === "toolCallInvocation",
   };
 };
 

--- a/frontend/src/utils/chat/agent.js
+++ b/frontend/src/utils/chat/agent.js
@@ -7,6 +7,30 @@ import { THREAD_RENAME_EVENT } from "@/components/Sidebar/ActiveWorkspaces/Threa
 
 export const AGENT_SESSION_START = "agentSessionStart";
 export const AGENT_SESSION_END = "agentSessionEnd";
+export const AGENT_THINKING_START = "agentThinkingStart";
+export const AGENT_THINKING_STOP = "agentThinkingStop";
+
+// Stream event types that mean the agent is actively doing internal work (a
+// thought or a tool call) - the head should pulse. Anything that produces the
+// final answer or signals the turn is over settles it. usageMetrics/chatId are
+// emitted by the agent backend at the end of every turn (even when the answer is
+// empty), so they reliably stop the pulse instead of us trying to guess from the
+// last message - which can be a leftover reasoning bubble that never settles.
+const AGENT_THINKING_EVENTS = ["statusResponse", "toolCallInvocation"];
+const AGENT_SETTLED_EVENTS = [
+  "fullTextResponse",
+  "textResponseChunk",
+  "usageMetrics",
+  "chatId",
+];
+
+function reportAgentThinking(streamEventType) {
+  if (AGENT_THINKING_EVENTS.includes(streamEventType))
+    window.dispatchEvent(new CustomEvent(AGENT_THINKING_START));
+  else if (AGENT_SETTLED_EVENTS.includes(streamEventType))
+    window.dispatchEvent(new CustomEvent(AGENT_THINKING_STOP));
+}
+
 const handledEvents = [
   "statusResponse",
   "fileDownloadCard",
@@ -77,6 +101,11 @@ export default function handleSocketResponse(socket, event, setChatHistory) {
     // trigger TTS auto-play
     if (data.content?.type === "chatId" && data.content?.chatId)
       emitAssistantMessageCompleteEvent(data.content.chatId);
+
+    // Drive the agent head animation off the live event stream rather than the
+    // last rendered message - a thought/tool call pulses it, the answer or the
+    // end-of-turn markers settle it.
+    reportAgentThinking(data.content?.type);
 
     return setChatHistory((prev) => {
       if (data.content.type === "removeStatusResponse")
@@ -337,4 +366,26 @@ export function useIsAgentSessionActive() {
   }, []);
 
   return activeSession;
+}
+
+export function useIsAgentThinking() {
+  const [thinking, setThinking] = useState(false);
+  useEffect(() => {
+    if (!window) return;
+    const start = () => setThinking(true);
+    const stop = () => setThinking(false);
+    window.addEventListener(AGENT_THINKING_START, start);
+    window.addEventListener(AGENT_THINKING_STOP, stop);
+    // A session boundary always settles the head - the previous turn is done.
+    window.addEventListener(AGENT_SESSION_START, stop);
+    window.addEventListener(AGENT_SESSION_END, stop);
+    return () => {
+      window.removeEventListener(AGENT_THINKING_START, start);
+      window.removeEventListener(AGENT_THINKING_STOP, stop);
+      window.removeEventListener(AGENT_SESSION_START, stop);
+      window.removeEventListener(AGENT_SESSION_END, stop);
+    };
+  }, []);
+
+  return thinking;
 }

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -186,6 +186,10 @@ async function tooledStream(
   }
 
   const msgUUID = v4();
+  // Reasoning streams under its own uuid so it stays a separate status bubble.
+  // Reusing `msgUUID` would let the answer's `textResponseChunk` merge into the
+  // reasoning message on the frontend and render the thoughts as visible text.
+  const reasoningUUID = `${msgUUID}:reasoning`;
   const formattedMessages = formatMessagesForTools(messages, formatOptions);
   const tools = formatFunctionsToTools(functions);
 
@@ -207,17 +211,12 @@ async function tooledStream(
   let usage = null;
   let reasoningText = "";
 
-  // Emit a `</think>` chunk and reset reasoning state. Used whenever we
-  // transition out of a reasoning stretch (into visible text, into a tool
-  // call, or at end of stream) so the frontend regex stays balanced.
+  // `reasoningText` tracks whether we're mid-thought; it gates the "Thinking:"
+  // header that prefixes the first reasoning token (see below). Clear it
+  // whenever we leave a reasoning stretch - into visible text, a tool call, or
+  // end of stream - so a later stretch starts a fresh status bubble.
   const closeReasoningIfOpen = () => {
     if (reasoningText.length === 0) return;
-    result.textResponse += "</think>";
-    eventHandler?.("reportStreamEvent", {
-      type: "textResponseChunk",
-      uuid: msgUUID,
-      content: "</think>",
-    });
     reasoningText = "";
   };
 
@@ -231,20 +230,22 @@ async function tooledStream(
     const choice = chunk.choices[0];
 
     // Reasoning models (LM Studio, Lemonade, DeepSeek, etc.) emit thinking
-    // tokens via `delta.reasoning_content`. Wrap them in <think>...</think>
-    // so the frontend's ThoughtContainer collapses them into a pane.
+    // tokens via `delta.reasoning_content`. Reasoning is ephemeral debug
+    // output, so surface it live as a `statusResponse` (collapsing into the
+    // same status group as tool activity) and never persist it to the message.
     const reasoningToken = choice.delta?.reasoning_content;
     if (reasoningToken) {
-      const wrappedChunk =
+      const liveChunk =
         reasoningText.length === 0
-          ? `<think>${reasoningToken}`
+          ? `Thinking:\n\n${reasoningToken}`
           : reasoningToken;
+
       reasoningText += reasoningToken;
-      result.textResponse += wrappedChunk;
+
       eventHandler?.("reportStreamEvent", {
-        type: "textResponseChunk",
-        uuid: msgUUID,
-        content: wrappedChunk,
+        type: "statusResponse",
+        uuid: reasoningUUID,
+        content: liveChunk,
       });
     }
 
@@ -410,13 +411,9 @@ async function tooledComplete(
     };
   }
 
-  // Wrap any reasoning content in <think>...</think> so the frontend can
-  // collapse it into a thought pane, matching the streaming path.
-  const reasoning = completion.reasoning_content;
-  const textResponse =
-    reasoning && reasoning.trim().length > 0
-      ? `<think>${reasoning}</think>${completion.content ?? ""}`
-      : completion.content;
+  // Non-streaming path: reasoning_content is neither surfaced nor persisted
+  // (only the streaming path shows reasoning live). Return the visible answer.
+  const textResponse = completion.content;
 
   return {
     textResponse,

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -205,6 +205,21 @@ async function tooledStream(
 
   const toolCallsByIndex = {};
   let usage = null;
+  let reasoningText = "";
+
+  // Emit a `</think>` chunk and reset reasoning state. Used whenever we
+  // transition out of a reasoning stretch (into visible text, into a tool
+  // call, or at end of stream) so the frontend regex stays balanced.
+  const closeReasoningIfOpen = () => {
+    if (reasoningText.length === 0) return;
+    result.textResponse += "</think>";
+    eventHandler?.("reportStreamEvent", {
+      type: "textResponseChunk",
+      uuid: msgUUID,
+      content: "</think>",
+    });
+    reasoningText = "";
+  };
 
   for await (const chunk of stream) {
     // Capture usage from final chunk (some providers send usage after finish_reason)
@@ -215,7 +230,26 @@ async function tooledStream(
     if (!chunk?.choices?.[0]) continue;
     const choice = chunk.choices[0];
 
+    // Reasoning models (LM Studio, Lemonade, DeepSeek, etc.) emit thinking
+    // tokens via `delta.reasoning_content`. Wrap them in <think>...</think>
+    // so the frontend's ThoughtContainer collapses them into a pane.
+    const reasoningToken = choice.delta?.reasoning_content;
+    if (reasoningToken) {
+      const wrappedChunk =
+        reasoningText.length === 0
+          ? `<think>${reasoningToken}`
+          : reasoningToken;
+      reasoningText += reasoningToken;
+      result.textResponse += wrappedChunk;
+      eventHandler?.("reportStreamEvent", {
+        type: "textResponseChunk",
+        uuid: msgUUID,
+        content: wrappedChunk,
+      });
+    }
+
     if (choice.delta?.content) {
+      closeReasoningIfOpen();
       result.textResponse += choice.delta.content;
       eventHandler?.("reportStreamEvent", {
         type: "textResponseChunk",
@@ -225,6 +259,7 @@ async function tooledStream(
     }
 
     if (choice.delta?.tool_calls) {
+      closeReasoningIfOpen();
       for (const toolCall of choice.delta.tool_calls) {
         const idx = toolCall.index ?? 0;
 
@@ -259,6 +294,10 @@ async function tooledStream(
       }
     }
   }
+
+  // Defensive close in case the stream ended mid-reasoning (e.g. abort, or a
+  // provider that emits reasoning but no follow-up content/tool_call).
+  closeReasoningIfOpen();
 
   // Auto-record usage if provider is passed and usage is available
   if (provider?.recordUsage && usage) {
@@ -371,8 +410,16 @@ async function tooledComplete(
     };
   }
 
+  // Wrap any reasoning content in <think>...</think> so the frontend can
+  // collapse it into a thought pane, matching the streaming path.
+  const reasoning = completion.reasoning_content;
+  const textResponse =
+    reasoning && reasoning.trim().length > 0
+      ? `<think>${reasoning}</think>${completion.content ?? ""}`
+      : completion.content;
+
   return {
-    textResponse: completion.content,
+    textResponse,
     cost,
     usage,
   };

--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -201,6 +201,10 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
     // when no tool call is parsed.
     let textResponse = "";
     let reasoningText = "";
+    // Tracks whether this turn has streamed any reasoning. We use it to hold
+    // back the live content preview only while a model is actively reasoning -
+    // see the content block below for why.
+    let sawReasoning = false;
     const historyMessages = this.buildToolCallMessages(history, functions);
     const stream = await chatCb({ messages: historyMessages });
 
@@ -214,13 +218,17 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
       if (!chunk?.choices?.[0]) continue; // Skip if no choices
       const choice = chunk.choices[0];
 
-      const reasoningToken = choice.delta?.reasoning_content;
+      // Reasoning field varies by provider: DeepSeek/LMStudio/Lemonade use
+      // `reasoning_content`, OpenRouter uses `reasoning`. Accept either.
+      const reasoningToken =
+        choice.delta?.reasoning_content ?? choice.delta?.reasoning;
       if (reasoningToken) {
         const liveChunk =
           reasoningText.length === 0
             ? `Thinking:\n\n${reasoningToken}`
             : reasoningToken;
         reasoningText += reasoningToken;
+        sawReasoning = true;
         eventHandler?.("reportStreamEvent", {
           type: "statusResponse",
           uuid: reasoningUUID,
@@ -233,11 +241,20 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
         // fresh "Thinking:" bubble.
         if (reasoningText.length > 0) reasoningText = "";
         textResponse += choice.delta.content;
-        eventHandler?.("reportStreamEvent", {
-          type: "statusResponse",
-          uuid: msgUUID,
-          content: choice.delta.content,
-        });
+
+        // Stream the content preview live so the user sees progress - EXCEPT
+        // when the model has reasoned this turn. The preview shares the
+        // reasoning's status group, and the collapsed bubble only shows its
+        // last entry, so a streaming preview would overtake the thoughts and
+        // make them appear to vanish. When there's no reasoning, there are no
+        // thoughts to bury, so we keep the live preview.
+        if (!sawReasoning) {
+          eventHandler?.("reportStreamEvent", {
+            type: "statusResponse",
+            uuid: msgUUID,
+            content: choice.delta.content,
+          });
+        }
       }
     }
 
@@ -381,8 +398,10 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           const choice = chunk.choices[0];
 
           // Reasoning is ephemeral debug output - surface it live as a
-          // `statusResponse` and never persist it to the message.
-          const reasoningToken = choice.delta?.reasoning_content;
+          // `statusResponse` and never persist it to the message. Field name
+          // varies by provider (`reasoning_content` vs OpenRouter's `reasoning`).
+          const reasoningToken =
+            choice.delta?.reasoning_content ?? choice.delta?.reasoning;
           if (reasoningToken) {
             const liveChunk =
               reasoningText.length === 0

--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -191,14 +191,12 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
 
     const msgUUID = v4();
     // `textResponse` stays content-only so safeJsonParse below can still
-    // match a tool-call JSON payload. `displayedResponse` mirrors what was
-    // shown to the user — reasoning wrapped in <think>...</think> followed
-    // by content — and is returned as the text response when no tool call
-    // is parsed. The live status bubble uses human-readable framing
-    // ("Thinking:" / "Done thinking.") instead of raw tags because the
-    // StatusResponse component renders text literally.
+    // match a tool-call JSON payload, and is returned as the text response
+    // when no tool call is parsed. Reasoning is ephemeral and never persisted;
+    // it is surfaced live in the status bubble with human-readable framing
+    // ("Thinking:" / "Done thinking.") because the StatusResponse component
+    // renders text literally.
     let textResponse = "";
-    let displayedResponse = "";
     let reasoningText = "";
     const historyMessages = this.buildToolCallMessages(history, functions);
     const stream = await chatCb({ messages: historyMessages });
@@ -219,10 +217,6 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           reasoningText.length === 0
             ? `Thinking:\n\n${reasoningToken}`
             : reasoningToken;
-        displayedResponse +=
-          reasoningText.length === 0
-            ? `<think>${reasoningToken}`
-            : reasoningToken;
         reasoningText += reasoningToken;
         eventHandler?.("reportStreamEvent", {
           type: "statusResponse",
@@ -237,11 +231,9 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           ? `\n\nDone thinking.\n\n${choice.delta.content}`
           : choice.delta.content;
         if (closingReasoning) {
-          displayedResponse += `</think>`;
           reasoningText = "";
         }
         textResponse += choice.delta.content;
-        displayedResponse += choice.delta.content;
         eventHandler?.("reportStreamEvent", {
           type: "statusResponse",
           uuid: msgUUID,
@@ -250,17 +242,9 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
       }
     }
 
-    // Stream ended while still inside a reasoning block (e.g. model
-    // produced only reasoning then stopped). Close the tag in the
-    // returned text so the frontend regex stays balanced.
-    if (reasoningText.length > 0) {
-      displayedResponse += `</think>`;
-      reasoningText = "";
-    }
-
     const call = safeJsonParse(textResponse, null);
     if (call === null)
-      return { toolCall: null, text: displayedResponse, uuid: msgUUID }; // failed to parse, so must be regular text response.
+      return { toolCall: null, text: textResponse, uuid: msgUUID }; // failed to parse, so must be regular text response.
 
     const { valid, reason } = this.validFuncCall(call, functions);
     if (!valid) {
@@ -378,6 +362,10 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           "Will assume chat completion without tool call inputs."
         );
         const msgUUID = v4();
+        // Reasoning streams under its own uuid so it stays a separate status
+        // bubble. Reusing `msgUUID` would let the answer's `textResponseChunk`
+        // merge into the reasoning message and render the thoughts as text.
+        const reasoningUUID = `${msgUUID}:reasoning`;
         completion = { content: "" };
         let reasoningText = "";
         const stream = await chatCallback({
@@ -386,12 +374,6 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
 
         const closeReasoningIfOpen = () => {
           if (reasoningText.length === 0) return;
-          completion.content += "</think>";
-          eventHandler?.("reportStreamEvent", {
-            type: "textResponseChunk",
-            uuid: msgUUID,
-            content: "</think>",
-          });
           reasoningText = "";
         };
 
@@ -399,18 +381,19 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           if (!chunk?.choices?.[0]) continue; // Skip if no choices
           const choice = chunk.choices[0];
 
+          // Reasoning is ephemeral debug output - surface it live as a
+          // `statusResponse` and never persist it to the message.
           const reasoningToken = choice.delta?.reasoning_content;
           if (reasoningToken) {
-            const wrappedChunk =
+            const liveChunk =
               reasoningText.length === 0
-                ? `<think>${reasoningToken}`
+                ? `Thinking:\n\n${reasoningToken}`
                 : reasoningToken;
             reasoningText += reasoningToken;
-            completion.content += wrappedChunk;
             eventHandler?.("reportStreamEvent", {
-              type: "textResponseChunk",
-              uuid: msgUUID,
-              content: wrappedChunk,
+              type: "statusResponse",
+              uuid: reasoningUUID,
+              content: liveChunk,
             });
           }
 
@@ -493,13 +476,9 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           completion = { content: response };
         } else {
           const message = response.choices?.[0]?.message ?? {};
-          const reasoning = message.reasoning_content;
-          completion = {
-            content:
-              reasoning && reasoning.trim().length > 0
-                ? `<think>${reasoning}</think>${message.content ?? ""}`
-                : message.content,
-          };
+          // Non-streaming path: reasoning_content is neither surfaced nor
+          // persisted; keep only the visible answer.
+          completion = { content: message.content };
         }
       }
 

--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -190,7 +190,16 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
     if (history[history.length - 1].role !== "user") return null;
 
     const msgUUID = v4();
+    // `textResponse` stays content-only so safeJsonParse below can still
+    // match a tool-call JSON payload. `displayedResponse` mirrors what was
+    // shown to the user — reasoning wrapped in <think>...</think> followed
+    // by content — and is returned as the text response when no tool call
+    // is parsed. The live status bubble uses human-readable framing
+    // ("Thinking:" / "Done thinking.") instead of raw tags because the
+    // StatusResponse component renders text literally.
     let textResponse = "";
+    let displayedResponse = "";
+    let reasoningText = "";
     const historyMessages = this.buildToolCallMessages(history, functions);
     const stream = await chatCb({ messages: historyMessages });
 
@@ -204,19 +213,54 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
       if (!chunk?.choices?.[0]) continue; // Skip if no choices
       const choice = chunk.choices[0];
 
-      if (choice.delta?.content) {
-        textResponse += choice.delta.content;
+      const reasoningToken = choice.delta?.reasoning_content;
+      if (reasoningToken) {
+        const liveChunk =
+          reasoningText.length === 0
+            ? `Thinking:\n\n${reasoningToken}`
+            : reasoningToken;
+        displayedResponse +=
+          reasoningText.length === 0
+            ? `<think>${reasoningToken}`
+            : reasoningToken;
+        reasoningText += reasoningToken;
         eventHandler?.("reportStreamEvent", {
           type: "statusResponse",
           uuid: msgUUID,
-          content: choice.delta.content,
+          content: liveChunk,
+        });
+      }
+
+      if (choice.delta?.content) {
+        const closingReasoning = reasoningText.length > 0;
+        const liveChunk = closingReasoning
+          ? `\n\nDone thinking.\n\n${choice.delta.content}`
+          : choice.delta.content;
+        if (closingReasoning) {
+          displayedResponse += `</think>`;
+          reasoningText = "";
+        }
+        textResponse += choice.delta.content;
+        displayedResponse += choice.delta.content;
+        eventHandler?.("reportStreamEvent", {
+          type: "statusResponse",
+          uuid: msgUUID,
+          content: liveChunk,
         });
       }
     }
 
+    // Stream ended while still inside a reasoning block (e.g. model
+    // produced only reasoning then stopped). Close the tag in the
+    // returned text so the frontend regex stays balanced.
+    if (reasoningText.length > 0) {
+      displayedResponse += `</think>`;
+      reasoningText = "";
+    }
+
     const call = safeJsonParse(textResponse, null);
     if (call === null)
-      return { toolCall: null, text: textResponse, uuid: msgUUID }; // failed to parse, so must be regular text response.
+      return { toolCall: null, text: displayedResponse, uuid: msgUUID }; // failed to parse, so must be regular text response.
 
     const { valid, reason } = this.validFuncCall(call, functions);
     if (!valid) {
@@ -335,14 +379,43 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
         );
         const msgUUID = v4();
         completion = { content: "" };
+        let reasoningText = "";
         const stream = await chatCallback({
           messages: this.cleanMsgs(messages),
         });
 
+        const closeReasoningIfOpen = () => {
+          if (reasoningText.length === 0) return;
+          completion.content += "</think>";
+          eventHandler?.("reportStreamEvent", {
+            type: "textResponseChunk",
+            uuid: msgUUID,
+            content: "</think>",
+          });
+          reasoningText = "";
+        };
+
         for await (const chunk of stream) {
           if (!chunk?.choices?.[0]) continue; // Skip if no choices
           const choice = chunk.choices[0];
+
+          const reasoningToken = choice.delta?.reasoning_content;
+          if (reasoningToken) {
+            const wrappedChunk =
+              reasoningText.length === 0
+                ? `<think>${reasoningToken}`
+                : reasoningToken;
+            reasoningText += reasoningToken;
+            completion.content += wrappedChunk;
+            eventHandler?.("reportStreamEvent", {
+              type: "textResponseChunk",
+              uuid: msgUUID,
+              content: wrappedChunk,
+            });
+          }
+
           if (choice.delta?.content) {
+            closeReasoningIfOpen();
             completion.content += choice.delta.content;
             eventHandler?.("reportStreamEvent", {
               type: "textResponseChunk",
@@ -351,6 +424,8 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
             });
           }
         }
+
+        closeReasoningIfOpen();
       }
 
       // The UnTooled class inherited Deduplicator is mostly useful to prevent the agent
@@ -414,10 +489,18 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
         // If the response from the callback is the raw OpenAI Spec response object, we can use that directly.
         // Otherwise, we will assume the response is just the string output we wanted (see: `#handleFunctionCallChat` which returns the content only)
         // This handles both streaming and non-streaming completions.
-        completion =
-          typeof response === "string"
-            ? { content: response }
-            : response.choices?.[0]?.message;
+        if (typeof response === "string") {
+          completion = { content: response };
+        } else {
+          const message = response.choices?.[0]?.message ?? {};
+          const reasoning = message.reasoning_content;
+          completion = {
+            content:
+              reasoning && reasoning.trim().length > 0
+                ? `<think>${reasoning}</think>${message.content ?? ""}`
+                : message.content,
+          };
+        }
       }
 
       // The UnTooled class inherited Deduplicator is mostly useful to prevent the agent

--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -190,12 +190,15 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
     if (history[history.length - 1].role !== "user") return null;
 
     const msgUUID = v4();
+    // Reasoning streams under its own uuid so it stays a separate status bubble
+    // that survives after the turn. The tentative tool-call/answer text streams
+    // under `msgUUID` and is removed once we know what it was - so it must not
+    // share a uuid with the reasoning, or removing it would take the thoughts
+    // with it (matches the tooled.js / second-stream behavior below).
+    const reasoningUUID = `${msgUUID}:reasoning`;
     // `textResponse` stays content-only so safeJsonParse below can still
     // match a tool-call JSON payload, and is returned as the text response
-    // when no tool call is parsed. Reasoning is ephemeral and never persisted;
-    // it is surfaced live in the status bubble with human-readable framing
-    // ("Thinking:" / "Done thinking.") because the StatusResponse component
-    // renders text literally.
+    // when no tool call is parsed.
     let textResponse = "";
     let reasoningText = "";
     const historyMessages = this.buildToolCallMessages(history, functions);
@@ -220,24 +223,20 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
         reasoningText += reasoningToken;
         eventHandler?.("reportStreamEvent", {
           type: "statusResponse",
-          uuid: msgUUID,
+          uuid: reasoningUUID,
           content: liveChunk,
         });
       }
 
       if (choice.delta?.content) {
-        const closingReasoning = reasoningText.length > 0;
-        const liveChunk = closingReasoning
-          ? `\n\nDone thinking.\n\n${choice.delta.content}`
-          : choice.delta.content;
-        if (closingReasoning) {
-          reasoningText = "";
-        }
+        // Leaving the reasoning stretch - reset so a later stretch starts a
+        // fresh "Thinking:" bubble.
+        if (reasoningText.length > 0) reasoningText = "";
         textResponse += choice.delta.content;
         eventHandler?.("reportStreamEvent", {
           type: "statusResponse",
           uuid: msgUUID,
-          content: liveChunk,
+          content: choice.delta.content,
         });
       }
     }

--- a/server/utils/agents/aibitat/providers/ollama.js
+++ b/server/utils/agents/aibitat/providers/ollama.js
@@ -318,6 +318,10 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       this.resetUsage();
       await OllamaAILLM.cacheContextWindows();
       const msgUUID = v4();
+      // Reasoning streams under its own uuid so it stays a separate status
+      // bubble. Reusing `msgUUID` would let the answer's `textResponseChunk`
+      // merge into the reasoning message and render the thoughts as text.
+      const reasoningUUID = `${msgUUID}:reasoning`;
       const formattedMessages = this.#formatMessagesForOllamaTools(messages);
       const tools = formatFunctionsToTools(functions);
 
@@ -331,6 +335,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       });
 
       let textResponse = "";
+      let reasoningText = "";
       let toolCalls = null;
 
       for await (const chunk of stream) {
@@ -344,7 +349,23 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
 
         if (!chunk?.message) continue;
 
+        // Reasoning is ephemeral debug output - surface it live as a
+        // `statusResponse` and never persist it to the message.
+        if (chunk.message.thinking) {
+          const liveChunk =
+            reasoningText.length === 0
+              ? `Thinking:\n\n${chunk.message.thinking}`
+              : chunk.message.thinking;
+          reasoningText += chunk.message.thinking;
+          eventHandler?.("reportStreamEvent", {
+            type: "statusResponse",
+            uuid: reasoningUUID,
+            content: liveChunk,
+          });
+        }
+
         if (chunk.message.content) {
+          reasoningText = "";
           textResponse += chunk.message.content;
           eventHandler?.("reportStreamEvent", {
             type: "textResponseChunk",
@@ -354,6 +375,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
         }
 
         if (chunk.message.tool_calls?.length > 0) {
+          reasoningText = "";
           toolCalls = chunk.message.tool_calls;
           eventHandler?.("reportStreamEvent", {
             uuid: `${msgUUID}:tool_call_invocation`,
@@ -452,9 +474,12 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
           "Will assume chat completion without tool call inputs."
         );
         const msgUUID = v4();
+        // Reasoning streams under its own uuid so it stays a separate status
+        // bubble. Reusing `msgUUID` would let the answer's `textResponseChunk`
+        // merge into the reasoning message and render the thoughts as text.
+        const reasoningUUID = `${msgUUID}:reasoning`;
         completion = { content: "" };
         let reasoningText = "";
-        let token = "";
         const stream = await this.#handleFunctionCallStream({
           messages: this.cleanMsgs(messages),
         });
@@ -462,31 +487,32 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
         for await (const chunk of stream) {
           if (!chunk.hasOwnProperty("message")) continue;
 
-          const content = chunk.message?.content;
+          // Reasoning is ephemeral debug output - surface it live as a
+          // `statusResponse` and never persist it to the message.
           const reasoningToken = chunk.message?.thinking;
           if (reasoningToken) {
-            if (reasoningText.length === 0) {
-              reasoningText = `<think>${reasoningToken}`;
-              token = `<think>${reasoningToken}`;
-            } else {
-              reasoningText += reasoningToken;
-              token = reasoningToken;
-            }
-          } else if (content.length > 0) {
-            if (reasoningText.length > 0) {
-              token = `</think>${content}`;
-              reasoningText = "";
-            } else {
-              token = content;
-            }
+            const liveChunk =
+              reasoningText.length === 0
+                ? `Thinking:\n\n${reasoningToken}`
+                : reasoningToken;
+            reasoningText += reasoningToken;
+            eventHandler?.("reportStreamEvent", {
+              type: "statusResponse",
+              uuid: reasoningUUID,
+              content: liveChunk,
+            });
           }
 
-          completion.content += token;
-          eventHandler?.("reportStreamEvent", {
-            type: "textResponseChunk",
-            uuid: msgUUID,
-            content: token,
-          });
+          const content = chunk.message?.content;
+          if (content) {
+            reasoningText = "";
+            completion.content += content;
+            eventHandler?.("reportStreamEvent", {
+              type: "textResponseChunk",
+              uuid: msgUUID,
+              content,
+            });
+          }
         }
       }
 


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5676
UPSTREAM PR: https://github.com/Mintplex-Labs/anything-llm/pull/5972

### TLDR

This PR fixes a few things:

- Surfaces thinking tokens in agent mode for both the `tooledStream` and `untooled` stream pathways (any provider emitting `reasoning_content`), instead of only Ollama.
- Unifies how reasoning is presented: it now streams live into the collapsible `StatusResponse` bubble (same place tool activity shows) and is ephemeral — a reloaded conversation shows only tool status + the final answer. This replaces the old `<think>` thought-pane that stacked a separate pane per step.
- Ollama stream refactor: Ollama does not use `tooled` or `untooled`stream pathways, instead its own bespoke implementation using `</think>` tags. It has been refactored to match the behavior in `tooled` and `untooled` 
- Fixes the pulsing head icon. It used to stop pulsing the moment a tool call or the answer rendered, and on untooled reasoning turns it could get stuck pulsing forever. It now pulses through the whole agent status stream (thinking + tool calls) and settles to static once the final response streams or the agent goes idle.
- Fixes untooled streams where the thoughts would vanish the instant the final response started streaming — they now persist in the collapsible status bubble, matching tooled.


### Description

In agent mode, only `ollama` surfaced reasoning — and it did so as a standalone `<think>` thought pane that was persisted into the saved message. Every other provider routing through the shared OpenAI-compatible helpers (`tooled.js` / `untooled.js`) dropped `reasoning_content` entirely, so users got a long pause then only the final answer.

This PR does two things:

- **Surfaces reasoning for all providers** routing through the shared helpers (any model emitting `reasoning_content`).
- **Unifies how reasoning is presented.** It now streams live into the collapsible `StatusResponse` bubble (the same place tool activity shows), framed with `"Thinking:"`, and is no longer persisted — a reloaded conversation shows only tool status + the final answer. This replaces the old `<think>` thought-pane approach, which stacked a separate pane per step in multi-step runs (per review feedback).

This is a behavior change for Ollama too: its agent reasoning used to render as a thought pane and survive reload, and is now ephemeral.

**Scope:**
- Covered: the streaming paths (`tooledStream`, `UnTooled.stream` / `streamingFunctionCall`) plus Ollama.
- Out of scope (native, non-OpenAI-shaped reasoning streams, follow-up?): `anthropic.js`, `openai.js`, `gemini.js`, `bedrock.js`. 
- Regular (non-agent) chat is unchanged — it still persists reasoning as `<think>` panes. The agent/regular asymmetry is noted for a separate discussion.

**Implementation notes:**
- Reasoning streams under its own event id (`${msgUUID}:reasoning`) so the answer's `textResponseChunk` doesn't merge into the reasoning bubble and render thoughts as visible text.
- Frontend: the TTS/copy action bar is now gated on a `visibleResponseContent()` helper so reasoning-only bubbles don't get a copy button that copies an empty string.

**Agent head animation (pulse) fix:**

The animated agent head is meant to pulse while the agent is actively thinking or invoking a tool, and go static once the final answer is streaming or the agent is idle. It was instead deriving "is the agent working" from the chat tail — pulse while a session is open and the last message is a status bubble. In an interactive `@agent` session the socket stays open between turns, so any turn that ended on a status bubble (e.g. an untooled reasoning turn that finished on a thought with no trailing answer) left the head pulsing forever.

It now drives the animation off the live stream events instead of the rendered tail:
- A `statusResponse` (thinking) or `toolCallInvocation` event starts the pulse.
- The final answer (`textResponseChunk` / `fullTextResponse`) or the end-of-turn markers (`usageMetrics` / `chatId`, which the agent backend emits at the end of every turn even when the answer is empty) settle it to static, as does a session start/end.

This is tracked with a small `useIsAgentThinking()` hook (mirroring `useIsAgentSessionActive`) fed by `AGENT_THINKING_START` / `AGENT_THINKING_STOP` events dispatched from the websocket handler.

**Untooled reasoning persistence fix:**

In tooled mode the reasoning bubble persists after the answer lands (collapsible), but in untooled mode the thoughts disappeared the moment the response finished. `streamingFunctionCall` was streaming both the reasoning and the tentative tool-call/answer preview under the same `msgUUID`, then calling `removeStatusResponse(msgUUID)` to clear the preview once the turn resolved — which wiped the thoughts along with it. Reasoning now streams under its own `${msgUUID}:reasoning` bubble so the cleanup only removes the preview, matching `tooled.js` and the existing second-stream path.

### Visuals (if applicable)

<img width="1144" height="429" alt="image" src="https://github.com/user-attachments/assets/ff9f897f-62c5-4725-b7e1-cbc122b51002" />

### Additional Information

- Tested across tooled and untooled paths with reasoning models (LM Studio, Koboldcpp, DeepSeek, Lemonade, Moonshot) in both agent and regular chat.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
