### PR TITLE
fix: stream vector-cache reads/writes to support very large documents

### DIFF
--- a/server/__tests__/utils/files/vectorCache.test.js
+++ b/server/__tests__/utils/files/vectorCache.test.js
@@ -1,0 +1,111 @@
+/* eslint-env jest */
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { v5: uuidv5 } = require("uuid");
+
+// The vector-cache helpers resolve their storage directory from STORAGE_DIR at
+// require-time (when NODE_ENV !== "development"), so point it at an isolated
+// temp directory before importing the module under test.
+const STORAGE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "allm-vector-cache-"));
+process.env.NODE_ENV = "test";
+process.env.STORAGE_DIR = STORAGE_DIR;
+
+// Avoid pulling Prisma-backed models (and a real DB connection) into the test.
+jest.mock("../../../models/documents", () => ({ Document: {} }));
+jest.mock("../../../models/documentSyncQueue", () => ({ DocumentSyncQueue: {} }));
+
+const {
+  storeVectorResult,
+  cachedVectorInformation,
+} = require("../../../utils/files");
+
+const vectorCacheDir = path.resolve(STORAGE_DIR, "vector-cache");
+const cacheFileFor = (filename) =>
+  path.resolve(vectorCacheDir, `${uuidv5(filename, uuidv5.URL)}.json`);
+
+const makeChunk = (i) => ({
+  id: `chunk-${i}`,
+  values: [i, i + 0.1, i + 0.2],
+  metadata: { text: `content ${i}`, source: "unit-test" },
+});
+
+beforeEach(() => fs.rmSync(vectorCacheDir, { recursive: true, force: true }));
+afterAll(() => fs.rmSync(STORAGE_DIR, { recursive: true, force: true }));
+
+describe("vector-cache storeVectorResult / cachedVectorInformation", () => {
+  test("writes the cache as JSON-lines (header + one JSON value per line)", async () => {
+    const filename = "documents/flat.json";
+    const data = [makeChunk(1), makeChunk(2), makeChunk(3)];
+
+    await storeVectorResult(data, filename);
+
+    const lines = fs
+      .readFileSync(cacheFileFor(filename), "utf8")
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+
+    // A header line + one line per chunk - never a single serialized array.
+    expect(lines).toHaveLength(data.length + 1);
+    expect(JSON.parse(lines[0]).__cacheType).toBe("vector-cache");
+    lines.slice(1).forEach((line, idx) => {
+      expect(JSON.parse(line)).toEqual(data[idx]);
+    });
+  });
+
+  test("reads back a JSON-lines cache file written by storeVectorResult", async () => {
+    const filename = "documents/roundtrip.json";
+    const data = [makeChunk(10), makeChunk(11), makeChunk(12)];
+
+    await storeVectorResult(data, filename);
+    const { exists, chunks } = await cachedVectorInformation(filename);
+
+    expect(exists).toBe(true);
+    expect(chunks).toEqual(data);
+  });
+
+  test("round-trips nested array-of-arrays chunk batches (Chroma layout)", async () => {
+    const filename = "documents/batched.json";
+    // Some vector DBs (e.g. Chroma) cache `toChunks(vectors, 500)`, so each
+    // array element is itself an array of records.
+    const data = [
+      [makeChunk(1), makeChunk(2)],
+      [makeChunk(3), makeChunk(4)],
+    ];
+
+    await storeVectorResult(data, filename);
+    const { chunks } = await cachedVectorInformation(filename);
+
+    expect(chunks).toEqual(data);
+  });
+
+  test("still reads legacy single-array cache files for backwards compatibility", async () => {
+    const filename = "documents/legacy.json";
+    const data = [makeChunk(7), makeChunk(8)];
+
+    // Reproduce a cache file written by the previous implementation.
+    fs.mkdirSync(vectorCacheDir, { recursive: true });
+    fs.writeFileSync(cacheFileFor(filename), JSON.stringify(data), "utf8");
+
+    const { exists, chunks } = await cachedVectorInformation(filename);
+
+    expect(exists).toBe(true);
+    expect(chunks).toEqual(data);
+  });
+
+  test("checkOnly reports existence without reading file contents", async () => {
+    const filename = "documents/exists.json";
+    expect(await cachedVectorInformation(filename, true)).toBe(false);
+
+    await storeVectorResult([makeChunk(1)], filename);
+    expect(await cachedVectorInformation(filename, true)).toBe(true);
+  });
+
+  test("returns an empty result when no filename is provided", async () => {
+    expect(await cachedVectorInformation(null)).toEqual({
+      exists: false,
+      chunks: [],
+    });
+    expect(await cachedVectorInformation(null, true)).toBe(false);
+  });
+});

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -1,6 +1,9 @@
 const fs = require("fs");
 const path = require("path");
 const { v5: uuidv5 } = require("uuid");
+const readline = require("readline");
+const { Readable } = require("stream");
+const { pipeline } = require("stream/promises");
 const { Document } = require("../../models/documents");
 const { DocumentSyncQueue } = require("../../models/documentSyncQueue");
 const documentsPath =
@@ -162,6 +165,69 @@ async function getDocumentsByFolder(folderName = "") {
   return { folder: folderName, documents, code: 200, error: null };
 }
 
