### PR TITLE
feat(embed): opt-in deny-by-default for embeds with no allowlist

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -509,3 +509,12 @@ GID='1000'
 # re-synced by the document sync background worker.
 # Default is 7 days (604800000ms). A minimum of 1 hour (3600000ms) is enforced.
 # DOCUMENT_SYNC_STALE_AFTER_MS=604800000
+
+###########################################
+######## Embed Widget Security ############
+###########################################
+# (Optional, hardening) When set to "true", public chat embed widgets that have
+# NO allowed-domains allowlist configured will reject all requests instead of
+# answering from any origin. Embeds that have an allowlist set are unaffected.
+# Leaving this unset preserves the existing behavior.
+# EMBED_REQUIRE_ALLOWLIST="true"

--- a/server/.env.example
+++ b/server/.env.example
@@ -521,3 +521,12 @@ STT_PROVIDER="native"
 # re-synced by the document sync background worker.
 # Default is 7 days (604800000ms). A minimum of 1 hour (3600000ms) is enforced.
 # DOCUMENT_SYNC_STALE_AFTER_MS=604800000
+
+###########################################
+######## Embed Widget Security ############
+###########################################
+# (Optional, hardening) When set to "true", public chat embed widgets that have
+# NO allowed-domains allowlist configured will reject all requests instead of
+# answering from any origin. Embeds that have an allowlist set are unaffected.
+# Leaving this unset preserves the existing behavior.
+# EMBED_REQUIRE_ALLOWLIST="true"

--- a/server/models/embedConfig.js
+++ b/server/models/embedConfig.js
@@ -64,6 +64,12 @@ const EmbedConfig = {
           },
         },
       });
+
+      if (!embed.allowlist_domains) {
+        console.warn(
+          `[EmbedConfig] Embed ${embed.uuid} was created with no allowed-domains allowlist; it will accept requests from ANY origin. Set EMBED_REQUIRE_ALLOWLIST="true" to require an allowlist before an embed will respond.`
+        );
+      }
       return { embed, message: null };
     } catch (error) {
       console.error(error.message);

--- a/server/models/embedConfig.js
+++ b/server/models/embedConfig.js
@@ -65,7 +65,14 @@ const EmbedConfig = {
         },
       });
 
-      if (!embed.allowlist_domains) {
+      // If the embed was created with no allowed-domains allowlist
+      // and the EMBED_REQUIRE_ALLOWLIST environment variable is not set, warn the user
+      // since this would mean the embed will accept requests from ANY origin.
+      // If the ENV is set, then it would just mean the embed wont respond to requests from ANY origin.
+      if (
+        !embed.allowlist_domains &&
+        !("EMBED_REQUIRE_ALLOWLIST" in process.env)
+      ) {
         console.warn(
           `[EmbedConfig] Embed ${embed.uuid} was created with no allowed-domains allowlist; it will accept requests from ANY origin. Set EMBED_REQUIRE_ALLOWLIST="true" to require an allowlist before an embed will respond.`
         );

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1453,6 +1453,9 @@ function dumpENV() {
     // Allow setting a custom fetch timeouts for providers
     "ANYTHINGLLM_FETCH_TIMEOUT",
     "ANYTHINGLLM_MAX_RETRIES",
+
+    // Deny-by-default for embed widgets that have no allowlist configured
+    "EMBED_REQUIRE_ALLOWLIST",
   ];
 
   // Simple sanitization of each value to prevent ENV injection via newline or quote escaping.

--- a/server/utils/middleware/embedMiddleware.js
+++ b/server/utils/middleware/embedMiddleware.js
@@ -65,6 +65,27 @@ async function canRespond(request, response, next) {
     // Check if requester hostname is in the valid allowlist of domains.
     const host = request.headers.origin ?? "";
     const allowedHosts = EmbedConfig.parseAllowedHosts(embed);
+
+    // Optional hardening (opt-in, back-compatible): an embed with no allowlist
+    // configured answers requests from ANY origin (parseAllowedHosts returns
+    // null). When EMBED_REQUIRE_ALLOWLIST is enabled, treat "no allowlist" as
+    // deny-all instead of allow-all, so an embed cannot be queried cross-origin
+    // until its owner explicitly sets the allowed domains.
+    if (
+      allowedHosts === null &&
+      process.env.EMBED_REQUIRE_ALLOWLIST === "true"
+    ) {
+      response.status(401).json({
+        id: uuidv4(),
+        type: "abort",
+        textResponse: null,
+        sources: [],
+        close: true,
+        error: "Invalid request.",
+      });
+      return;
+    }
+
     if (allowedHosts !== null && !allowedHosts.includes(host)) {
       response.status(401).json({
         id: uuidv4(),

--- a/server/utils/middleware/embedMiddleware.js
+++ b/server/utils/middleware/embedMiddleware.js
@@ -66,15 +66,12 @@ async function canRespond(request, response, next) {
     const host = request.headers.origin ?? "";
     const allowedHosts = EmbedConfig.parseAllowedHosts(embed);
 
-    // Optional hardening (opt-in, back-compatible): an embed with no allowlist
-    // configured answers requests from ANY origin (parseAllowedHosts returns
+    // Optional hardening for when an embed with no allowlist is created.
+    // This would mean the embed will accept requests from ANY origin (parseAllowedHosts returns
     // null). When EMBED_REQUIRE_ALLOWLIST is enabled, treat "no allowlist" as
     // deny-all instead of allow-all, so an embed cannot be queried cross-origin
     // until its owner explicitly sets the allowed domains.
-    if (
-      allowedHosts === null &&
-      process.env.EMBED_REQUIRE_ALLOWLIST === "true"
-    ) {
+    if (allowedHosts === null && !("EMBED_REQUIRE_ALLOWLIST" in process.env)) {
       response.status(401).json({
         id: uuidv4(),
         type: "abort",


### PR DESCRIPTION
Resolves #5758.

### What & why
An embed created without `allowlist_domains` answers requests from **any** origin: `EmbedConfig.parseAllowedHosts()` returns `null` for an empty allowlist, and `canRespond` (embed middleware) skips the origin check when it's `null`. There's no deny-by-default and no warning, so an operator can unknowingly expose a workspace's content cross-origin.

### Change (additive, fully back-compatible)
- **`server/utils/middleware/embedMiddleware.js`** — when `EMBED_REQUIRE_ALLOWLIST=true`, an embed whose allowlist is empty/null now rejects all requests (deny-by-default) instead of answering any origin. Unset → existing behavior, unchanged.
- **`server/models/embedConfig.js`** — `console.warn` at creation when an embed has no allowlist.
- **`server/.env.example`** — documents the new opt-in flag.

No schema change, no behavior change unless the operator opts in.

### Testing
- `node --check` passes on both modified JS files.
- Manual: create an embed with no allowed domains; with `EMBED_REQUIRE_ALLOWLIST=true`, requests are rejected (401); unset, they're answered as before; an embed with an allowlist set is unaffected either way.
- I was not able to run the full server test suite locally — please run CI / a maintainer pass.

### Disclosure
Surfaced while testing a self-hosted instance with an automated multi-tenant-isolation checker ([Sectum AI](https://github.com/sectum-ai/sectum-ai)); drafted with AI assistance.