### PR TITLE
docs: list all cloud embedding providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,17 @@ AnythingLLM supports multiple users as well where you can control the access and
 - [AnythingLLM Native Embedder](/server/storage/models/README.md) (default)
 - [OpenAI](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
+- [Gemini](https://ai.google.dev/)
 - [LocalAI (all)](https://localai.io/)
 - [Ollama (all)](https://ollama.ai/)
 - [LM Studio (all)](https://lmstudio.ai)
+- [Lemonade](https://lemonade-server.ai)
+- [OpenRouter](https://openrouter.ai/)
+- [LiteLLM](https://github.com/BerriAI/litellm)
 - [Cohere](https://cohere.com/)
+- [Voyage AI](https://www.voyageai.com/)
+- [Mistral](https://mistral.ai/)
+- Generic OpenAI-compatible embedding APIs
 
 **Audio Transcription models:**
 


### PR DESCRIPTION
## Summary
- add the missing cloud embedder entries to the top-level README list
- align the documented embedder providers with the options exposed in `frontend/src/pages/GeneralSettings/EmbeddingPreference/index.jsx`
- explicitly mention Voyage AI so users do not have to inspect the code to confirm support

## Test plan
- `git diff --check`
- docs-only change; no code paths or generated artifacts changed

connect #5700
