### PR TITLE
Upgrade KaTeX from 0.6.0 to 0.16.11 to support modern LaTeX commands

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "i18next": "^23.11.3",
     "i18next-browser-languagedetector": "^7.2.1",
     "js-levenshtein": "^1.1.6",
-    "katex": "^0.6.0",
+    "katex": "^0.16.11",
     "lodash.debounce": "^4.0.8",
     "markdown-it": "^13.0.1",
     "moment": "^2.30.1",


### PR DESCRIPTION
## Summary

The frontend currently uses KaTeX 0.6.0, which lacks support for several commonly used LaTeX commands.

This PR upgrades KaTeX to 0.16.11.

## Fixed Examples

- \boxed{x+1}
- \cancel{x}
- \color{red}{x}
- \begin{bmatrix}1&2\\3&4\end{bmatrix}

## Verification

Tested rendering before and after the upgrade.

Previously unsupported commands now render correctly, while existing expressions continue to render as expected.