### PR TITLE
docs: fix self-hosted terms wording

### DIFF
--- a/TERMS_SELF_HOSTED.md
+++ b/TERMS_SELF_HOSTED.md
@@ -23,7 +23,7 @@ _by default, AnythingLLM does **everything on-device first** - so you would have
 ## 4. Security & Network
 * **No "Phone Home":** Aside from [optional telemetry](https://github.com/Mintplex-Labs/anything-llm?tab=readme-ov-file#telemetry--privacy), the software does not require an external connection to Mintplex Labs servers to function.
 * **Environment Security:** The user is responsible for securing the host environment, including network firewalls, SSL/TLS encryption, and access control for the AnythingLLM instance.
-* **CDN Assets:** Out of a convience to international users, we use a hosted CDN to mirror some critical path models (eg: the default embedder and reranking ONNX models) which are not available in all regions. These models are downloaded from our CDN as a fallback, and any air-gapped installations you can either download these models manually or use another provider. Assets of these nature are downloaded once and cached in your associated local storage.
+* **CDN Assets:** As a convenience to international users, we use a hosted CDN to mirror some critical path models (eg: the default embedder and reranking ONNX models) which are not available in all regions. These models are downloaded from our CDN as a fallback, and for any air-gapped installations you can either download these models manually or use another provider. Assets of this nature are downloaded once and cached in your associated local storage.
 
 ## 5. Licensing and Liability
 * **License:** The AnythingLLM core is provided under the **MIT License**.


### PR DESCRIPTION
Summary:
- Fixes clear spelling or wording mistakes in documentation.
- Keeps the change text-only with no behavior impact.

Testing:
- `git diff --check`
- `uvx codespell` on the changed files