### PR TITLE
feat: highlight variable references in agent flow blocks

### DIFF
--- a/frontend/src/pages/Admin/AgentBuilder/VariableInput/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/VariableInput/index.jsx
@@ -1,17 +1,26 @@
 import React, { forwardRef, useRef } from "react";
 
-// Matches a ${variableName} reference, e.g. ${userId} or ${data.user.name}.
+/**
+ * Matches a ${variableName} reference, e.g. ${userId} or ${data.user.name}.
+ * @type {string}
+ */
 const VARIABLE_PATTERN = "\\$\\{[^}]+\\}";
 
-// The highlight box drawn around a ${variable}. A 30% tint (composited over
-// whatever is behind it) instead of a solid fill, so the text stays readable
-// against both the light and dark themes. sky-300 matches the cta blue but,
-// being a standard palette color, supports the /30 opacity modifier (the
-// var-based theme colors don't). Shared with the "Variables" hint chips so the
-// two always look the same.
+/**
+ * The highlight box drawn around a ${variableName}. A 30% tint (composited over
+ * whatever is behind it) instead of a solid fill, so the text stays readable
+ * against both the light and dark themes. sky-300 matches the cta blue but,
+ * being a standard palette color, supports the /30 opacity modifier (the
+ * var-based theme colors don't). Shared with the "Variables" hint chips so the
+ * two always look the same.
+ * @type {string}
+ */
 export const VARIABLE_HIGHLIGHT_CLASS = "rounded-[3px] bg-sky-300/30";
 
