### PR TITLE
Minify Generic OpenAI request bodies for better server compatibility

### DIFF
--- a/server/utils/AiProviders/genericOpenAi/index.js
+++ b/server/utils/AiProviders/genericOpenAi/index.js
@@ -24,6 +24,7 @@ class GenericOpenAiLLM {
     this.openai = new OpenAIApi({
       baseURL: this.basePath,
       apiKey: process.env.GENERIC_OPEN_AI_API_KEY ?? null,
+      fetch: GenericOpenAiLLM.compactJsonFetch,
       defaultHeaders: {
         "User-Agent": getAnythingLLMUserAgent(),
         ...GenericOpenAiLLM.parseCustomHeaders(),
@@ -74,6 +75,25 @@ class GenericOpenAiLLM {
     }
 
     return headers;
+  }
+
+  /**
+   * A `fetch` that minifies JSON request bodies before sending. The OpenAI SDK
+   * pretty-prints bodies (`JSON.stringify(body, null, 2)`), but compact JSON is a
+   * lossless round-trip and the more universally compatible form across backends.
+   * Only string JSON bodies are touched; multipart/binary and unparseable bodies pass through as-is.
+   * @param {string|URL} url - the request url
+   * @param {Object} [init] - the fetch init options
+   * @returns {Promise<Response>}
+   */
+  static compactJsonFetch(url, init = {}) {
+    const { fetch: openAiFetch } = require("openai/_shims/index.js");
+    if (init && typeof init.body === "string") {
+      try {
+        init.body = JSON.stringify(JSON.parse(init.body));
+      } catch {}
+    }
+    return openAiFetch(url, init);
   }
 
   #appendContext(contextTexts = []) {

--- a/server/utils/agents/aibitat/providers/genericOpenAi.js
+++ b/server/utils/agents/aibitat/providers/genericOpenAi.js
@@ -23,6 +23,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
     const client = new OpenAI({
       baseURL: process.env.GENERIC_OPEN_AI_BASE_PATH,
       apiKey: process.env.GENERIC_OPEN_AI_API_KEY ?? null,
+      fetch: GenericOpenAiLLM.compactJsonFetch,
       defaultHeaders: {
         "User-Agent": getAnythingLLMUserAgent(),
         ...GenericOpenAiLLM.parseCustomHeaders(),


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5752 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- Chats and agents sent to a Generic OpenAI endpoint would hang forever with no response, no error, and no timeout — even though the endpoint was healthy and `curl`/other clients got normal responses from the same URL.
- Root cause: the `openai` Node SDK serializes every request body as pretty-printed JSON (`JSON.stringify(body, null, 2)`), so the body contains literal newlines, and some OpenAI-compatible servers mishandle that whitespace and never respond.
- Confirmed by replaying the exact request with `curl`: a compact single-line body streamed instantly, while the same body pretty-printed with newlines hung indefinitely.
- This is a server-side regression, not ours — the SDK has always pretty-printed bodies (verified `4.38.5` and `4.95.1` behave identically). It surfaced on Jan after the unified llama.cpp router process introduced in v0.8.0, which the reporter's v0.8.2 inherits.
- Fix: a small `fetch` wrapper on the Generic OpenAI clients (chat + agent paths) re-serializes string JSON request bodies compactly before sending. Minified JSON is a lossless round-trip and the more universally compatible form on the wire, so it works across every backend the provider targets.
- Safe for other providers: the transform only removes formatting whitespace — values, string contents (including `\n`/`\t` inside messages), escapes, and numbers stay byte-identical to what the SDK already produced. Only string JSON bodies are touched; multipart/binary and unparseable bodies pass through untouched.
- Scoped to the Generic OpenAI provider's clients only — OpenAI, Anthropic, Groq, Together, etc. build their own clients that are not modified and keep sending requests exactly as before.
- Jan regression reference: [v0.8.0 changelog](https://www.jan.ai/changelog/2026-05-22-jan-v0.8.0) (router process introduced), [v0.8.0 release](https://github.com/janhq/jan/releases/tag/v0.8.0), [v0.8.2 release](https://github.com/janhq/jan/releases/tag/v0.8.2) (version reported in #5752).

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