+// Written as the first line of every vector-cache file so reads can tell the
+// streamed JSON-lines format apart from the legacy single JSON-array format.
+const VECTOR_CACHE_HEADER = {
+  __cacheType: "vector-cache",
+  format: "jsonl",
+  version: 1,
+};
+
+function isVectorCacheHeader(value) {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    value.__cacheType === "vector-cache"
+  );
+}
+
+/**
+ * Reads a vector-cache file back into an array of cached chunks.
+ *
+ * Files are stored as JSON-lines (a {@link VECTOR_CACHE_HEADER} line followed by
+ * one JSON value per line) so arbitrarily large caches can be streamed off disk
+ * without ever materializing the whole payload as a single string - doing so
+ * throws "RangeError: Invalid string length" once the data exceeds V8's max
+ * string size. Cache files written by previous versions stored the data as a
+ * single JSON array, so those are still read for backwards compatibility.
+ * @param {string} file - absolute path to the cache file
+ * @returns {Promise<any[]>} - the cached chunks
+ */
+async function readVectorCacheFile(file) {
+  const input = fs.createReadStream(file, { encoding: "utf8" });
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+
+  const chunks = [];
+  let format = null; // "jsonl" | "legacy"
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      const value = JSON.parse(trimmed);
+      if (format === null) {
+        // The first non-empty line determines the on-disk format.
+        if (isVectorCacheHeader(value)) {
+          format = "jsonl";
+          continue; // header is metadata, not a cached chunk
+        }
+        // Legacy caches serialize the entire payload as a single JSON array, so
+        // the first line already contains every cached chunk.
+        return Array.isArray(value) ? value : [value];
+      }
+      chunks.push(value);
+    }
+  } finally {
+    // Always release the file handle - returning early (legacy format) leaves
+    // the underlying read stream open since closing the interface alone does
+    // not destroy it.
+    rl.close();
+    input.destroy();
+  }
+  return chunks;
+}
+
 /**
  * Searches the vector-cache folder for existing information so we dont have to re-embed a
  * document and can instead push directly to vector db.
@@ -182,8 +248,7 @@ async function cachedVectorInformation(filename = null, checkOnly = false) {
   console.log(
     `Cached vectorized results of ${filename} found! Using cached data to save on embed costs.`
   );
-  const rawData = fs.readFileSync(file, "utf8");
-  return { exists: true, chunks: JSON.parse(rawData) };
+  return { exists: true, chunks: await readVectorCacheFile(file) };
 }
 
 // vectorData: pre-chunked vectorized data for a given file that includes the proper metadata and chunk-size limit so it can be iterated and dumped into Pinecone, etc
@@ -197,7 +262,21 @@ async function storeVectorResult(vectorData = [], filename = null) {
 
   const digest = uuidv5(filename, uuidv5.URL);
   const writeTo = path.resolve(vectorCachePath, `${digest}.json`);
-  fs.writeFileSync(writeTo, JSON.stringify(vectorData), "utf8");
+
+  // Stream the cache to disk as JSON-lines (a header line followed by one JSON
+  // value per line) instead of `JSON.stringify(vectorData)`. Serializing the
+  // entire array at once throws "RangeError: Invalid string length" once the
+  // result exceeds V8's max string size, which broke caching - and therefore
+  // re-embedding avoidance - for very large documents. See issue #5063.
+  function* cacheLines() {
+    yield `${JSON.stringify(VECTOR_CACHE_HEADER)}\n`;
+    for (const chunk of vectorData) yield `${JSON.stringify(chunk)}\n`;
+  }
+
+  await pipeline(
+    Readable.from(cacheLines()),
+    fs.createWriteStream(writeTo, { encoding: "utf8" })
+  );
   return;
 }
 


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5063

### Description

Embedding a sufficiently large document fails at the very end of vectorization
with `RangeError: Invalid string length`, even though the vectors were already
inserted into the vector database:

```
[VectorDB::Weaviate] addDocumentToNamespace Invalid string length
error: Failed to vectorize <file>.jsonl
```

**Root cause:** the vector-cache helpers serialize/deserialize the entire
payload as a single string:

- `storeVectorResult` writes the cache with `JSON.stringify(vectorData)`
- `cachedVectorInformation` reads it back with `JSON.parse(fs.readFileSync(...))`

Once the cached data exceeds V8's maximum string size (~512MB) either call
throws, so caching the embeddings fails (and, for a previously cached large
file, the read used to avoid re-embedding would fail too).

**Fix:** store the cache as JSON-lines — a small header line followed by one
JSON value per chunk — and stream it both ways:

- Writes use `stream.pipeline(Readable.from(...), createWriteStream(...))`, so
  the payload is never materialized as one string and backpressure is respected.
- Reads stream line-by-line with `readline`, parsing each line individually.

The header line keeps reads fully backwards compatible: cache files written by
previous versions are a single JSON array (and were necessarily small enough to
have been written), so they are detected and parsed exactly as before. The read
stream is also explicitly destroyed when returning early for the legacy format
so the file handle is not leaked.

### Visuals (if applicable)

N/A — backend only.

### Additional Information

- The cache file location and extension (`<digest>.json`) are unchanged, so the
  vector-cache purge / empty-check logic is unaffected.
- Added `server/__tests__/utils/files/vectorCache.test.js` covering the
  JSON-lines round-trip (including the nested array-of-arrays layout used by
  Chroma), legacy single-array backwards compatibility, and the
  `checkOnly`/empty-filename paths.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
