### PR TITLE
Mistral Embedding Encoding

### DIFF
--- a/server/utils/EmbeddingEngines/localAi/index.js
+++ b/server/utils/EmbeddingEngines/localAi/index.js
@@ -58,11 +58,15 @@ class LocalAiEmbedder {
     for (const chunk of toChunks(textChunks, this.maxConcurrentChunks)) {
       embeddingRequests.push(
         new Promise((resolve) => {
+          // NB: LocalAI versions < v2.29 ignored encoding_format and always returned float arrays,
+          // causing the OpenAI SDK's default base64 decode to silently produce dims/4 zero vectors.
+          // Fixed in LocalAI PR #9135 (Mar 2026). Pinning "float" here for safety with older versions.
           this.openai.embeddings
             .create({
               model: this.model,
               input: chunk,
               dimensions: this.outputDimensions,
+              encoding_format: "float",
             })
             .then((result) => {
               chunksProcessed += chunk.length;

--- a/server/utils/EmbeddingEngines/mistral/index.js
+++ b/server/utils/EmbeddingEngines/mistral/index.js
@@ -23,6 +23,7 @@ class MistralEmbedder {
       const response = await this.openai.embeddings.create({
         model: this.model,
         input: textChunks,
+        encoding_format: "float",
       });
       const embeddings = response?.data?.map((emb) => emb.embedding) || [];
       if (embeddings.length === 0)


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [x] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5794
connect #5798

### Description

- Accommodate for change in Mistral Embedder to use proper encoding format by moving to `float`
- Additionally potentially solve `localai` since apparently documentation shows it used to work with base64

All other providers who do pass this are untouched since for generic it is impossible to know, openrouter is unknown for handling, as is litellm and would be handled on case by case basis.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
