### PR TITLE
fix(agents): add reasoning parsing support for non-Ollama agent providers

### DIFF
--- a/server/__tests__/utils/agents/aibitat/providers/helpers/untooled.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/helpers/untooled.test.js
@@ -85,3 +85,49 @@ describe("UnTooled: validFuncCall", () => {
     expect(result.reason).toBe("Unknown argument: unknown provided but not in schema.");
   });
 });
+
+describe("UnTooled: complete with reasoning", () => {
+  const untooled = new UnTooled();
+
+  it("should extract reasoning_content and prepend it wrapped in <think> tags", async () => {
+    const chatCallback = jest.fn().mockResolvedValue({
+      choices: [{
+        message: {
+          content: "Hello world",
+          reasoning_content: "Hmm, let me think...",
+        }
+      }]
+    });
+
+    const result = await untooled.complete([{ role: "user", content: "hi" }], [], chatCallback);
+    expect(result.textResponse).toBe("<think>Hmm, let me think...</think>Hello world");
+  });
+
+  it("should extract reasoningContent.text and prepend it wrapped in <think> tags", async () => {
+    const chatCallback = jest.fn().mockResolvedValue({
+      choices: [{
+        message: {
+          content: "Hello world",
+          reasoningContent: { text: "Hmm, let me think..." },
+        }
+      }]
+    });
+
+    const result = await untooled.complete([{ role: "user", content: "hi" }], [], chatCallback);
+    expect(result.textResponse).toBe("<think>Hmm, let me think...</think>Hello world");
+  });
+
+  it("should extract thinking and prepend it wrapped in <think> tags", async () => {
+    const chatCallback = jest.fn().mockResolvedValue({
+      choices: [{
+        message: {
+          content: "Hello world",
+          thinking: "Hmm, let me think...",
+        }
+      }]
+    });
+
+    const result = await untooled.complete([{ role: "user", content: "hi" }], [], chatCallback);
+    expect(result.textResponse).toBe("<think>Hmm, let me think...</think>Hello world");
+  });
+});

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -204,6 +204,7 @@ async function tooledStream(
 
   const toolCallsByIndex = {};
   let usage = null;
+  let reasoningText = "";
 
   for await (const chunk of stream) {
     // Capture usage from final chunk (some providers send usage after finish_reason)
@@ -213,6 +214,43 @@ async function tooledStream(
 
     if (!chunk?.choices?.[0]) continue;
     const choice = chunk.choices[0];
+
+    const reasoningToken =
+      choice.delta?.reasoning_content ||
+      choice.delta?.reasoningContent?.text ||
+      choice.delta?.thinking;
+
+    if (reasoningToken) {
+      if (reasoningText.length === 0) {
+        const startTag = "<think>";
+        eventHandler?.("reportStreamEvent", {
+          type: "textResponseChunk",
+          uuid: msgUUID,
+          content: startTag + reasoningToken,
+        });
+        reasoningText += startTag + reasoningToken;
+      } else {
+        eventHandler?.("reportStreamEvent", {
+          type: "textResponseChunk",
+          uuid: msgUUID,
+          content: reasoningToken,
+        });
+        reasoningText += reasoningToken;
+      }
+      continue;
+    }
+
+    const isStandardToken = !!choice.delta?.content || !!choice.delta?.tool_calls;
+    if (reasoningText.length > 0 && !reasoningToken && isStandardToken) {
+      const endTag = "</think>";
+      eventHandler?.("reportStreamEvent", {
+        type: "textResponseChunk",
+        uuid: msgUUID,
+        content: endTag,
+      });
+      result.textResponse += reasoningText + endTag;
+      reasoningText = "";
+    }
 
     if (choice.delta?.content) {
       result.textResponse += choice.delta.content;
@@ -257,6 +295,16 @@ async function tooledStream(
         }
       }
     }
+  }
+
+  if (reasoningText.length > 0 && !result.textResponse.endsWith("</think>")) {
+    const endTag = "</think>";
+    eventHandler?.("reportStreamEvent", {
+      type: "textResponseChunk",
+      uuid: msgUUID,
+      content: endTag,
+    });
+    result.textResponse += reasoningText + endTag;
   }
 
   // Auto-record usage if provider is passed and usage is available
@@ -369,8 +417,17 @@ async function tooledComplete(
     };
   }
 
+  let textResponse = completion.content;
+  const reasoningContent =
+    completion.reasoning_content ||
+    completion.reasoningContent?.text ||
+    completion.thinking;
+  if (reasoningContent && reasoningContent.trim().length > 0) {
+    textResponse = `<think>${reasoningContent}</think>${textResponse || ""}`;
+  }
+
   return {
-    textResponse: completion.content,
+    textResponse,
     cost,
     usage,
   };

