### PR TITLE
fix: respect IME composition in prompt input

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -54,6 +54,7 @@ export default function PromptInput({
   const formRef = useRef(null);
   const textareaRef = useRef(null);
   const [_, setFocused] = useState(false);
+  const isComposingRef = useRef(false);
   const undoStack = useRef([]);
   const redoStack = useRef([]);
   const { textSizeClass } = useTextSize();
@@ -137,6 +138,13 @@ export default function PromptInput({
    * @param {KeyboardEvent} event
    */
   function captureEnterOrUndo(event) {
+    const isComposing =
+      isComposingRef.current ||
+      event.isComposing ||
+      event.nativeEvent?.isComposing ||
+      event.keyCode === 229;
+    if (isComposing) return;
+
     // Forward keyboard events to the ToolsMenu when open
     if (showTools) {
       if (
@@ -299,7 +307,7 @@ export default function PromptInput({
   }
 
   function handleChange(e) {
-    debouncedSaveState(-1);
+    if (!isComposingRef.current) debouncedSaveState(-1);
     adjustTextArea(e);
     const value = e.target.value;
     setPromptInput(value);
@@ -309,6 +317,16 @@ export default function PromptInput({
       setShowTools(false);
       autoOpenedToolsRef.current = false;
     }
+  }
+
+  function handleCompositionStart() {
+    isComposingRef.current = true;
+  }
+
+  function handleCompositionEnd(e) {
+    isComposingRef.current = false;
+    adjustTextArea(e);
+    setPromptInput(e.target.value);
   }
 
   return (
@@ -349,6 +367,8 @@ export default function PromptInput({
                   ref={textareaRef}
                   onChange={handleChange}
                   onKeyDown={captureEnterOrUndo}
+                  onCompositionStart={handleCompositionStart}
+                  onCompositionEnd={handleCompositionEnd}
                   onPaste={(e) => {
                     saveCurrentState();
                     handlePasteEvent(e);


### PR DESCRIPTION
## Summary
- Guard prompt keyboard shortcuts while an IME composition is active, including Enter/keyCode 229 events from Android/Japanese keyboards.
- Track composition start/end on the chat textarea and sync the final composed value/height after conversion completes.
- Avoid adding undo snapshots while composition is in progress so the prompt does not interfere with conversion state.

## Why
Issue #5696 reports Japanese IME input as unusable on Android. The prompt input currently handles Enter and tool-menu shortcuts before checking whether the key event belongs to an active IME composition, which can turn conversion/confirmation keystrokes into submit/menu behavior.

This PR addresses the Japanese IME input portion of #5696. It does not claim to fix the separate Android MCP tools issue from the same report.

## Testing
- `yarn eslint src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx`
- `yarn build`