### PR TITLE
Migrate slash commands to admin user on multi-user-mode

### DIFF
--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -625,6 +625,7 @@ function systemEndpoints(app) {
         await Memory.migrateToMultiUser(user.id);
         await WorkspaceChats.migrateToMultiUser(user.id);
         await MobileDevice.migrateDevicesToMultiUser(user.id);
+        await SlashCommandPresets.migrateToMultiUser(user.id);
         await AgentSkillWhitelist.clearSingleUserWhitelist();
         await updateENV(
           {

--- a/server/models/slashCommandsPresets.js
+++ b/server/models/slashCommandsPresets.js
@@ -112,6 +112,32 @@ const SlashCommandPresets = {
       return false;
     }
   },
+
+  /**
+   * Migrates all slash command presets with null userId to the specified admin user.
+   * Called during multi-user mode enablement to assign orphaned presets to the new admin.
+   * @param {number} adminUserId - The admin user ID to assign presets to
+   * @returns {Promise<void>}
+   */
+  migrateToMultiUser: async function (adminUserId) {
+    try {
+      await prisma.slash_command_presets.updateMany({
+        where: { userId: null },
+        data: {
+          userId: adminUserId,
+          uid: adminUserId,
+        },
+      });
+      console.log(
+        "Successfully migrated slash command presets to multi-user mode"
+      );
+    } catch (error) {
+      console.error(
+        "Error migrating slash command presets to multi-user mode:",
+        error
+      );
+    }
+  },
 };
 
 module.exports.SlashCommandPresets = SlashCommandPresets;


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5682

### Description

On swap to multi-user mode - transfer all slash commands to admin user like we do for other assets (like device tokens, etc)

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
