### PR TITLE
refactor Prompt to not block main chat content

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -313,6 +313,7 @@ export default function PromptInput({
 
   return (
     <div
+      id="prompt-input-wrapper"
       className={
         centered
           ? "w-full relative flex justify-center items-center"

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -53,6 +53,28 @@ export default function ChatContainer({
   const pendingMessageChecked = useRef(false);
   const pendingResetRef = useRef(false);
 
+  const isEmpty =
+    chatHistory.length === 0 && !sessionStorage.getItem(PENDING_HOME_MESSAGE);
+
+  /**
+   * Keep chat history bottom-padding in sync with the prompt input's
+   * actual rendered height so expanding input never covers messages.
+   */
+  useEffect(() => {
+    if (isEmpty) return;
+    const wrapper = document.getElementById("prompt-input-wrapper");
+    const chatEl = document.getElementById("chat-history");
+    if (!wrapper || !chatEl) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      const inputHeight =
+        entry.borderBoxSize?.[0]?.blockSize ?? entry.target.offsetHeight;
+      chatEl.style.paddingBottom = `${inputHeight}px`;
+    });
+    observer.observe(wrapper);
+    return () => observer.disconnect();
+  }, [isEmpty]);
+
   const { listening, resetTranscript } = useSpeechRecognition({
     clearTranscriptOnListen: true,
   });
@@ -376,9 +398,6 @@ export default function ChatContainer({
       }
     };
   }, [socketId]);
-
-  const isEmpty =
-    chatHistory.length === 0 && !sessionStorage.getItem(PENDING_HOME_MESSAGE);
 
   if (isEmpty) {
     return (


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [x] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5690

### Description

Dynamically resize prompt input and keep it to where thread is always scrollable to be viewed with max prompt height.
Should have no impact or changes in UI (default messages, attachments, tool menu, etc) for how they work currently.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
