### PR TITLE
feat: expose requestToolApproval to custom agent skills

### DIFF
--- a/server/__tests__/utils/agents/imported.test.js
+++ b/server/__tests__/utils/agents/imported.test.js
@@ -1,0 +1,128 @@
+// Set required env vars before requiring modules.
+// imported.js resolves its plugins path from STORAGE_DIR at require time.
+process.env.STORAGE_DIR = __dirname;
+process.env.NODE_ENV = "test";
+
+const ImportedPlugin = require("../../../utils/agents/imported");
+
+/**
+ * Build an ImportedPlugin instance WITHOUT touching disk. The real constructor
+ * require()s a handler.js file, but plugin() only reads this.handler,
+ * this.name, and this.config - so we bypass the constructor and set those
+ * three directly.
+ */
+function makePlugin({
+  hubId = "acme/my-skill",
+  handlerRuntime = { handler: async () => "ok" },
+} = {}) {
+  const instance = Object.create(ImportedPlugin.prototype);
+  instance.config = {
+    hubId,
+    description: "Test skill",
+    entrypoint: { params: {} },
+  };
+  instance.name = hubId;
+  instance.handler = { runtime: handlerRuntime };
+  return instance;
+}
+
+/**
+ * Run the plugin's setup() against a fake aibitat and return the function
+ * config that was registered (its properties become the handler's `this`).
+ */
+function registerAndGetFn(plugin, aibitatOverrides = {}) {
+  let registered = null;
+  const fakeAibitat = {
+    function(config) {
+      registered = config;
+      return this;
+    },
+    handlerProps: { log: jest.fn() },
+    introspect: jest.fn(),
+    ...aibitatOverrides,
+  };
+
+  const built = plugin.plugin();
+  built.setup(fakeAibitat);
+  return { fn: registered, aibitat: fakeAibitat };
+}
+
+describe("ImportedPlugin custom skill - requestToolApproval helper", () => {
+  it("exposes requestToolApproval on the registered function config", () => {
+    const { fn } = registerAndGetFn(makePlugin());
+    expect(typeof fn.requestToolApproval).toBe("function");
+  });
+
+  it("forces skillName to the skill's hubId and passes payload/description through", async () => {
+    const spy = jest.fn().mockResolvedValue({ approved: true, message: "ok" });
+    const { fn } = registerAndGetFn(makePlugin({ hubId: "acme/cleaner" }), {
+      requestToolApproval: spy,
+    });
+
+    const result = await fn.requestToolApproval({
+      skillName: "gmail-send-email", // spoof attempt - must be ignored
+      payload: { recordId: 42 },
+      description: "Delete record 42?",
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      skillName: "acme/cleaner",
+      payload: { recordId: 42 },
+      description: "Delete record 42?",
+    });
+    expect(result).toEqual({ approved: true, message: "ok" });
+  });
+
+  it("defaults payload to {} and description to null when called with no args", async () => {
+    const spy = jest.fn().mockResolvedValue({ approved: true, message: "ok" });
+    const { fn } = registerAndGetFn(makePlugin({ hubId: "acme/thing" }), {
+      requestToolApproval: spy,
+    });
+
+    await fn.requestToolApproval();
+
+    expect(spy).toHaveBeenCalledWith({
+      skillName: "acme/thing",
+      payload: {},
+      description: null,
+    });
+  });
+
+  it("resolves approved (does not throw) when aibitat has no approval channel", async () => {
+    // fakeAibitat here has no requestToolApproval (non-interactive context).
+    const { fn } = registerAndGetFn(makePlugin());
+
+    const result = await fn.requestToolApproval({ description: "anything" });
+
+    expect(result).toEqual({
+      approved: true,
+      message: "Approval not required in this context.",
+    });
+  });
+
+  it("cannot be overridden by the skill's own handler.js exports", async () => {
+    // A handler that tries to shadow the real helper to bypass approval.
+    const malicious = jest
+      .fn()
+      .mockResolvedValue({ approved: true, message: "spoofed" });
+    const realChannel = jest
+      .fn()
+      .mockResolvedValue({ approved: false, message: "real" });
+
+    const { fn } = registerAndGetFn(
+      makePlugin({
+        handlerRuntime: {
+          handler: async () => "ok",
+          requestToolApproval: malicious,
+        },
+      }),
+      { requestToolApproval: realChannel }
+    );
+
+    const result = await fn.requestToolApproval({ description: "x" });
+
+    expect(malicious).not.toHaveBeenCalled();
+    expect(realChannel).toHaveBeenCalled();
+    expect(result).toEqual({ approved: false, message: "real" });
+  });
+});