-// Shared text metrics so the backdrop and the real field line up exactly.
+/**
+ * Shared text metrics so the backdrop and the real field line up exactly.
+ * @type {string}
+ */
 const FIELD_TEXT = "block w-full p-2.5 text-sm";
 
 /**
@@ -77,7 +86,7 @@ const VariableInput = forwardRef(function VariableInput(
         onScroll={handleScroll}
         autoComplete="off"
         spellCheck={false}
-        className={`relative bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${
+        className={`relative border-none bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${
           multiline ? "resize-y" : ""
         } ${FIELD_TEXT} ${fontClass}`}
         {...props}
@@ -86,9 +95,13 @@ const VariableInput = forwardRef(function VariableInput(
   );
 });
 
-// Split the value into plain text and ${...} tokens, wrapping each token in a
-// highlight box. The token text itself stays transparent (inherited from the
-// backdrop) so only the colored box shows through behind the real field text.
+/**
+ * Split the value into plain text and ${...} tokens, wrapping each token in a
+ * highlight box. The token text itself stays transparent (inherited from the
+ * backdrop) so only the colored box shows through behind the real field text.
+ * @param {string} value
+ * @returns {React.ReactNode[]}
+ */
 function renderHighlightedParts(value) {
   if (!value) return null;
 

--- a/frontend/src/pages/Admin/AgentBuilder/VariableInput/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/VariableInput/index.jsx
@@ -28,7 +28,14 @@ const FIELD_TEXT = "block w-full p-2.5 text-sm";
  * API Call block's "insert variable" button) can read/set the cursor position.
  */
 const VariableInput = forwardRef(function VariableInput(
-  { value = "", onChange, multiline = false, mono = false, ...props },
+  {
+    value = "",
+    onChange,
+    multiline = false,
+    mono = false,
+    className = "",
+    ...props
+  },
   ref
 ) {
   const backdropRef = useRef(null);
@@ -46,8 +53,14 @@ const VariableInput = forwardRef(function VariableInput(
     ? "whitespace-pre-wrap break-words"
     : "whitespace-pre";
 
+  // input and textarea behave identically here except for the tag, the resize
+  // handle, and the text type, so render whichever one through a single path.
+  const Field = multiline ? "textarea" : "input";
+
   return (
-    <div className="relative w-full rounded-lg bg-theme-settings-input-bg">
+    <div
+      className={`relative w-full rounded-lg bg-theme-settings-input-bg ${className}`}
+    >
       <div
         ref={backdropRef}
         aria-hidden="true"
@@ -56,30 +69,19 @@ const VariableInput = forwardRef(function VariableInput(
         {renderHighlightedParts(value)}
       </div>
 
-      {multiline ? (
-        <textarea
-          ref={ref}
-          value={value}
-          onChange={onChange}
-          onScroll={handleScroll}
-          autoComplete="off"
-          spellCheck={false}
-          className={`relative resize-y bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${FIELD_TEXT} ${fontClass}`}
-          {...props}
-        />
-      ) : (
-        <input
-          ref={ref}
-          type="text"
-          value={value}
-          onChange={onChange}
-          onScroll={handleScroll}
-          autoComplete="off"
-          spellCheck={false}
-          className={`relative bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${FIELD_TEXT} ${fontClass}`}
-          {...props}
-        />
-      )}
+      <Field
+        ref={ref}
+        type={multiline ? undefined : "text"}
+        value={value}
+        onChange={onChange}
+        onScroll={handleScroll}
+        autoComplete="off"
+        spellCheck={false}
+        className={`relative bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${
+          multiline ? "resize-y" : ""
+        } ${FIELD_TEXT} ${fontClass}`}
+        {...props}
+      />
     </div>
   );
 });

--- a/frontend/src/pages/Admin/AgentBuilder/VariableInput/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/VariableInput/index.jsx
@@ -1,0 +1,108 @@
+import React, { forwardRef, useRef } from "react";
+
+// Matches a ${variableName} reference, e.g. ${userId} or ${data.user.name}.
+const VARIABLE_PATTERN = "\\$\\{[^}]+\\}";
+
+// The highlight box drawn around a ${variable}. A 30% tint (composited over
+// whatever is behind it) instead of a solid fill, so the text stays readable
+// against both the light and dark themes. sky-300 matches the cta blue but,
+// being a standard palette color, supports the /30 opacity modifier (the
+// var-based theme colors don't). Shared with the "Variables" hint chips so the
+// two always look the same.
+export const VARIABLE_HIGHLIGHT_CLASS = "rounded-[3px] bg-sky-300/30";
+
+// Shared text metrics so the backdrop and the real field line up exactly.
+const FIELD_TEXT = "block w-full p-2.5 text-sm";
+
+/**
+ * A text input / textarea that live-highlights ${variable} references the same
+ * way system prompt variables are highlighted, so it's obvious which parts of
+ * the field will be swapped for a flow variable at runtime.
+ *
+ * How it works: a read-only "backdrop" sits behind a transparent-background
+ * field. The backdrop renders the same text but draws a colored box around any
+ * ${...} token. The real field renders on top, so the visible characters line
+ * up over the highlight boxes while the field stays fully editable.
+ *
+ * The ref is forwarded to the underlying input/textarea so callers (like the
+ * API Call block's "insert variable" button) can read/set the cursor position.
+ */
+const VariableInput = forwardRef(function VariableInput(
+  { value = "", onChange, multiline = false, mono = false, ...props },
+  ref
+) {
+  const backdropRef = useRef(null);
+
+  // Keep the highlight backdrop scrolled in lockstep with the field so the
+  // boxes stay aligned once the text overflows the visible area.
+  const handleScroll = (e) => {
+    if (!backdropRef.current) return;
+    backdropRef.current.scrollTop = e.target.scrollTop;
+    backdropRef.current.scrollLeft = e.target.scrollLeft;
+  };
+
+  const fontClass = mono ? "font-mono" : "";
+  const wrapClass = multiline
+    ? "whitespace-pre-wrap break-words"
+    : "whitespace-pre";
+
+  return (
+    <div className="relative w-full rounded-lg bg-theme-settings-input-bg">
+      <div
+        ref={backdropRef}
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-0 overflow-hidden rounded-lg text-transparent ${wrapClass} ${FIELD_TEXT} ${fontClass}`}
+      >
+        {renderHighlightedParts(value)}
+      </div>
+
+      {multiline ? (
+        <textarea
+          ref={ref}
+          value={value}
+          onChange={onChange}
+          onScroll={handleScroll}
+          autoComplete="off"
+          spellCheck={false}
+          className={`relative resize-y bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${FIELD_TEXT} ${fontClass}`}
+          {...props}
+        />
+      ) : (
+        <input
+          ref={ref}
+          type="text"
+          value={value}
+          onChange={onChange}
+          onScroll={handleScroll}
+          autoComplete="off"
+          spellCheck={false}
+          className={`relative bg-transparent text-theme-text-primary placeholder:text-theme-settings-input-placeholder rounded-lg outline-none focus:outline-primary-button active:outline-primary-button ${FIELD_TEXT} ${fontClass}`}
+          {...props}
+        />
+      )}
+    </div>
+  );
+});
+
+// Split the value into plain text and ${...} tokens, wrapping each token in a
+// highlight box. The token text itself stays transparent (inherited from the
+// backdrop) so only the colored box shows through behind the real field text.
+function renderHighlightedParts(value) {
+  if (!value) return null;
+
+  // The capturing group keeps the matched ${...} tokens in the split result.
+  const parts = value.split(new RegExp(`(${VARIABLE_PATTERN})`, "g"));
+  const isVariable = new RegExp(`^${VARIABLE_PATTERN}$`);
+  return parts.map((part, index) => {
+    if (!isVariable.test(part))
+      return <React.Fragment key={index}>{part}</React.Fragment>;
+
+    return (
+      <span key={index} className={VARIABLE_HIGHLIGHT_CLASS}>
+        {part}
+      </span>
+    );
+  });
+}
+
+export default VariableInput;

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/ApiCallNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/ApiCallNode/index.jsx
@@ -63,14 +63,13 @@ export default function ApiCallNode({
           URL
         </label>
         <div className="flex gap-2">
-          <div className="flex-1">
-            <VariableInput
-              ref={urlInputRef}
-              placeholder="https://api.example.com/endpoint"
-              value={config.url}
-              onChange={(e) => onConfigChange({ url: e.target.value })}
-            />
-          </div>
+          <VariableInput
+            ref={urlInputRef}
+            className="flex-1"
+            placeholder="https://api.example.com/endpoint"
+            value={config.url}
+            onChange={(e) => onConfigChange({ url: e.target.value })}
+          />
           <div className="relative">
             <button
               ref={varButtonRef}
@@ -143,15 +142,14 @@ export default function ApiCallNode({
                 autoComplete="off"
                 spellCheck={false}
               />
-              <div className="flex-1">
-                <VariableInput
-                  placeholder="Value"
-                  value={header.value}
-                  onChange={(e) =>
-                    handleHeaderChange(index, "value", e.target.value)
-                  }
-                />
-              </div>
+              <VariableInput
+                className="flex-1"
+                placeholder="Value"
+                value={header.value}
+                onChange={(e) =>
+                  handleHeaderChange(index, "value", e.target.value)
+                }
+              />
               <button
                 onClick={() => removeHeader(index)}
                 className="p-2.5 rounded-lg border-none bg-theme-settings-input-bg text-theme-text-primary hover:text-red-500 hover:border-red-500/20 hover:bg-red-500/10 transition-colors duration-300"
@@ -220,20 +218,16 @@ export default function ApiCallNode({
                       autoComplete="off"
                       spellCheck={false}
                     />
-                    <div className="flex-1">
-                      <VariableInput
-                        placeholder="Value"
-                        value={item.value}
-                        onChange={(e) => {
-                          const newFormData = [...(config.formData || [])];
-                          newFormData[index] = {
-                            ...item,
-                            value: e.target.value,
-                          };
-                          onConfigChange({ formData: newFormData });
-                        }}
-                      />
-                    </div>
+                    <VariableInput
+                      className="flex-1"
+                      placeholder="Value"
+                      value={item.value}
+                      onChange={(e) => {
+                        const newFormData = [...(config.formData || [])];
+                        newFormData[index] = { ...item, value: e.target.value };
+                        onConfigChange({ formData: newFormData });
+                      }}
+                    />
                     <button
                       onClick={() => {
                         const newFormData = [...(config.formData || [])].filter(

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/ApiCallNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/ApiCallNode/index.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/refs */
 import React, { useRef, useState } from "react";
 import { Plus, X, CaretDown } from "@phosphor-icons/react";
+import VariableInput from "../../VariableInput";
 
 export default function ApiCallNode({
   config,
@@ -62,16 +63,14 @@ export default function ApiCallNode({
           URL
         </label>
         <div className="flex gap-2">
-          <input
-            ref={urlInputRef}
-            type="text"
-            placeholder="https://api.example.com/endpoint"
-            value={config.url}
-            onChange={(e) => onConfigChange({ url: e.target.value })}
-            className="flex-1 border-none bg-theme-settings-input-bg text-theme-text-primary placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5"
-            autoComplete="off"
-            spellCheck={false}
-          />
+          <div className="flex-1">
+            <VariableInput
+              ref={urlInputRef}
+              placeholder="https://api.example.com/endpoint"
+              value={config.url}
+              onChange={(e) => onConfigChange({ url: e.target.value })}
+            />
+          </div>
           <div className="relative">
             <button
               ref={varButtonRef}
@@ -144,17 +143,15 @@ export default function ApiCallNode({
                 autoComplete="off"
                 spellCheck={false}
               />
-              <input
-                type="text"
-                placeholder="Value"
-                value={header.value}
-                onChange={(e) =>
-                  handleHeaderChange(index, "value", e.target.value)
-                }
-                className="flex-1 border-none bg-theme-settings-input-bg text-theme-text-primary placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5"
-                autoComplete="off"
-                spellCheck={false}
-              />
+              <div className="flex-1">
+                <VariableInput
+                  placeholder="Value"
+                  value={header.value}
+                  onChange={(e) =>
+                    handleHeaderChange(index, "value", e.target.value)
+                  }
+                />
+              </div>
               <button
                 onClick={() => removeHeader(index)}
                 className="p-2.5 rounded-lg border-none bg-theme-settings-input-bg text-theme-text-primary hover:text-red-500 hover:border-red-500/20 hover:bg-red-500/10 transition-colors duration-300"
@@ -198,14 +195,13 @@ export default function ApiCallNode({
               </option>
             </select>
             {config.bodyType === "json" ? (
-              <textarea
+              <VariableInput
+                multiline
+                mono
+                rows={4}
                 placeholder='{"key": "value"}'
                 value={config.body}
                 onChange={(e) => onConfigChange({ body: e.target.value })}
-                className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-theme-text-primary placeholder:text-theme-text-secondary/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none light:bg-theme-settings-input-bg light:border-black/10 font-mono"
-                rows={4}
-                autoComplete="off"
-                spellCheck={false}
               />
             ) : config.bodyType === "form" ? (
               <div className="space-y-2">
@@ -224,19 +220,20 @@ export default function ApiCallNode({
                       autoComplete="off"
                       spellCheck={false}
                     />
-                    <input
-                      type="text"
-                      placeholder="Value"
-                      value={item.value}
-                      onChange={(e) => {
-                        const newFormData = [...(config.formData || [])];
-                        newFormData[index] = { ...item, value: e.target.value };
-                        onConfigChange({ formData: newFormData });
-                      }}
-                      className="flex-1 p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-theme-text-primary placeholder:text-theme-text-secondary/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none light:bg-theme-settings-input-bg light:border-black/10"
-                      autoComplete="off"
-                      spellCheck={false}
-                    />
+                    <div className="flex-1">
+                      <VariableInput
+                        placeholder="Value"
+                        value={item.value}
+                        onChange={(e) => {
+                          const newFormData = [...(config.formData || [])];
+                          newFormData[index] = {
+                            ...item,
+                            value: e.target.value,
+                          };
+                          onConfigChange({ formData: newFormData });
+                        }}
+                      />
+                    </div>
                     <button
                       onClick={() => {
                         const newFormData = [...(config.formData || [])].filter(
@@ -265,14 +262,12 @@ export default function ApiCallNode({
                 </button>
               </div>
             ) : (
-              <textarea
+              <VariableInput
+                multiline
+                rows={4}
                 placeholder="Raw request body..."
                 value={config.body}
                 onChange={(e) => onConfigChange({ body: e.target.value })}
-                className="w-full border-none bg-theme-settings-input-bg text-theme-text-primary placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5"
-                rows={4}
-                autoComplete="off"
-                spellCheck={false}
               />
             )}
           </div>

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/LLMInstructionNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/LLMInstructionNode/index.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import VariableInput from "../../VariableInput";
 
 export default function LLMInstructionNode({
   config,
@@ -11,7 +12,9 @@ export default function LLMInstructionNode({
         <label className="block text-sm font-medium text-theme-text-primary mb-2">
           Instruction
         </label>
-        <textarea
+        <VariableInput
+          multiline
+          rows={3}
           value={config?.instruction || ""}
           onChange={(e) =>
             onConfigChange({
@@ -19,8 +22,6 @@ export default function LLMInstructionNode({
               instruction: e.target.value,
             })
           }
-          className="w-full border-none bg-theme-settings-input-bg text-theme-text-primary placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5"
-          rows={3}
           placeholder="Enter instructions for the LLM..."
         />
       </div>

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/StartNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/StartNode/index.jsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { Fragment } from "react";
 import { Plus, X } from "@phosphor-icons/react";
+import { VARIABLE_HIGHLIGHT_CLASS } from "../../VariableInput";
 
 export default function StartNode({
   config,
@@ -13,9 +14,40 @@ export default function StartNode({
     onConfigChange({ variables: newVars });
   };
 
+  const definedVariables = config.variables.filter((v) => v.name);
+
   return (
     <div className="space-y-4">
-      <h3 className="text-sm font-medium text-theme-text-primary">Variables</h3>
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium text-theme-text-primary">
+          Variables
+        </h3>
+        <p className="text-xs text-theme-text-secondary">
+          Define values here, then reference them in any block below by wrapping
+          the name in{" "}
+          <span
+            className={`${VARIABLE_HIGHLIGHT_CLASS} px-1 py-0.5 text-theme-text-primary`}
+          >
+            {"${variableName}"}
+          </span>
+          . References are highlighted as you type.
+        </p>
+        {definedVariables.length > 0 && (
+          <p className="text-xs text-theme-text-secondary">
+            For example:{" "}
+            {definedVariables.slice(0, 3).map((variable, index) => (
+              <Fragment key={variable.name}>
+                <span
+                  className={`${VARIABLE_HIGHLIGHT_CLASS} px-1 py-0.5 text-theme-text-primary`}
+                >
+                  {`\${${variable.name}}`}
+                </span>
+                {index < Math.min(definedVariables.length, 3) - 1 && ", "}
+              </Fragment>
+            ))}
+          </p>
+        )}
+      </div>
       {config.variables.map((variable, index) => (
         <div key={index} className="flex gap-2">
           <input

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/StartNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/StartNode/index.jsx
@@ -15,6 +15,7 @@ export default function StartNode({
   };
 
   const definedVariables = config.variables.filter((v) => v.name);
+  const exampleVariables = definedVariables.slice(0, 3);
 
   return (
     <div className="space-y-4">
@@ -32,17 +33,17 @@ export default function StartNode({
           </span>
           . References are highlighted as you type.
         </p>
-        {definedVariables.length > 0 && (
+        {exampleVariables.length > 0 && (
           <p className="text-xs text-theme-text-secondary">
             For example:{" "}
-            {definedVariables.slice(0, 3).map((variable, index) => (
+            {exampleVariables.map((variable, index) => (
               <Fragment key={variable.name}>
                 <span
                   className={`${VARIABLE_HIGHLIGHT_CLASS} px-1 py-0.5 text-theme-text-primary`}
                 >
                   {`\${${variable.name}}`}
                 </span>
-                {index < Math.min(definedVariables.length, 3) - 1 && ", "}
+                {index < exampleVariables.length - 1 && ", "}
               </Fragment>
             ))}
           </p>

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/WebScrapingNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/WebScrapingNode/index.jsx
@@ -1,4 +1,5 @@
 import Toggle from "@/components/lib/Toggle";
+import VariableInput from "../../VariableInput";
 
 export default function WebScrapingNode({
   config,
@@ -11,8 +12,7 @@ export default function WebScrapingNode({
         <label className="block text-sm font-medium text-theme-text-primary mb-2">
           URL to Scrape
         </label>
-        <input
-          type="url"
+        <VariableInput
           value={config?.url || ""}
           onChange={(e) =>
             onConfigChange({
@@ -20,7 +20,6 @@ export default function WebScrapingNode({
               url: e.target.value,
             })
           }
-          className="w-full border-none bg-theme-settings-input-bg text-theme-text-primary placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5"
           placeholder="https://example.com"
         />
       </div>
@@ -60,13 +59,12 @@ export default function WebScrapingNode({
           <p className="text-xs text-theme-text-secondary mb-2">
             Enter a valid CSS selector to scrape the content of the page.
           </p>
-          <input
+          <VariableInput
             value={config.querySelector}
             onChange={(e) =>
               onConfigChange({ ...config, querySelector: e.target.value })
             }
             placeholder=".article-content, #content, .main-content, etc."
-            className="w-full border-none bg-theme-settings-input-bg text-theme-text-primary text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5"
           />
         </div>
       )}


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [x] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

N/A (internal ticket)

### Description

It was not obvious how to reference flow variables inside agent flow blocks. The `${variableName}` syntax was only explained in the official docs, never surfaced in the UI, and there was no visual indication of which text in a field would be swapped for a variable at runtime.

This PR makes variables discoverable in the agent flow builder:

- **Live highlighting.** Variable references (`${variableName}`) are now highlighted inline as you type, the same way system prompt variables are highlighted on the Default System Prompt page. This is done with a new shared `VariableInput` component that layers a highlight backdrop behind a transparent-text field, so the field stays fully editable and the existing "insert variable" button keeps working.
- **A "Variables" hint.** The Flow Variables block now explains the `${variableName}` syntax and shows example chips for the variables you have defined, so you no longer have to read the docs to know how to reference them.

Highlighting and the hint cover the fields where variables are actually used: API Call (URL, request body, header values, form-data values), LLM Instruction (instruction), and Web Scraping (URL, query selector). Header and form-data names are left as plain inputs since variables there are rare.

### Visuals (if applicable)

<!-- Screenshots: the Flow Variables hint, and ${variable} highlight boxes in the URL / instruction fields, in both light and dark mode. -->

<img width="578" height="287" alt="image" src="https://github.com/user-attachments/assets/4eff6c43-3de3-43cb-a512-832580d5381d" />

<img width="581" height="445" alt="image" src="https://github.com/user-attachments/assets/730dd257-0984-4520-b600-6ab1c6add98e" />

<img width="580" height="385" alt="image" src="https://github.com/user-attachments/assets/4a717d63-e604-44e4-9903-6cbbd7c12ea6" />

<img width="592" height="480" alt="image" src="https://github.com/user-attachments/assets/5e52f913-ef7c-40f6-b336-43c3336d4143" />


### Additional Information

- The highlight uses `bg-sky-300/30` (a 30% tint). It is intentionally a standard Tailwind palette color rather than the theme's `cta-button`: the var-based theme colors do not support Tailwind opacity modifiers, and a translucent tint keeps the text readable against both the light and dark themes (a solid fill washed the text out in dark mode). `sky-300` matches the cta blue.


### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
