### PR TITLE
router-models: accurate token/message counting for model router decisions

### DIFF
--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -434,6 +434,7 @@ export const AVAILABLE_LLM_PROVIDERS = [
       "GenericOpenAiTokenLimit",
       "GenericOpenAiKey",
     ],
+    connectionConfig: ["GenericOpenAiBasePath"],
   },
 ];
 

--- a/frontend/src/pages/GeneralSettings/ModelRouters/LLMProviderModelPicker/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/LLMProviderModelPicker/index.jsx
@@ -50,8 +50,9 @@ export default function LLMProviderModelPicker({
   function isConfigured(providerValue) {
     if (!settings) return true;
     const llm = availableProviders.find((l) => l.value === providerValue);
-    if (!llm?.requiredConfig?.length) return true;
-    return llm.requiredConfig.every((key) => !!settings[key]);
+    const keys = llm?.connectionConfig || llm?.requiredConfig;
+    if (!keys?.length) return true;
+    return keys.every((key) => !!settings[key]);
   }
 
   useEffect(() => {

--- a/frontend/src/pages/GeneralSettings/ModelRouters/NewRouterModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/NewRouterModal/index.jsx
@@ -168,11 +168,7 @@ export default function NewRouterModal({
               {loading ? (
                 <>
                   <CircleNotch className="h-4 w-4 animate-spin" />
-                  {t(
-                    isEdit
-                      ? "model-router.edit-router.saving"
-                      : "model-router.new-router.creating"
-                  )}
+                  {t("common.saving")}
                 </>
               ) : isEdit ? (
                 t("model-router.edit-router.save")

--- a/server/__tests__/utils/chats/openaiCompatible.test.js
+++ b/server/__tests__/utils/chats/openaiCompatible.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest, node */
 const { OpenAICompatibleChat } = require('../../../utils/chats/openaiCompatible');
 const { WorkspaceChats } = require('../../../models/workspaceChats');
-const { getVectorDbClass, getLLMProvider } = require('../../../utils/helpers');
+const { getVectorDbClass, getLLMProvider, resolveProviderConnector } = require('../../../utils/helpers');
 const { extractTextContent, extractAttachments } = require('../../../endpoints/api/openai/helpers');
 
 // Mock dependencies
@@ -62,6 +62,11 @@ describe('OpenAICompatibleChat', () => {
       defaultTemp: 0.7,
     };
     getLLMProvider.mockReturnValue(mockLLMConnector);
+    resolveProviderConnector.mockResolvedValue({
+      connector: mockLLMConnector,
+      routingMetadata: null,
+      prefetchedContext: null,
+    });
 
     // Setup WorkspaceChats mock
     WorkspaceChats.new.mockResolvedValue({ chat: { id: 'mock-chat-id' } });

--- a/server/endpoints/api/openai/index.js
+++ b/server/endpoints/api/openai/index.js
@@ -58,16 +58,24 @@ function apiOpenAICompatibleEndpoints(app) {
       const data = [];
       const workspaces = await Workspace.where();
       for (const workspace of workspaces) {
+        let ownedBy;
         const provider = workspace?.chatProvider ?? process.env.LLM_PROVIDER;
-        let LLMProvider = getLLMProvider({
-          provider,
-          model: workspace?.chatModel,
-        });
+
+        if (provider === "anythingllm-router") {
+          ownedBy = `${provider}-${workspace?.chatModel || "auto"}`;
+        } else {
+          const LLMProvider = getLLMProvider({
+            provider,
+            model: workspace?.chatModel,
+          });
+          ownedBy = `${provider}-${LLMProvider.model}`;
+        }
+
         data.push({
           id: workspace.slug,
           object: "model",
           created: Math.floor(Number(new Date(workspace.createdAt)) / 1000),
-          owned_by: `${provider}-${LLMProvider.model}`,
+          owned_by: ownedBy,
         });
       }
       return response.status(200).json({

--- a/server/endpoints/api/openai/index.js
+++ b/server/endpoints/api/openai/index.js
@@ -2,10 +2,7 @@ const { v4: uuidv4 } = require("uuid");
 const { Document } = require("../../../models/documents");
 const { Telemetry } = require("../../../models/telemetry");
 const { Workspace } = require("../../../models/workspace");
-const {
-  getLLMProvider,
-  getEmbeddingEngineSelection,
-} = require("../../../utils/helpers");
+const { getEmbeddingEngineSelection } = require("../../../utils/helpers");
 const { reqBody } = require("../../../utils/http");
 const { validApiKey } = require("../../../utils/middleware/validApiKey");
 const { EventLogs } = require("../../../models/eventLogs");
@@ -58,24 +55,11 @@ function apiOpenAICompatibleEndpoints(app) {
       const data = [];
       const workspaces = await Workspace.where();
       for (const workspace of workspaces) {
-        let ownedBy;
-        const provider = workspace?.chatProvider ?? process.env.LLM_PROVIDER;
-
-        if (provider === "anythingllm-router") {
-          ownedBy = `${provider}-${workspace?.chatModel || "auto"}`;
-        } else {
-          const LLMProvider = getLLMProvider({
-            provider,
-            model: workspace?.chatModel,
-          });
-          ownedBy = `${provider}-${LLMProvider.model}`;
-        }
-
         data.push({
           id: workspace.slug,
           object: "model",
           created: Math.floor(Number(new Date(workspace.createdAt)) / 1000),
-          owned_by: ownedBy,
+          owned_by: workspace?.chatProvider || process.env.LLM_PROVIDER,
         });
       }
       return response.status(200).json({

--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -4,7 +4,10 @@ const { Telemetry } = require("../../../models/telemetry");
 const { DocumentVectors } = require("../../../models/vectors");
 const { Workspace } = require("../../../models/workspace");
 const { WorkspaceChats } = require("../../../models/workspaceChats");
-const { getVectorDbClass, getLLMProvider } = require("../../../utils/helpers");
+const {
+  getVectorDbClass,
+  resolveProviderConnector,
+} = require("../../../utils/helpers");
 const { multiUserMode, reqBody } = require("../../../utils/http");
 const { validApiKey } = require("../../../utils/middleware/validApiKey");
 const { VALID_CHAT_MODE } = require("../../../utils/chats/stream");
@@ -984,30 +987,10 @@ function apiWorkspaceEndpoints(app) {
           return input;
         };
 
-        const effectiveProvider =
-          workspace?.chatProvider || process.env.LLM_PROVIDER;
-        let LLMConnector;
-        if (effectiveProvider === "anythingllm-router") {
-          const {
-            AnythingLLMModelRouter,
-          } = require("../../../utils/AiProviders/modelRouter");
-          const routerWorkspace = workspace?.router_id
-            ? workspace
-            : {
-                ...workspace,
-                router_id: process.env.MODEL_ROUTER_ID
-                  ? Number(process.env.MODEL_ROUTER_ID)
-                  : null,
-              };
-          const router = new AnythingLLMModelRouter(routerWorkspace);
-          await router.resolve({ prompt: String(query) }, {});
-          LLMConnector = router.delegateProvider;
-        } else {
-          LLMConnector = getLLMProvider({
-            provider: workspace?.chatProvider,
-            model: workspace?.chatModel,
-          });
-        }
+        const { connector: LLMConnector } = await resolveProviderConnector({
+          workspace,
+          prompt: String(query),
+        });
 
         const results = await VectorDb.performSimilaritySearch({
           namespace: workspace.slug,

--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -984,10 +984,35 @@ function apiWorkspaceEndpoints(app) {
           return input;
         };
 
+        const effectiveProvider =
+          workspace?.chatProvider || process.env.LLM_PROVIDER;
+        let LLMConnector;
+        if (effectiveProvider === "anythingllm-router") {
+          const {
+            AnythingLLMModelRouter,
+          } = require("../../../utils/AiProviders/modelRouter");
+          const routerWorkspace = workspace?.router_id
+            ? workspace
+            : {
+                ...workspace,
+                router_id: process.env.MODEL_ROUTER_ID
+                  ? Number(process.env.MODEL_ROUTER_ID)
+                  : null,
+              };
+          const router = new AnythingLLMModelRouter(routerWorkspace);
+          await router.resolve({ prompt: String(query) }, {});
+          LLMConnector = router.delegateProvider;
+        } else {
+          LLMConnector = getLLMProvider({
+            provider: workspace?.chatProvider,
+            model: workspace?.chatModel,
+          });
+        }
+
         const results = await VectorDb.performSimilaritySearch({
           namespace: workspace.slug,
           input: String(query),
-          LLMConnector: getLLMProvider(),
+          LLMConnector,
           similarityThreshold: parseSimilarityThreshold(),
           topN: parseTopN(),
           rerank: workspace?.vectorSearchMode === "rerank",

--- a/server/utils/agents/aibitat/plugins/memory.js
+++ b/server/utils/agents/aibitat/plugins/memory.js
@@ -1,5 +1,8 @@
 const { v4 } = require("uuid");
-const { getVectorDbClass, getLLMProvider } = require("../../../helpers");
+const {
+  getVectorDbClass,
+  resolveProviderConnector,
+} = require("../../../helpers");
 const { Deduplicator } = require("../utils/dedupe");
 
 const memory = {
@@ -81,30 +84,11 @@ const memory = {
           search: async function (query = "") {
             try {
               const workspace = this.super.handlerProps.invocation.workspace;
-              const effectiveProvider =
-                workspace?.chatProvider || process.env.LLM_PROVIDER;
-              let LLMConnector;
-              if (effectiveProvider === "anythingllm-router") {
-                const {
-                  AnythingLLMModelRouter,
-                } = require("../../AiProviders/modelRouter");
-                const routerWorkspace = workspace?.router_id
-                  ? workspace
-                  : {
-                      ...workspace,
-                      router_id: process.env.MODEL_ROUTER_ID
-                        ? Number(process.env.MODEL_ROUTER_ID)
-                        : null,
-                    };
-                const router = new AnythingLLMModelRouter(routerWorkspace);
-                await router.resolve({ prompt: query }, {});
-                LLMConnector = router.delegateProvider;
-              } else {
-                LLMConnector = getLLMProvider({
-                  provider: workspace?.chatProvider,
-                  model: workspace?.chatModel,
+              const { connector: LLMConnector } =
+                await resolveProviderConnector({
+                  workspace,
+                  prompt: query,
                 });
-              }
               const vectorDB = getVectorDbClass();
               const { contextTexts = [] } =
                 await vectorDB.performSimilaritySearch({

--- a/server/utils/agents/aibitat/plugins/memory.js
+++ b/server/utils/agents/aibitat/plugins/memory.js
@@ -81,10 +81,30 @@ const memory = {
           search: async function (query = "") {
             try {
               const workspace = this.super.handlerProps.invocation.workspace;
-              const LLMConnector = getLLMProvider({
-                provider: workspace?.chatProvider,
-                model: workspace?.chatModel,
-              });
+              const effectiveProvider =
+                workspace?.chatProvider || process.env.LLM_PROVIDER;
+              let LLMConnector;
+              if (effectiveProvider === "anythingllm-router") {
+                const {
+                  AnythingLLMModelRouter,
+                } = require("../../AiProviders/modelRouter");
+                const routerWorkspace = workspace?.router_id
+                  ? workspace
+                  : {
+                      ...workspace,
+                      router_id: process.env.MODEL_ROUTER_ID
+                        ? Number(process.env.MODEL_ROUTER_ID)
+                        : null,
+                    };
+                const router = new AnythingLLMModelRouter(routerWorkspace);
+                await router.resolve({ prompt: query }, {});
+                LLMConnector = router.delegateProvider;
+              } else {
+                LLMConnector = getLLMProvider({
+                  provider: workspace?.chatProvider,
+                  model: workspace?.chatModel,
+                });
+              }
               const vectorDB = getVectorDbClass();
               const { contextTexts = [] } =
                 await vectorDB.performSimilaritySearch({

--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -229,15 +229,26 @@ class EphemeralAgentHandler extends AgentHandler {
         };
 
     const router = new AnythingLLMModelRouter(routerWorkspace);
+    const { ModelRouterService } = require("../router");
+    const workspace = this.#workspace;
+    const user = this.#userId ? { id: this.#userId } : null;
+    const effectivePrompt = prompt || this.#prompt;
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      user,
+      thread: this.#threadId ? { id: this.#threadId } : null,
+      message: effectivePrompt,
+      apiSessionId: this.#sessionId,
+    });
+
     await router.resolve(
       {
-        prompt: prompt || this.#prompt,
+        prompt: effectivePrompt,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
         attachments: this.#attachments || [],
       },
-      {
-        user: this.#userId ? { id: this.#userId } : null,
-        thread: this.#threadId ? { id: this.#threadId } : null,
-      }
+      { user, thread: this.#threadId ? { id: this.#threadId } : null }
     );
 
     this.provider = router.resolvedRoute.provider;
@@ -634,12 +645,13 @@ class EphemeralEventListener extends EventEmitter {
 
   /**
    * Compacts all messages in class and returns them in a condensed format.
-   * @returns {{thoughts: string[], textResponse: string}}
+   * @returns {{thoughts: string[], textResponse: string, outputs: object[], metrics: object}}
    */
   packMessages() {
     const thoughts = [];
     const outputs = [];
     let textResponse = null;
+    let metrics = {};
     for (let msg of this.messages) {
       if (msg.type === "statusResponse") {
         thoughts.push(msg.content);
@@ -651,12 +663,20 @@ class EphemeralEventListener extends EventEmitter {
         continue;
       }
 
-      // All other message types are treated as the text response
-      // This preserves original behavior where any non-statusResponse message
-      // sets the textResponse
+      if (msg.type === "reportStreamEvent") {
+        const inner = msg.content;
+        if (inner?.type === "textResponseChunk" && inner?.content)
+          textResponse = (textResponse || "") + inner.content;
+        if (inner?.type === "fullTextResponse" && inner?.content)
+          textResponse = inner.content;
+        if (inner?.type === "usageMetrics" && inner?.metrics)
+          metrics = inner.metrics;
+        continue;
+      }
+
       textResponse = msg.content;
     }
-    return { thoughts, textResponse, outputs };
+    return { thoughts, textResponse, outputs, metrics };
   }
 
   /**
@@ -703,6 +723,47 @@ class EphemeralEventListener extends EventEmitter {
           close: false,
           error: null,
         });
+      }
+
+      if (data.type === "reportStreamEvent") {
+        const inner = data.content;
+        if (!inner?.type) return;
+
+        if (inner.type === "textResponseChunk") {
+          return writeResponseChunk(response, {
+            id: uuid,
+            type: "textResponseChunk",
+            textResponse: inner.content,
+            sources: [],
+            close: false,
+            error: null,
+          });
+        }
+
+        if (inner.type === "fullTextResponse") {
+          return writeResponseChunk(response, {
+            id: uuid,
+            type: "textResponse",
+            textResponse: inner.content,
+            sources: [],
+            attachments: [],
+            close: true,
+            error: null,
+            animate: false,
+          });
+        }
+
+        if (inner.type === "usageMetrics" && inner.metrics) {
+          return writeResponseChunk(response, {
+            id: uuid,
+            type: "usageMetrics",
+            metrics: inner.metrics,
+            close: false,
+            error: null,
+          });
+        }
+
+        return;
       }
 
       return writeResponseChunk(response, {

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -489,15 +489,29 @@ class AgentHandler {
     }
 
     const router = new AnythingLLMModelRouter(routerWorkspace);
+    const { ModelRouterService } = require("../router");
+    const workspace = this.invocation.workspace;
+    const user = this.invocation.user_id
+      ? { id: this.invocation.user_id }
+      : null;
+    const effectivePrompt = prompt || this.invocation.prompt;
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      user,
+      thread: this.invocation.thread_id
+        ? { id: this.invocation.thread_id }
+        : null,
+      message: effectivePrompt,
+    });
+
     await router.resolve(
       {
-        prompt: prompt || this.invocation.prompt,
+        prompt: effectivePrompt,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
         attachments: this.attachments || [],
       },
-      {
-        user: this.invocation.user_id ? { id: this.invocation.user_id } : null,
-        thread,
-      }
+      { user, thread }
     );
 
     this.provider = router.resolvedRoute.provider;

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4 } = require("uuid");
 const { DocumentManager } = require("../DocumentManager");
 const { WorkspaceChats } = require("../../models/workspaceChats");
-const { getVectorDbClass, getLLMProvider } = require("../helpers");
+const { getVectorDbClass, resolveProviderConnector } = require("../helpers");
 const { writeResponseChunk } = require("../helpers/chat/responses");
 const {
   chatPrompt,
@@ -223,47 +223,14 @@ async function chatSync({
       });
   }
 
-  let LLMConnector;
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  if (effectiveProvider === "anythingllm-router") {
-    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../router");
-
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-
-    const router = new AnythingLLMModelRouter(routerWorkspace);
-    const ctx = await ModelRouterService.gatherRoutingContext({
-      workspace,
-      user,
-      thread,
-      message,
-      apiSessionId: sessionId,
-    });
-
-    await router.resolve(
-      {
-        prompt: message,
-        conversationTokenCount: ctx.conversationTokenCount,
-        conversationMessageCount: ctx.conversationMessageCount,
-        attachments,
-      },
-      { user, thread }
-    );
-
-    LLMConnector = router.delegateProvider;
-  } else {
-    LLMConnector = getLLMProvider({
-      provider: workspace?.chatProvider,
-      model: workspace?.chatModel,
-    });
-  }
+  const { connector: LLMConnector } = await resolveProviderConnector({
+    workspace,
+    prompt: message,
+    user,
+    thread,
+    attachments,
+    apiSessionId: sessionId,
+  });
 
   const VectorDb = getVectorDbClass();
   const messageLimit = workspace?.openAiHistory || 20;
@@ -622,47 +589,14 @@ async function streamChat({
       });
   }
 
-  let LLMConnector;
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  if (effectiveProvider === "anythingllm-router") {
-    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../router");
-
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-
-    const router = new AnythingLLMModelRouter(routerWorkspace);
-    const ctx = await ModelRouterService.gatherRoutingContext({
-      workspace,
-      user,
-      thread,
-      message,
-      apiSessionId: sessionId,
-    });
-
-    await router.resolve(
-      {
-        prompt: message,
-        conversationTokenCount: ctx.conversationTokenCount,
-        conversationMessageCount: ctx.conversationMessageCount,
-        attachments,
-      },
-      { user, thread }
-    );
-
-    LLMConnector = router.delegateProvider;
-  } else {
-    LLMConnector = getLLMProvider({
-      provider: workspace?.chatProvider,
-      model: workspace?.chatModel,
-    });
-  }
+  const { connector: LLMConnector } = await resolveProviderConnector({
+    workspace,
+    prompt: message,
+    user,
+    thread,
+    attachments,
+    apiSessionId: sessionId,
+  });
 
   const VectorDb = getVectorDbClass();
   const messageLimit = workspace?.openAiHistory || 20;

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -189,7 +189,7 @@ async function chatSync({
     // After this, we conclude the call as we normally do.
     return await eventListener
       .waitForClose()
-      .then(async ({ thoughts, textResponse, outputs }) => {
+      .then(async ({ thoughts, textResponse, outputs, metrics }) => {
         // Merge outputs from packMessages with outputs from aibitat (contains file download metadata with proper types)
         // These are needed for the download endpoint to authorize file access
         const allOutputs = [...outputs, ...agentHandler.getPendingOutputs()];
@@ -204,6 +204,7 @@ async function chatSync({
             type: chatMode,
             thoughts,
             outputs: allOutputs,
+            metrics,
           },
           include: false,
           apiSessionId: sessionId,
@@ -217,14 +218,53 @@ async function chatSync({
           textResponse,
           thoughts,
           outputs,
+          metrics,
         };
       });
   }
 
-  const LLMConnector = getLLMProvider({
-    provider: workspace?.chatProvider,
-    model: workspace?.chatModel,
-  });
+  let LLMConnector;
+  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
+  if (effectiveProvider === "anythingllm-router") {
+    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
+    const { ModelRouterService } = require("../router");
+
+    const routerWorkspace = workspace?.router_id
+      ? workspace
+      : {
+          ...workspace,
+          router_id: process.env.MODEL_ROUTER_ID
+            ? Number(process.env.MODEL_ROUTER_ID)
+            : null,
+        };
+
+    const router = new AnythingLLMModelRouter(routerWorkspace);
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      user,
+      thread,
+      message,
+      apiSessionId: sessionId,
+    });
+
+    await router.resolve(
+      {
+        prompt: message,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
+        attachments,
+      },
+      { user, thread }
+    );
+
+    LLMConnector = router.delegateProvider;
+  } else {
+    LLMConnector = getLLMProvider({
+      provider: workspace?.chatProvider,
+      model: workspace?.chatModel,
+    });
+  }
+
   const VectorDb = getVectorDbClass();
   const messageLimit = workspace?.openAiHistory || 20;
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
@@ -548,7 +588,7 @@ async function streamChat({
     // and stream back any results we get from agents as they come in.
     return eventListener
       .streamAgentEvents(response, uuid)
-      .then(async ({ thoughts, textResponse, outputs }) => {
+      .then(async ({ thoughts, textResponse, outputs, metrics }) => {
         // Merge outputs from packMessages with outputs from aibitat (contains file download metadata with proper types)
         // These are needed for the download endpoint to authorize file access
         const allOutputs = [...outputs, ...agentHandler.getPendingOutputs()];
@@ -563,6 +603,7 @@ async function streamChat({
             type: chatMode,
             thoughts,
             outputs: allOutputs,
+            metrics,
           },
           include: true,
           threadId: thread?.id || null,
@@ -576,14 +617,52 @@ async function streamChat({
           outputs,
           close: true,
           error: false,
+          metrics,
         });
       });
   }
 
-  const LLMConnector = getLLMProvider({
-    provider: workspace?.chatProvider,
-    model: workspace?.chatModel,
-  });
+  let LLMConnector;
+  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
+  if (effectiveProvider === "anythingllm-router") {
+    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
+    const { ModelRouterService } = require("../router");
+
+    const routerWorkspace = workspace?.router_id
+      ? workspace
+      : {
+          ...workspace,
+          router_id: process.env.MODEL_ROUTER_ID
+            ? Number(process.env.MODEL_ROUTER_ID)
+            : null,
+        };
+
+    const router = new AnythingLLMModelRouter(routerWorkspace);
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      user,
+      thread,
+      message,
+      apiSessionId: sessionId,
+    });
+
+    await router.resolve(
+      {
+        prompt: message,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
+        attachments,
+      },
+      { user, thread }
+    );
+
+    LLMConnector = router.delegateProvider;
+  } else {
+    LLMConnector = getLLMProvider({
+      provider: workspace?.chatProvider,
+      model: workspace?.chatModel,
+    });
+  }
 
   const VectorDb = getVectorDbClass();
   const messageLimit = workspace?.openAiHistory || 20;

--- a/server/utils/chats/embed.js
+++ b/server/utils/chats/embed.js
@@ -1,5 +1,5 @@
 const { v4: uuidv4 } = require("uuid");
-const { getVectorDbClass, getLLMProvider } = require("../helpers");
+const { getVectorDbClass, resolveProviderConnector } = require("../helpers");
 const { chatPrompt, sourceIdentifier } = require("./index");
 const { EmbedChats } = require("../../models/embedChats");
 const {
@@ -250,34 +250,12 @@ async function resolveLLMConnectorForEmbed({
   message,
   sessionId,
 }) {
-  const workspace = embed?.workspace;
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  const isRouterProvider = effectiveProvider === "anythingllm-router";
-
-  if (!isRouterProvider) {
-    return {
-      connector: getLLMProvider({
-        provider: workspace?.chatProvider,
-        model: chatModel ?? workspace?.chatModel,
-      }),
-      prefetchedContext: null,
-      error: null,
-    };
-  }
-
+  // If a chat model is provided, use it to override the workspace chat model
+  // otherwise use the workspace chat model as we do everywhere else.
+  const workspace = chatModel
+    ? { ...embed?.workspace, chatModel }
+    : embed?.workspace;
   try {
-    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../router");
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-
-    const router = new AnythingLLMModelRouter(routerWorkspace);
     const messageLimit = workspace?.openAiHistory || 20;
     const embedHistory = await recentEmbedChatHistory(
       sessionId,
@@ -287,31 +265,26 @@ async function resolveLLMConnectorForEmbed({
     const embedMessageCount = await EmbedChats.count({
       embed_id: embed.id,
       session_id: sessionId,
-    });
-    const ctx = await ModelRouterService.gatherRoutingContext({
-      workspace,
-      message,
-      chatHistoryOverride: embedHistory,
-      messageCountOverride: embedMessageCount,
+      include: true,
     });
 
-    await router.resolve(
-      {
-        prompt: message,
-        conversationTokenCount: ctx.conversationTokenCount,
-        conversationMessageCount: ctx.conversationMessageCount,
-        attachments: [],
-      },
-      { user: null, thread: null }
-    );
+    const { connector, prefetchedContext } = await resolveProviderConnector({
+      workspace,
+      prompt: message,
+      chatHistoryOverride: embedHistory,
+      // +1 to include the current in-flight message to ensure routing rules are evaluated against the real total.
+      messageCountOverride: embedMessageCount + 1,
+    });
 
     return {
-      connector: router.delegateProvider,
-      prefetchedContext: {
-        rawHistory: embedHistory.rawHistory,
-        chatHistory: embedHistory.chatHistory,
-        pinnedDocs: ctx.pinnedDocs,
-      },
+      connector,
+      prefetchedContext: prefetchedContext
+        ? {
+            rawHistory: embedHistory.rawHistory,
+            chatHistory: embedHistory.chatHistory,
+            pinnedDocs: prefetchedContext.pinnedDocs,
+          }
+        : null,
       error: null,
     };
   } catch (routerError) {

--- a/server/utils/chats/embed.js
+++ b/server/utils/chats/embed.js
@@ -31,13 +31,16 @@ async function streamChatWithForEmbed(
     embed.workspace.openAiTemp = parseFloat(temperatureOverride);
 
   const uuid = uuidv4();
-  const { connector: LLMConnector, error: routerError } =
-    await resolveLLMConnectorForEmbed({
-      embed,
-      chatModel,
-      message,
-      sessionId,
-    });
+  const {
+    connector: LLMConnector,
+    prefetchedContext,
+    error: routerError,
+  } = await resolveLLMConnectorForEmbed({
+    embed,
+    chatModel,
+    message,
+    sessionId,
+  });
 
   if (routerError) {
     return writeResponseChunk(response, {
@@ -76,31 +79,29 @@ async function streamChatWithForEmbed(
   let contextTexts = [];
   let sources = [];
   let pinnedDocIdentifiers = [];
-  const { rawHistory, chatHistory } = await recentEmbedChatHistory(
-    sessionId,
-    embed,
-    messageLimit
-  );
+  const {
+    rawHistory,
+    chatHistory,
+    pinnedDocs: prefetchedPinnedDocs,
+  } = prefetchedContext ??
+  (await recentEmbedChatHistory(sessionId, embed, messageLimit));
 
-  // See stream.js comment for more information on this implementation.
-  await new DocumentManager({
-    workspace: embed.workspace,
-    maxTokens: LLMConnector.promptWindowLimit(),
-  })
-    .pinnedDocs()
-    .then((pinnedDocs) => {
-      pinnedDocs.forEach((doc) => {
-        const { pageContent, ...metadata } = doc;
-        pinnedDocIdentifiers.push(sourceIdentifier(doc));
-        contextTexts.push(doc.pageContent);
-        sources.push({
-          text:
-            pageContent.slice(0, 1_000) +
-            "...continued on in source document...",
-          ...metadata,
-        });
-      });
+  const pinnedDocs =
+    prefetchedPinnedDocs ??
+    (await new DocumentManager({
+      workspace: embed.workspace,
+      maxTokens: LLMConnector.promptWindowLimit(),
+    }).pinnedDocs());
+  pinnedDocs.forEach((doc) => {
+    const { pageContent, ...metadata } = doc;
+    pinnedDocIdentifiers.push(sourceIdentifier(doc));
+    contextTexts.push(doc.pageContent);
+    sources.push({
+      text:
+        pageContent.slice(0, 1_000) + "...continued on in source document...",
+      ...metadata,
     });
+  });
 
   const vectorSearchResults =
     embeddingsCount !== 0
@@ -259,14 +260,14 @@ async function resolveLLMConnectorForEmbed({
         provider: workspace?.chatProvider,
         model: chatModel ?? workspace?.chatModel,
       }),
+      prefetchedContext: null,
       error: null,
     };
   }
 
   try {
     const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { TokenManager } = require("../helpers/tiktoken");
-
+    const { ModelRouterService } = require("../router");
     const routerWorkspace = workspace?.router_id
       ? workspace
       : {
@@ -277,18 +278,28 @@ async function resolveLLMConnectorForEmbed({
         };
 
     const router = new AnythingLLMModelRouter(routerWorkspace);
-    const tokenManager = new TokenManager();
-    const conversationTokenCount = tokenManager.countFromString(message);
-    const conversationMessageCount = await EmbedChats.count({
+    const messageLimit = workspace?.openAiHistory || 20;
+    const embedHistory = await recentEmbedChatHistory(
+      sessionId,
+      embed,
+      messageLimit
+    );
+    const embedMessageCount = await EmbedChats.count({
       embed_id: embed.id,
       session_id: sessionId,
+    });
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      message,
+      chatHistoryOverride: embedHistory,
+      messageCountOverride: embedMessageCount,
     });
 
     await router.resolve(
       {
         prompt: message,
-        conversationTokenCount,
-        conversationMessageCount,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
         attachments: [],
       },
       { user: null, thread: null }
@@ -296,11 +307,17 @@ async function resolveLLMConnectorForEmbed({
 
     return {
       connector: router.delegateProvider,
+      prefetchedContext: {
+        rawHistory: embedHistory.rawHistory,
+        chatHistory: embedHistory.chatHistory,
+        pinnedDocs: ctx.pinnedDocs,
+      },
       error: null,
     };
   } catch (routerError) {
     return {
       connector: null,
+      prefetchedContext: null,
       error: `Model router error: ${routerError.message}`,
     };
   }

--- a/server/utils/chats/openaiCompatible.js
+++ b/server/utils/chats/openaiCompatible.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4 } = require("uuid");
 const { DocumentManager } = require("../DocumentManager");
 const { WorkspaceChats } = require("../../models/workspaceChats");
-const { getVectorDbClass, getLLMProvider } = require("../helpers");
+const { getVectorDbClass, resolveProviderConnector } = require("../helpers");
 const { writeResponseChunk } = require("../helpers/chat/responses");
 const { chatPrompt, sourceIdentifier } = require("./index");
 
@@ -18,49 +18,18 @@ async function chatSync({
   const uuid = uuidv4();
   const chatMode = workspace?.chatMode ?? "automatic";
 
-  let LLMConnector;
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  if (effectiveProvider === "anythingllm-router") {
-    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../router");
-
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-
-    const router = new AnythingLLMModelRouter(routerWorkspace);
-    const ctx = await ModelRouterService.gatherRoutingContext({
-      workspace,
-      message: prompt,
-      chatHistoryOverride: {
-        rawHistory: history,
-        chatHistory: history,
-      },
-      messageCountOverride: history.length,
-    });
-
-    await router.resolve(
-      {
-        prompt,
-        conversationTokenCount: ctx.conversationTokenCount,
-        conversationMessageCount: ctx.conversationMessageCount,
-        attachments,
-      },
-      { user: null, thread: null }
-    );
-
-    LLMConnector = router.delegateProvider;
-  } else {
-    LLMConnector = getLLMProvider({
-      provider: workspace?.chatProvider,
-      model: workspace?.chatModel,
-    });
-  }
+  const { connector: LLMConnector } = await resolveProviderConnector({
+    workspace,
+    prompt,
+    attachments,
+    chatHistoryOverride: {
+      rawHistory: history,
+      chatHistory: history,
+    },
+    // Do not +1 to this, since OAI message history ends in a user message
+    // and does not need to re-include an uncounted user message.
+    messageCountOverride: history.length,
+  });
 
   const VectorDb = getVectorDbClass();
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
@@ -262,49 +231,18 @@ async function streamChat({
   const uuid = uuidv4();
   const chatMode = workspace?.chatMode ?? "automatic";
 
-  let LLMConnector;
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  if (effectiveProvider === "anythingllm-router") {
-    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../router");
-
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-
-    const router = new AnythingLLMModelRouter(routerWorkspace);
-    const ctx = await ModelRouterService.gatherRoutingContext({
-      workspace,
-      message: prompt,
-      chatHistoryOverride: {
-        rawHistory: history,
-        chatHistory: history,
-      },
-      messageCountOverride: history.length,
-    });
-
-    await router.resolve(
-      {
-        prompt,
-        conversationTokenCount: ctx.conversationTokenCount,
-        conversationMessageCount: ctx.conversationMessageCount,
-        attachments,
-      },
-      { user: null, thread: null }
-    );
-
-    LLMConnector = router.delegateProvider;
-  } else {
-    LLMConnector = getLLMProvider({
-      provider: workspace?.chatProvider,
-      model: workspace?.chatModel,
-    });
-  }
+  const { connector: LLMConnector } = await resolveProviderConnector({
+    workspace,
+    prompt,
+    attachments,
+    chatHistoryOverride: {
+      rawHistory: history,
+      chatHistory: history,
+    },
+    // Do not +1 to this, since OAI message history ends in a user message
+    // and does not need to re-include an uncounted user message.
+    messageCountOverride: history.length,
+  });
 
   const VectorDb = getVectorDbClass();
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);

--- a/server/utils/chats/openaiCompatible.js
+++ b/server/utils/chats/openaiCompatible.js
@@ -17,10 +17,51 @@ async function chatSync({
 }) {
   const uuid = uuidv4();
   const chatMode = workspace?.chatMode ?? "automatic";
-  const LLMConnector = getLLMProvider({
-    provider: workspace?.chatProvider,
-    model: workspace?.chatModel,
-  });
+
+  let LLMConnector;
+  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
+  if (effectiveProvider === "anythingllm-router") {
+    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
+    const { ModelRouterService } = require("../router");
+
+    const routerWorkspace = workspace?.router_id
+      ? workspace
+      : {
+          ...workspace,
+          router_id: process.env.MODEL_ROUTER_ID
+            ? Number(process.env.MODEL_ROUTER_ID)
+            : null,
+        };
+
+    const router = new AnythingLLMModelRouter(routerWorkspace);
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      message: prompt,
+      chatHistoryOverride: {
+        rawHistory: history,
+        chatHistory: history,
+      },
+      messageCountOverride: history.length,
+    });
+
+    await router.resolve(
+      {
+        prompt,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
+        attachments,
+      },
+      { user: null, thread: null }
+    );
+
+    LLMConnector = router.delegateProvider;
+  } else {
+    LLMConnector = getLLMProvider({
+      provider: workspace?.chatProvider,
+      model: workspace?.chatModel,
+    });
+  }
+
   const VectorDb = getVectorDbClass();
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
   const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
@@ -220,10 +261,51 @@ async function streamChat({
 }) {
   const uuid = uuidv4();
   const chatMode = workspace?.chatMode ?? "automatic";
-  const LLMConnector = getLLMProvider({
-    provider: workspace?.chatProvider,
-    model: workspace?.chatModel,
-  });
+
+  let LLMConnector;
+  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
+  if (effectiveProvider === "anythingllm-router") {
+    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
+    const { ModelRouterService } = require("../router");
+
+    const routerWorkspace = workspace?.router_id
+      ? workspace
+      : {
+          ...workspace,
+          router_id: process.env.MODEL_ROUTER_ID
+            ? Number(process.env.MODEL_ROUTER_ID)
+            : null,
+        };
+
+    const router = new AnythingLLMModelRouter(routerWorkspace);
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      message: prompt,
+      chatHistoryOverride: {
+        rawHistory: history,
+        chatHistory: history,
+      },
+      messageCountOverride: history.length,
+    });
+
+    await router.resolve(
+      {
+        prompt,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
+        attachments,
+      },
+      { user: null, thread: null }
+    );
+
+    LLMConnector = router.delegateProvider;
+  } else {
+    LLMConnector = getLLMProvider({
+      provider: workspace?.chatProvider,
+      model: workspace?.chatModel,
+    });
+  }
+
   const VectorDb = getVectorDbClass();
   const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
   const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -2,7 +2,7 @@ const { v4: uuidv4 } = require("uuid");
 const { DocumentManager } = require("../DocumentManager");
 const { WorkspaceChats } = require("../../models/workspaceChats");
 const { WorkspaceParsedFiles } = require("../../models/workspaceParsedFiles");
-const { getVectorDbClass, getLLMProvider } = require("../helpers");
+const { getVectorDbClass, resolveProviderConnector } = require("../helpers");
 const { writeResponseChunk } = require("../helpers/chat/responses");
 const { grepAgents } = require("./agents");
 const {
@@ -344,10 +344,6 @@ async function streamChatWithWorkspace(
   return;
 }
 
-/**
- * Resolves the LLM connector, either directly or via the model router.
- * @returns {Promise<{ connector: Object, routingMetadata: Object|null, error: string|null }>}
- */
 async function resolveLLMConnector({
   workspace,
   message,
@@ -355,58 +351,15 @@ async function resolveLLMConnector({
   thread,
   attachments,
 }) {
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  const isRouterProvider = effectiveProvider === "anythingllm-router";
-
-  if (!isRouterProvider) {
-    return {
-      connector: getLLMProvider({
-        provider: workspace?.chatProvider,
-        model: workspace?.chatModel,
-      }),
-      routingMetadata: null,
-      prefetchedContext: null,
-      error: null,
-    };
-  }
-
   try {
-    const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../router");
-
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-
-    const router = new AnythingLLMModelRouter(routerWorkspace);
-    const ctx = await ModelRouterService.gatherRoutingContext({
+    const result = await resolveProviderConnector({
       workspace,
+      prompt: message,
       user,
       thread,
-      message,
+      attachments,
     });
-
-    await router.resolve(
-      {
-        prompt: message,
-        conversationTokenCount: ctx.conversationTokenCount,
-        conversationMessageCount: ctx.conversationMessageCount,
-        attachments,
-      },
-      { user, thread }
-    );
-
-    return {
-      connector: router.delegateProvider,
-      routingMetadata: router.routingMetadata,
-      prefetchedContext: ctx,
-      error: null,
-    };
+    return { ...result, error: null };
   } catch (routerError) {
     return {
       connector: null,

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -54,10 +54,11 @@ async function streamChatWithWorkspace(
   const {
     connector: LLMConnector,
     routingMetadata,
+    prefetchedContext,
     error: routerError,
   } = await resolveLLMConnector({
     workspace,
-    message,
+    message: updatedMessage,
     user,
     thread,
     attachments,
@@ -127,44 +128,42 @@ async function streamChatWithWorkspace(
   let contextTexts = [];
   let sources = [];
   let pinnedDocIdentifiers = [];
-  const { rawHistory, chatHistory } = await recentChatHistory({
-    user,
-    workspace,
-    thread,
-    messageLimit,
+
+  // If the router pre-fetched context we can reuse it; otherwise fetch fresh.
+  const {
+    rawHistory,
+    chatHistory,
+    pinnedDocs: prefetchedPinnedDocs,
+    parsedFiles: prefetchedParsedFiles,
+  } = prefetchedContext ??
+  (await recentChatHistory({ user, workspace, thread, messageLimit }));
+
+  // Pinned docs — reuse pre-fetched if available, otherwise fetch with token cap.
+  const pinnedDocs =
+    prefetchedPinnedDocs ??
+    (await new DocumentManager({
+      workspace,
+      maxTokens: LLMConnector.promptWindowLimit(),
+    }).pinnedDocs());
+  pinnedDocs.forEach((doc) => {
+    const { pageContent, ...metadata } = doc;
+    pinnedDocIdentifiers.push(sourceIdentifier(doc));
+    contextTexts.push(doc.pageContent);
+    sources.push({
+      text:
+        pageContent.slice(0, 1_000) + "...continued on in source document...",
+      ...metadata,
+    });
   });
 
-  // Look for pinned documents and see if the user decided to use this feature. We will also do a vector search
-  // as pinning is a supplemental tool but it should be used with caution since it can easily blow up a context window.
-  // However we limit the maximum of appended context to 80% of its overall size, mostly because if it expands beyond this
-  // it will undergo prompt compression anyway to make it work. If there is so much pinned that the context here is bigger than
-  // what the model can support - it would get compressed anyway and that really is not the point of pinning. It is really best
-  // suited for high-context models.
-  await new DocumentManager({
-    workspace,
-    maxTokens: LLMConnector.promptWindowLimit(),
-  })
-    .pinnedDocs()
-    .then((pinnedDocs) => {
-      pinnedDocs.forEach((doc) => {
-        const { pageContent, ...metadata } = doc;
-        pinnedDocIdentifiers.push(sourceIdentifier(doc));
-        contextTexts.push(doc.pageContent);
-        sources.push({
-          text:
-            pageContent.slice(0, 1_000) +
-            "...continued on in source document...",
-          ...metadata,
-        });
-      });
-    });
-
-  // Inject any parsed files for this workspace/thread/user
-  const parsedFiles = await WorkspaceParsedFiles.getContextFiles(
-    workspace,
-    thread || null,
-    user || null
-  );
+  // Parsed files — reuse pre-fetched if available, otherwise fetch fresh.
+  const parsedFiles =
+    prefetchedParsedFiles ??
+    (await WorkspaceParsedFiles.getContextFiles(
+      workspace,
+      thread || null,
+      user || null
+    ));
   parsedFiles.forEach((doc) => {
     const { pageContent, ...metadata } = doc;
     contextTexts.push(doc.pageContent);
@@ -256,10 +255,13 @@ async function streamChatWithWorkspace(
 
   // Compress & Assemble message to ensure prompt passes token limit with room for response
   // and build system messages based on inputs and history.
-  const systemPrompt = await chatPrompt(workspace, user, {
-    prompt: updatedMessage,
-    rawHistory,
-  });
+  // Reuse the system prompt from routing pre-fetch when available.
+  const systemPrompt =
+    prefetchedContext?.systemPrompt ??
+    (await chatPrompt(workspace, user, {
+      prompt: updatedMessage,
+      rawHistory,
+    }));
   const messages = await LLMConnector.compressMessages(
     {
       systemPrompt,
@@ -363,13 +365,14 @@ async function resolveLLMConnector({
         model: workspace?.chatModel,
       }),
       routingMetadata: null,
+      prefetchedContext: null,
       error: null,
     };
   }
 
   try {
     const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
-    const { TokenManager } = require("../helpers/tiktoken");
+    const { ModelRouterService } = require("../router");
 
     const routerWorkspace = workspace?.router_id
       ? workspace
@@ -381,20 +384,18 @@ async function resolveLLMConnector({
         };
 
     const router = new AnythingLLMModelRouter(routerWorkspace);
-    const tokenManager = new TokenManager();
-    const conversationTokenCount = tokenManager.countFromString(message);
-    const conversationMessageCount = await WorkspaceChats.count({
-      workspaceId: workspace.id,
-      user_id: user?.id || null,
-      thread_id: thread?.id || null,
-      include: true,
+    const ctx = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      user,
+      thread,
+      message,
     });
 
     await router.resolve(
       {
         prompt: message,
-        conversationTokenCount,
-        conversationMessageCount,
+        conversationTokenCount: ctx.conversationTokenCount,
+        conversationMessageCount: ctx.conversationMessageCount,
         attachments,
       },
       { user, thread }
@@ -403,12 +404,14 @@ async function resolveLLMConnector({
     return {
       connector: router.delegateProvider,
       routingMetadata: router.routingMetadata,
+      prefetchedContext: ctx,
       error: null,
     };
   } catch (routerError) {
     return {
       connector: null,
       routingMetadata: null,
+      prefetchedContext: null,
       error: `Model router error: ${routerError.message}`,
     };
   }

--- a/server/utils/helpers/customModels.js
+++ b/server/utils/helpers/customModels.js
@@ -50,6 +50,7 @@ const SUPPORT_CUSTOM_MODELS = [
   "sambanova",
   "lemonade",
   "minimax",
+  "generic-openai",
   // Embedding Engines
   "native-embedder",
   "cohere-embedder",
@@ -136,6 +137,8 @@ async function getCustomModels(provider = "", apiKey = null, basePath = null) {
       return await getLemonadeModels(basePath, "embedding");
     case "minimax":
       return await getMinimaxModels(apiKey);
+    case "generic-openai":
+      return await getGenericOpenAiModels(basePath, apiKey);
     default:
       return { models: [], error: "Invalid provider for custom models" };
   }
@@ -1070,6 +1073,37 @@ async function getSambaNovaModels(_apiKey = null) {
   } catch (e) {
     console.error(`SambaNova:getSambaNovaModels`, e.message);
     return { models: [], error: "Could not fetch SambaNova Models" };
+  }
+}
+
+async function getGenericOpenAiModels(basePath = null, apiKey = null) {
+  try {
+    const { OpenAI: OpenAIApi } = require("openai");
+    const openai = new OpenAIApi({
+      baseURL: basePath || process.env.GENERIC_OPEN_AI_BASE_PATH,
+      apiKey: apiKey || process.env.GENERIC_OPEN_AI_API_KEY || null,
+    });
+    const models = await openai.models
+      .list()
+      .then((results) => results.data)
+      .then((models) =>
+        models.map((model) => ({
+          id: model.id,
+          name: model.id,
+          organization: model.owned_by ?? "generic-openai",
+        }))
+      )
+      .catch((e) => {
+        console.error(`GenericOpenAI:listModels`, e.message);
+        return [];
+      });
+
+    if (models.length > 0 && !!apiKey)
+      process.env.GENERIC_OPEN_AI_API_KEY = apiKey;
+    return { models, error: null };
+  } catch (e) {
+    console.error(`GenericOpenAI:getGenericOpenAiModels`, e.message);
+    return { models: [], error: "Could not fetch Generic OpenAI Models" };
   }
 }
 

--- a/server/utils/helpers/index.js
+++ b/server/utils/helpers/index.js
@@ -33,12 +33,15 @@
 
 /**
  * @typedef {Object} BaseLLMProvider - A basic llm provider object
+ * @property {string} className - Provider identifier used in logs and response metrics.
+ * @property {string} model - The active model name for this provider instance.
+ * @property {number} defaultTemp - Default sampling temperature (typically 0.7).
  * @property {Function} streamingEnabled - Checks if streaming is enabled for chat completions.
  * @property {Function} promptWindowLimit - Returns the token limit for the current model.
  * @property {Function} isValidChatCompletionModel - Validates if the provided model is suitable for chat completion.
  * @property {Function} constructPrompt - Constructs a formatted prompt for the chat completion request.
- * @property {getChatCompletionFunction} getChatCompletion - Gets a chat completion response from OpenAI.
- * @property {streamGetChatCompletionFunction} streamGetChatCompletion - Streams a chat completion response from OpenAI.
+ * @property {getChatCompletionFunction} getChatCompletion - Gets a chat completion response.
+ * @property {streamGetChatCompletionFunction} streamGetChatCompletion - Streams a chat completion response.
  * @property {Function} handleStream - Handles the streaming response.
  * @property {Function} embedTextInput - Embeds the provided text input using the specified embedder.
  * @property {Function} embedChunks - Embeds multiple chunks of text using the specified embedder.
@@ -125,6 +128,8 @@ function getVectorDbClass(getExactly = null) {
 
 /**
  * Returns the LLMProvider with its embedder attached via system or via defined provider.
+ * @notice Use resolveProviderConnector instead as this function DOES NOT handle the anythingllm-router provider.
+ * You should only use this function if you are absolutely sure you are not using the anythingllm-router provider ever in your code.
  * @param {{provider: string | null, model: string | null} | null} params - Initialize params for LLMs provider
  * @returns {BaseLLMProvider}
  */
@@ -610,6 +615,85 @@ function humanFileSize(bytes, si = false, dp = 1) {
   return bytes.toFixed(dp) + " " + units[u];
 }
 
+/**
+ * Async wrapper that resolves the correct LLM connector for a workspace,
+ * handling the anythingllm-router provider transparently. Callers get back
+ * a ready-to-use connector without needing to know about routing internals.
+ *
+ * @param {Object} opts
+ * @param {Object} opts.workspace - The workspace record (required)
+ * @param {string} [opts.prompt] - The current user prompt
+ * @param {Object|null} [opts.user] - The user object
+ * @param {Object|null} [opts.thread] - The thread object
+ * @param {Object[]} [opts.attachments] - Attachments array
+ * @param {Object|null} [opts.chatHistoryOverride] - Pre-fetched chat history
+ * @param {number|null} [opts.messageCountOverride] - Override for message count
+ * @param {string|null} [opts.apiSessionId] - API session scope
+ * @returns {Promise<{connector: BaseLLMProvider, routingMetadata: Object|null, prefetchedContext: Object|null}>}
+ */
+async function resolveProviderConnector({
+  workspace,
+  prompt = "",
+  user = null,
+  thread = null,
+  attachments = [],
+  chatHistoryOverride = null,
+  messageCountOverride = null,
+  apiSessionId = null,
+}) {
+  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
+
+  if (effectiveProvider !== "anythingllm-router") {
+    return {
+      connector: getLLMProvider({
+        provider: workspace?.chatProvider,
+        model: workspace?.chatModel,
+      }),
+      routingMetadata: null,
+      prefetchedContext: null,
+    };
+  }
+
+  const { AnythingLLMModelRouter } = require("../AiProviders/modelRouter");
+  const { ModelRouterService } = require("../router");
+
+  const routerWorkspace = workspace?.router_id
+    ? workspace
+    : {
+        ...workspace,
+        router_id: process.env.MODEL_ROUTER_ID
+          ? Number(process.env.MODEL_ROUTER_ID)
+          : null,
+      };
+
+  const router = new AnythingLLMModelRouter(routerWorkspace);
+  const ctx = await ModelRouterService.gatherRoutingContext({
+    workspace,
+    user,
+    thread,
+    message: prompt,
+    chatHistoryOverride,
+    messageCountOverride,
+    apiSessionId,
+  });
+
+  await router.resolve(
+    {
+      prompt,
+      conversationTokenCount: ctx.conversationTokenCount,
+      conversationMessageCount: ctx.conversationMessageCount,
+      attachments,
+    },
+    { user, thread }
+  );
+
+  return {
+    connector: router.delegateProvider,
+    routingMetadata: router.routingMetadata,
+    prefetchedContext: ctx,
+  };
+}
+
 module.exports = {
   getEmbeddingEngineSelection,
   maximumChunkLength,
@@ -617,6 +701,7 @@ module.exports = {
   getLLMProviderClass,
   getBaseLLMProviderModel,
   getLLMProvider,
+  resolveProviderConnector,
   toChunks,
   humanFileSize,
   reportEmbeddingProgress,

--- a/server/utils/router/index.js
+++ b/server/utils/router/index.js
@@ -292,6 +292,126 @@ class ModelRouterService {
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // Conversation context helpers
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Gather all conversation context needed for routing decisions. Fetches
+   * chat history, system prompt, pinned docs, and parsed files — everything
+   * that contributes to the token count sent to the LLM.
+   *
+   * Returns all fetched data so callers can re-use it downstream without
+   * hitting the DB or filesystem a second time.
+   *
+   * @param {Object} opts
+   * @param {Object} opts.workspace - The workspace record
+   * @param {Object|null} [opts.user] - The user object (or null)
+   * @param {Object|null} [opts.thread] - The thread object with at least { id } (or null)
+   * @param {string} opts.message - The current user prompt
+   * @param {Object} [opts.chatHistoryOverride] - If provided, skip DB lookup and use these directly
+   * @param {Object[]} [opts.chatHistoryOverride.rawHistory] - Raw DB rows
+   * @param {{role:string,content:string}[]} [opts.chatHistoryOverride.chatHistory] - Prompt-formatted history
+   * @param {number|null} [opts.messageCountOverride] - If provided, use this as the true message count instead of querying WorkspaceChats
+   * @param {string|null} [opts.apiSessionId] - If provided, scope chat history and count to this API session
+   * @returns {Promise<{
+   *   rawHistory: Object[],
+   *   chatHistory: {role:string,content:string}[],
+   *   systemPrompt: string,
+   *   contextTexts: string[],
+   *   pinnedDocs: Object[],
+   *   parsedFiles: Object[],
+   *   conversationTokenCount: number,
+   *   conversationMessageCount: number
+   * }>}
+   */
+  static async gatherRoutingContext({
+    workspace,
+    user = null,
+    thread = null,
+    message = "",
+    chatHistoryOverride = null,
+    messageCountOverride = null,
+    apiSessionId = null,
+  }) {
+    const { chatPrompt, recentChatHistory } = require("../chats");
+    const { DocumentManager } = require("../DocumentManager");
+    const {
+      WorkspaceParsedFiles,
+    } = require("../../models/workspaceParsedFiles");
+    const { TokenManager } = require("../helpers/tiktoken");
+
+    const messageLimit = workspace?.openAiHistory || 20;
+
+    const { rawHistory, chatHistory } = chatHistoryOverride
+      ? chatHistoryOverride
+      : await recentChatHistory({
+          user,
+          workspace,
+          thread,
+          messageLimit,
+          apiSessionId,
+        });
+
+    const systemPrompt = await chatPrompt(workspace, user, {
+      prompt: message,
+      rawHistory,
+    });
+
+    const pinnedDocs = await new DocumentManager({ workspace }).pinnedDocs();
+    const parsedFiles = await WorkspaceParsedFiles.getContextFiles(
+      workspace,
+      thread || null,
+      user || null
+    );
+
+    const contextTexts = [
+      ...pinnedDocs.map((doc) => doc.pageContent),
+      ...parsedFiles.map((doc) => doc.pageContent),
+    ];
+
+    const tokenManager = new TokenManager();
+    const systemTokens = tokenManager.countFromString(systemPrompt);
+    const contextTokens = contextTexts.reduce(
+      (sum, text) => sum + tokenManager.countFromString(text || ""),
+      0
+    );
+    const historyTokens = chatHistory.reduce(
+      (sum, msg) => sum + tokenManager.countFromString(msg.content || ""),
+      0
+    );
+    const messageTokens = tokenManager.countFromString(message);
+
+    // Use the true DB count for message count rather than the capped
+    // chatHistory length, so routing rules based on conversation length
+    // evaluate against the real total.
+    let conversationMessageCount;
+    if (messageCountOverride != null) {
+      conversationMessageCount = messageCountOverride;
+    } else {
+      const { WorkspaceChats } = require("../../models/workspaceChats");
+      conversationMessageCount = await WorkspaceChats.count({
+        workspaceId: workspace.id,
+        user_id: user?.id || null,
+        thread_id: thread?.id || null,
+        api_session_id: apiSessionId || null,
+        include: true,
+      });
+    }
+
+    return {
+      rawHistory,
+      chatHistory,
+      systemPrompt,
+      contextTexts,
+      pinnedDocs,
+      parsedFiles,
+      conversationTokenCount:
+        systemTokens + contextTokens + historyTokens + messageTokens,
+      conversationMessageCount,
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Route evaluation
   // ─────────────────────────────────────────────────────────────────────────────
 

--- a/server/utils/router/index.js
+++ b/server/utils/router/index.js
@@ -389,13 +389,14 @@ class ModelRouterService {
       conversationMessageCount = messageCountOverride;
     } else {
       const { WorkspaceChats } = require("../../models/workspaceChats");
-      conversationMessageCount = await WorkspaceChats.count({
+      const countClause = {
         workspaceId: workspace.id,
         user_id: user?.id || null,
         thread_id: thread?.id || null,
         api_session_id: apiSessionId || null,
-        include: true,
-      });
+      };
+      if (!apiSessionId) countClause.include = true;
+      conversationMessageCount = await WorkspaceChats.count(countClause);
     }
 
     return {

--- a/server/utils/router/index.js
+++ b/server/utils/router/index.js
@@ -383,7 +383,8 @@ class ModelRouterService {
 
     // Use the true DB count for message count rather than the capped
     // chatHistory length, so routing rules based on conversation length
-    // evaluate against the real total.
+    // evaluate against the real total. +1 to include the current in-flight
+    // message so ">=3" fires on the user's 3rd message, not the 4th.
     let conversationMessageCount;
     if (messageCountOverride != null) {
       conversationMessageCount = messageCountOverride;
@@ -396,7 +397,8 @@ class ModelRouterService {
         api_session_id: apiSessionId || null,
       };
       if (!apiSessionId) countClause.include = true;
-      conversationMessageCount = await WorkspaceChats.count(countClause);
+      conversationMessageCount =
+        (await WorkspaceChats.count(countClause)) + 1;
     }
 
     return {

--- a/server/utils/router/index.js
+++ b/server/utils/router/index.js
@@ -397,8 +397,7 @@ class ModelRouterService {
         api_session_id: apiSessionId || null,
       };
       if (!apiSessionId) countClause.include = true;
-      conversationMessageCount =
-        (await WorkspaceChats.count(countClause)) + 1;
+      conversationMessageCount = (await WorkspaceChats.count(countClause)) + 1;
     }
 
     return {

--- a/server/utils/router/index.js
+++ b/server/utils/router/index.js
@@ -491,10 +491,17 @@ class ModelRouterService {
     this.log(
       `Evaluating ${enabledRules.length} enabled rules (of ${rules.length} total) for router "${router.name}"`
     );
+
+    // For debugging purposes, truncate the prompt to 50 characters.
+    const truncatedPrompt = (
+      String(context.prompt).length > 50
+        ? String(context.prompt).slice(0, 25) +
+          "..." +
+          String(context.prompt).slice(-25)
+        : String(context.prompt)
+    ).replace(/[\n\r\t]+/g, " ");
     this.log(
-      `Context: prompt="${(context.prompt || "").slice(0, 100)}${context.prompt?.length > 100 ? "..." : ""}", ` +
-        `tokens=${context.conversationTokenCount ?? 0}, messages=${context.conversationMessageCount ?? 0}, ` +
-        `attachments=${context.attachments?.length ?? 0}`
+      `Context: prompt="${truncatedPrompt}", tokens=${context.conversationTokenCount ?? 0}, messages=${context.conversationMessageCount ?? 0}, attachments=${context.attachments?.length ?? 0}`
     );
   }
 

--- a/server/utils/telegramBot/chat/stream.js
+++ b/server/utils/telegramBot/chat/stream.js
@@ -1,5 +1,5 @@
 const { WorkspaceChats } = require("../../../models/workspaceChats");
-const { getLLMProvider, getVectorDbClass } = require("../../helpers");
+const { getVectorDbClass, resolveProviderConnector } = require("../../helpers");
 const { DocumentManager } = require("../../DocumentManager");
 const {
   sourceIdentifier,
@@ -97,41 +97,12 @@ async function streamResponse({
     ctx.bot.sendChatAction(chatId, "typing").catch(() => {});
   }, 4000);
 
-  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
-  let LLMConnector;
-  if (effectiveProvider === "anythingllm-router") {
-    const { AnythingLLMModelRouter } = require("../../AiProviders/modelRouter");
-    const { ModelRouterService } = require("../../router");
-    const routerWorkspace = workspace?.router_id
-      ? workspace
-      : {
-          ...workspace,
-          router_id: process.env.MODEL_ROUTER_ID
-            ? Number(process.env.MODEL_ROUTER_ID)
-            : null,
-        };
-    const router = new AnythingLLMModelRouter(routerWorkspace);
-    const ctx_ = await ModelRouterService.gatherRoutingContext({
-      workspace,
-      thread,
-      message,
-    });
-    await router.resolve(
-      {
-        prompt: message,
-        conversationTokenCount: ctx_.conversationTokenCount,
-        conversationMessageCount: ctx_.conversationMessageCount,
-        attachments,
-      },
-      { thread }
-    );
-    LLMConnector = router.delegateProvider;
-  } else {
-    LLMConnector = getLLMProvider({
-      provider: workspace?.chatProvider,
-      model: workspace?.chatModel,
-    });
-  }
+  const { connector: LLMConnector } = await resolveProviderConnector({
+    workspace,
+    prompt: message,
+    thread,
+    attachments,
+  });
   const VectorDb = getVectorDbClass();
   const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
 

--- a/server/utils/telegramBot/chat/stream.js
+++ b/server/utils/telegramBot/chat/stream.js
@@ -97,10 +97,41 @@ async function streamResponse({
     ctx.bot.sendChatAction(chatId, "typing").catch(() => {});
   }, 4000);
 
-  const LLMConnector = getLLMProvider({
-    provider: workspace?.chatProvider,
-    model: workspace?.chatModel,
-  });
+  const effectiveProvider = workspace?.chatProvider || process.env.LLM_PROVIDER;
+  let LLMConnector;
+  if (effectiveProvider === "anythingllm-router") {
+    const { AnythingLLMModelRouter } = require("../../AiProviders/modelRouter");
+    const { ModelRouterService } = require("../../router");
+    const routerWorkspace = workspace?.router_id
+      ? workspace
+      : {
+          ...workspace,
+          router_id: process.env.MODEL_ROUTER_ID
+            ? Number(process.env.MODEL_ROUTER_ID)
+            : null,
+        };
+    const router = new AnythingLLMModelRouter(routerWorkspace);
+    const ctx_ = await ModelRouterService.gatherRoutingContext({
+      workspace,
+      thread,
+      message,
+    });
+    await router.resolve(
+      {
+        prompt: message,
+        conversationTokenCount: ctx_.conversationTokenCount,
+        conversationMessageCount: ctx_.conversationMessageCount,
+        attachments,
+      },
+      { thread }
+    );
+    LLMConnector = router.delegateProvider;
+  } else {
+    LLMConnector = getLLMProvider({
+      provider: workspace?.chatProvider,
+      model: workspace?.chatModel,
+    });
+  }
   const VectorDb = getVectorDbClass();
   const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
 


### PR DESCRIPTION
### Description

Previously the router only counted tokens from the current user message, ignoring system prompt, chat history, pinned docs, and parsed files.

Introduce ModelRouterService.gatherRoutingContext() to compute the true conversation token count and reuse the fetched context downstream to avoid redundant DB/filesystem lookups.

Also adds model router support to the OpenAI-compatible and API chat handlers, propagates usageMetrics through ephemeral agents, and fixes the router input to use the attachment-injected message.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