--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -339,9 +339,47 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
           messages: this.cleanMsgs(messages),
         });
 
+        let reasoningText = "";
         for await (const chunk of stream) {
           if (!chunk?.choices?.[0]) continue; // Skip if no choices
           const choice = chunk.choices[0];
+
+          const reasoningToken =
+            choice.delta?.reasoning_content ||
+            choice.delta?.reasoningContent?.text ||
+            choice.delta?.thinking;
+
+          if (reasoningToken) {
+            if (reasoningText.length === 0) {
+              const startTag = "<think>";
+              eventHandler?.("reportStreamEvent", {
+                type: "textResponseChunk",
+                uuid: msgUUID,
+                content: startTag + reasoningToken,
+              });
+              reasoningText += startTag + reasoningToken;
+            } else {
+              eventHandler?.("reportStreamEvent", {
+                type: "textResponseChunk",
+                uuid: msgUUID,
+                content: reasoningToken,
+              });
+              reasoningText += reasoningToken;
+            }
+            continue;
+          }
+
+          if (reasoningText.length > 0 && !reasoningToken && choice.delta?.content) {
+            const endTag = "</think>";
+            eventHandler?.("reportStreamEvent", {
+              type: "textResponseChunk",
+              uuid: msgUUID,
+              content: endTag,
+            });
+            completion.content += reasoningText + endTag;
+            reasoningText = "";
+          }
+
           if (choice.delta?.content) {
             completion.content += choice.delta.content;
             eventHandler?.("reportStreamEvent", {
@@ -350,6 +388,16 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
               content: choice.delta.content,
             });
           }
+        }
+
+        if (reasoningText.length > 0 && !completion.content.endsWith("</think>")) {
+          const endTag = "</think>";
+          eventHandler?.("reportStreamEvent", {
+            type: "textResponseChunk",
+            uuid: msgUUID,
+            content: endTag,
+          });
+          completion.content += reasoningText + endTag;
         }
       }
 
@@ -424,8 +472,17 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
       // from calling the exact same function over and over in a loop within a single chat exchange
       // _but_ we should enable it to call previously used tools in a new chat interaction.
       this.deduplicator.reset("runs");
+      let textResponse = completion.content;
+      const reasoningContent =
+        completion.reasoning_content ||
+        completion.reasoningContent?.text ||
+        completion.thinking;
+      if (reasoningContent && reasoningContent.trim().length > 0) {
+        textResponse = `<think>${reasoningContent}</think>${textResponse || ""}`;
+      }
+
       return {
-        textResponse: completion.content,
+        textResponse,
         cost: 0,
       };
     } catch (error) {


### PR DESCRIPTION
### Pull Request Type

- [ ] feat (New feature)
- [x] fix (Bug fix)
- [ ] refactor (Code refactoring without changing behavior)
- [ ] style (UI style changes)
- [ ] chore (Build, CI, maintenance)
- [ ] docs (Documentation updates)

### Relevant Issues

resolves # (Resolves the issue: Non-Ollama Agent Providers Do Not Parse and Present Reasoning Content)

### Description

This Pull Request adds full reasoning and thinking token extraction and parsing support (e.g., DeepSeek R1 `<think>` tags) to all non-Ollama agent providers in AnythingLLM.

**The Problem:**
During normal chats, AnythingLLM correctly intercepts, wraps, and streams reasoning content (such as `reasoning_content` from DeepSeek or `<think>` tags) so users can see the LLM's thought process. However, during Agent executions, the shared agent runners (`tooled.js` and `untooled.js`) completely discard reasoning and thinking tokens for all 30+ non-Ollama providers (DeepSeek API, LM Studio, AWS Bedrock, GiteeAI, OpenRouter, Generic OpenAI, etc.), causing the agent's reasoning steps to be lost.

**The Solution:**
*   Modified `tooledStream` and `tooledComplete` in `tooled.js` to parse reasoning tokens (`choice.delta?.reasoning_content`, `choice.delta?.reasoningContent?.text`, or `choice.delta?.thinking`) and wrap them in `<think>...</think>` tags for streaming and final responses.
*   Modified `UnTooled.prototype.stream` and `UnTooled.prototype.complete` in `untooled.js` to support reasoning wrapping when agents run standard chat completions or fall back to normal chat.
*   Added comprehensive unit tests inside `untooled.test.js` to assert and verify reasoning extraction behaviors under diverse mock inputs.

This elegantly enables reasoning support globally across all OpenAI-compatible, Bedrock, and custom agent providers in AnythingLLM.

### Visuals (if applicable)

N/A (Backend logic enhancement)

### Additional Information

This has been tested locally using a custom verification mock framework under Node v25 to ensure robust stream chunk tracking and transitions to tool calling or standard text.

### Developer Validations

- [x] I ran lint checks from the root of the repo and committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