--- a/server/__tests__/utils/agents/imported.test.js
+++ b/server/__tests__/utils/agents/imported.test.js
@@ -13,11 +13,13 @@ const ImportedPlugin = require("../../../utils/agents/imported");
  */
 function makePlugin({
   hubId = "acme/my-skill",
+  name = "My Skill",
   handlerRuntime = { handler: async () => "ok" },
 } = {}) {
   const instance = Object.create(ImportedPlugin.prototype);
   instance.config = {
     hubId,
+    name,
     description: "Test skill",
     entrypoint: { params: {} },
   };
@@ -53,9 +55,9 @@ describe("ImportedPlugin custom skill - requestToolApproval helper", () => {
     expect(typeof fn.requestToolApproval).toBe("function");
   });
 
-  it("forces skillName to the skill's hubId and passes payload/description through", async () => {
+  it("forces skillName to the skill's display name and passes payload/description through", async () => {
     const spy = jest.fn().mockResolvedValue({ approved: true, message: "ok" });
-    const { fn } = registerAndGetFn(makePlugin({ hubId: "acme/cleaner" }), {
+    const { fn } = registerAndGetFn(makePlugin({ hubId: "acme/cleaner", name: "Acme Cleaner" }), {
       requestToolApproval: spy,
     });
 
@@ -66,7 +68,7 @@ describe("ImportedPlugin custom skill - requestToolApproval helper", () => {
     });
 
     expect(spy).toHaveBeenCalledWith({
-      skillName: "acme/cleaner",
+      skillName: "Acme Cleaner",
       payload: { recordId: 42 },
       description: "Delete record 42?",
     });
@@ -75,14 +77,14 @@ describe("ImportedPlugin custom skill - requestToolApproval helper", () => {
 
   it("defaults payload to {} and description to null when called with no args", async () => {
     const spy = jest.fn().mockResolvedValue({ approved: true, message: "ok" });
-    const { fn } = registerAndGetFn(makePlugin({ hubId: "acme/thing" }), {
+    const { fn } = registerAndGetFn(makePlugin({ hubId: "acme/thing", name: "Acme Thing" }), {
       requestToolApproval: spy,
     });
 
     await fn.requestToolApproval();
 
     expect(spy).toHaveBeenCalledWith({
-      skillName: "acme/thing",
+      skillName: "Acme Thing",
       payload: {},
       description: null,
     });

--- a/server/utils/agents/imported.js
+++ b/server/utils/agents/imported.js
@@ -178,6 +178,7 @@ class ImportedPlugin {
       name: this.name,
       config: this.config,
       setup(aibitat) {
+        const skillName = this.name; // hubId the skill is registered + whitelisted under.
         aibitat.function({
           super: aibitat,
           name: this.name,
@@ -196,6 +197,39 @@ class ImportedPlugin {
             additionalProperties: false,
           },
           ...customFunctions,
+          /**
+           * Pause the agent and ask the user to approve a potentially
+           * destructive action before the skill performs it. Shows the same
+           * Approve/Reject card the built-in tools use (e.g. gmail send/reply).
+           *
+           * `skillName` is supplied automatically (the skill's hubId) so a skill
+           * cannot spoof another tool's name to bypass its own approval - the
+           * author only provides the payload and description.
+           *
+           * Defined after `...customFunctions` so a skill's handler.js cannot
+           * override it. When no approval channel exists (e.g. scheduled jobs)
+           * it resolves approved so the skill still runs, matching how built-in
+           * tools fall through their approval guard.
+           *
+           * @param {{payload?: object, description?: string}} options
+           * @returns {Promise<{approved: boolean, message: string}>}
+           */
+          requestToolApproval: async ({
+            payload = {},
+            description = null,
+          } = {}) => {
+            if (typeof aibitat.requestToolApproval !== "function") {
+              return {
+                approved: true,
+                message: "Approval not required in this context.",
+              };
+            }
+            return aibitat.requestToolApproval({
+              skillName,
+              payload,
+              description,
+            });
+          },
         });
       },
     };

--- a/server/utils/agents/imported.js
+++ b/server/utils/agents/imported.js
@@ -154,6 +154,43 @@ class ImportedPlugin {
     return this.isValidLocation(handlerLocation);
   }
 
+  /**
+   * Creates a requestToolApproval function bound to a specific aibitat
+   * instance and skill name via closure — no `this` binding required.
+   *
+   * The returned function pauses the agent and asks the user to approve a
+   * potentially destructive action before the skill performs it.
+   *
+   * `skillName` is captured from the skill's hubId so a skill cannot spoof
+   * another tool's name to bypass its own approval.
+   *
+   * When no approval channel exists (e.g. scheduled jobs) it resolves
+   * approved so the skill still runs, matching how built-in tools fall
+   * through their approval guard.
+   *
+   * @param {object} aibitat - The aibitat instance.
+   * @param {string} skillName - The skill's hubId.
+   * @returns {function({payload?: object, description?: string}): Promise<{approved: boolean, message: string}>}
+   */
+  static createToolApprovalFn(aibitat, skillName) {
+    return async function requestToolApproval({
+      payload = {},
+      description = null,
+    } = {}) {
+      if (typeof aibitat?.requestToolApproval !== "function") {
+        return {
+          approved: true,
+          message: "Approval not required in this context.",
+        };
+      }
+      return aibitat.requestToolApproval({
+        skillName,
+        payload,
+        description,
+      });
+    };
+  }
+
   parseCallOptions() {
     const callOpts = {};
     if (!this.config.setup_args || typeof this.config.setup_args !== "object") {
@@ -178,15 +215,14 @@ class ImportedPlugin {
       name: this.name,
       config: this.config,
       setup(aibitat) {
-        const skillName = this.name; // hubId the skill is registered + whitelisted under.
         aibitat.function({
           super: aibitat,
           name: this.name,
           config: this.config,
           runtimeArgs: this.runtimeArgs,
           description: this.config.description,
-          logger: aibitat?.handlerProps?.log || console.log, // Allows plugin to log to the console.
-          introspect: aibitat?.introspect || console.log, // Allows plugin to display a "thought" the chat window UI.
+          logger: aibitat?.handlerProps?.log || console.log,
+          introspect: aibitat?.introspect || console.log,
           runtime: "docker",
           webScraper: sharedWebScraper,
           examples: this.config.examples ?? [],
@@ -197,39 +233,14 @@ class ImportedPlugin {
             additionalProperties: false,
           },
           ...customFunctions,
-          /**
-           * Pause the agent and ask the user to approve a potentially
-           * destructive action before the skill performs it. Shows the same
-           * Approve/Reject card the built-in tools use (e.g. gmail send/reply).
-           *
-           * `skillName` is supplied automatically (the skill's hubId) so a skill
-           * cannot spoof another tool's name to bypass its own approval - the
-           * author only provides the payload and description.
-           *
-           * Defined after `...customFunctions` so a skill's handler.js cannot
-           * override it. When no approval channel exists (e.g. scheduled jobs)
-           * it resolves approved so the skill still runs, matching how built-in
-           * tools fall through their approval guard.
-           *
-           * @param {{payload?: object, description?: string}} options
-           * @returns {Promise<{approved: boolean, message: string}>}
-           */
-          requestToolApproval: async ({
-            payload = {},
-            description = null,
-          } = {}) => {
-            if (typeof aibitat.requestToolApproval !== "function") {
-              return {
-                approved: true,
-                message: "Approval not required in this context.",
-              };
-            }
-            return aibitat.requestToolApproval({
-              skillName,
-              payload,
-              description,
-            });
-          },
+
+          // Add the requestToolApproval function to the plugin
+          // but do not allow the skill's own handler.js exports to override it.
+          // because it requires an explict shape to return elements to the UI.
+          requestToolApproval: ImportedPlugin.createToolApprovalFn(
+            aibitat,
+            this.config.name
+          ),
         });
       },
     };


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #

### Description

Built-in agent tools (gmail send/reply, filesystem writes, calendar edits, etc.) can pause the agent and show an Approve/Reject card before performing a destructive action. They do this by calling `requestToolApproval`, a method that lives on the live aibitat instance (attached by the websocket plugin).

Custom skills (user-authored imported plugins — a `plugin.json` + `handler.js`, usually installed from the Community Hub) had no sanctioned way to do the same. They already get first-class helpers like `this.introspect` and `this.logger` injected into their handler context, but not an approval helper.

This PR exposes `requestToolApproval` as a first-class helper on the custom-skill handler context, so a skill's `handler.js` can ask the user to confirm its own potentially destructive actions:

```js
const approval = await this.requestToolApproval({
  payload: { recordId },
  description: `Permanently delete record ${recordId}? This cannot be undone.`,
});
if (!approval.approved) return approval.message;
```

It returns the same `{ approved, message }` contract the built-in tools use and triggers the same Approve/Reject card. The frontend card, the "Always allow" whitelist, the `AGENT_AUTO_APPROVED_SKILLS` auto-approve, and the 120s timeout are all reused unchanged — there are no frontend or websocket changes.

Key behaviors:

- `skillName` is injected automatically as the skill's own hubId. The author only passes `payload` and `description`, so a skill cannot spoof another tool's name to ride that tool's whitelist and bypass its own approval.
- The helper is defined after the skill's own handler exports are spread in, so a skill's `handler.js` cannot override it.
- If no approval channel exists (e.g. a scheduled job, where there is no human to approve), the helper resolves approved so the skill still runs — matching how the built-in tools fall through their approval guard when the method is absent.

### Additional Information

The capability was technically reachable before this PR via `this.super.requestToolApproval`, but that was undocumented internal plumbing and unsafe to hand to skill authors directly (no skillName injection, overridable by the skill). This PR makes it a sanctioned, documented, and safe helper that sits alongside the existing `introspect`/`logger` helpers. The new code is roughly 15 lines in `server/utils/agents/imported.js`, plus a new unit test file.

How to test:

1. Create a custom skill under `server/storage/plugins/agent-skills/<hubId>/` whose `handler.js` calls `this.requestToolApproval({ description: "Confirm test action?" })` and returns the result.
2. Invoke it from an agent session in a workspace.
3. Confirm the Approve/Reject card appears, that Reject returns the rejection message to the chat, and that checking "Always allow" then re-invoking skips the card (the whitelist is keyed on the skill's hubId).

Follow-up (out of scope here): the external Community Hub skill-authoring docs should document `this.requestToolApproval(...)`.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
