### PR TITLE
docs: clarify text chunking strategy settings

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1130,7 +1130,7 @@ const TRANSLATIONS = {
     "desc-start":
       "Sometimes, you may want to change the default way that new documents are split and chunked before being inserted into your vector database.",
     "desc-end":
-      "You should only modify this setting if you understand how text splitting works and it's side effects.",
+      "AnythingLLM currently uses <strategy>LangChain's RecursiveCharacterTextSplitter</strategy> for document chunking. You should only modify these settings if you understand how that strategy affects retrieval quality and chunk size. See the <docs>LangChain recursive text splitter docs</docs> for more detail.",
     size: {
       title: "Text Chunk Size",
       description:

--- a/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
@@ -6,7 +6,7 @@ import CTAButton from "@/components/lib/CTAButton";
 import Admin from "@/models/admin";
 import showToast from "@/utils/toast";
 import { numberWithCommas } from "@/utils/numbers";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useModal } from "@/hooks/useModal";
 import ModalWrapper from "@/components/ModalWrapper";
 import ChangeWarningModal from "@/components/ChangeWarning";
@@ -117,7 +117,20 @@ export default function EmbeddingTextSplitterPreference() {
                 </div>
                 <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
                   {t("text.desc-start")} <br />
-                  {t("text.desc-end")}
+                  <Trans
+                    i18nKey="text.desc-end"
+                    components={{
+                      strategy: <code className="text-[11px] text-white/80" />,
+                      docs: (
+                        <a
+                          className="text-primary-button hover:underline"
+                          href="https://js.langchain.com/docs/concepts/text_splitters/recursive_text_splitter/"
+                          target="_blank"
+                          rel="noreferrer"
+                        />
+                      ),
+                    }}
+                  />
                 </p>
               </div>
               <div className="w-full justify-end flex">


### PR DESCRIPTION
## Summary
- explain that the chunking preferences page currently uses LangChain's `RecursiveCharacterTextSplitter`
- link the settings copy directly to the upstream strategy docs
- keep the change narrowly scoped to the existing admin settings page

## Validation
- `git diff --check`
- attempted `node frontend/src/locales/verifyTranslations.mjs`, but this runner only has Node v12.22.9 and the repo now expects a newer Node runtime (`Intl.DisplayNames` is unavailable here)

Closes Mintplex-Labs/anythingllm-docs#257