### PR TITLE
WorkspaceChat refactor

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/ThoughtContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/ThoughtContainer/index.jsx
@@ -152,29 +152,28 @@ export const ThoughtChainComponent = forwardRef(
               className="relative bg-zinc-800 light:bg-slate-100 p-4"
             >
               <div className="absolute top-4 left-4 w-[18px] h-[18px]">
-                {isThinking || isComplete ? (
-                  <>
-                    <video
-                      autoPlay
-                      loop
-                      muted
-                      playsInline
-                      className={`w-[18px] h-[18px] scale-[115%] transition-opacity duration-200 light:invert light:opacity-50 ${isThinking ? "opacity-100" : "opacity-0 hidden"}`}
-                      data-tooltip-id="cot-thinking"
-                      data-tooltip-content="Model is thinking..."
-                      aria-label="Model is thinking..."
-                    >
-                      <source src={ThinkingAnimation} type="video/webm" />
-                    </video>
-                    <img
-                      src={ThinkingStatic}
-                      alt="Thinking complete"
-                      className={`w-[18px] h-[18px] transition-opacity duration-200 light:invert light:opacity-50 ${!isThinking && isComplete ? "opacity-100" : "opacity-0 hidden"}`}
-                      data-tooltip-id="cot-thinking"
-                      data-tooltip-content="Model has finished thinking"
-                      aria-label="Model has finished thinking"
-                    />
-                  </>
+                {isThinking ? (
+                  <video
+                    autoPlay
+                    loop
+                    muted
+                    playsInline
+                    className="w-[18px] h-[18px] scale-[115%] light:invert light:opacity-50"
+                    data-tooltip-id="cot-thinking"
+                    data-tooltip-content="Model is thinking..."
+                    aria-label="Model is thinking..."
+                  >
+                    <source src={ThinkingAnimation} type="video/webm" />
+                  </video>
+                ) : isComplete ? (
+                  <img
+                    src={ThinkingStatic}
+                    alt="Thinking complete"
+                    className="w-[18px] h-[18px] light:invert light:opacity-50"
+                    data-tooltip-id="cot-thinking"
+                    data-tooltip-content="Model has finished thinking"
+                    aria-label="Model has finished thinking"
+                  />
                 ) : null}
               </div>
               {canExpand && (

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -15,7 +15,6 @@ import FileDownloadCard from "./FileDownloadCard";
 import { useManageWorkspaceModal } from "../../../Modals/ManageWorkspace";
 import ManageWorkspace from "../../../Modals/ManageWorkspace";
 import { ArrowDown } from "@phosphor-icons/react";
-import debounce from "lodash.debounce";
 import Chartable from "./Chartable";
 import ModelRouteNotification from "./ModelRouteNotification";
 import Workspace from "@/models/workspace";
@@ -54,28 +53,16 @@ export default forwardRef(function (
     }
   }, [history, isAtBottom, isStreaming, isUserScrolling]);
 
-  const handleScroll = (e) => {
+  const handleScroll = useCallback((e) => {
     const { scrollTop, scrollHeight, clientHeight } = e.target;
     const isBottom = scrollHeight - scrollTop - clientHeight < 2;
 
-    // Detect if this is a user-initiated scroll
     if (Math.abs(scrollTop - lastScrollTopRef.current) > 10) {
       setIsUserScrolling(!isBottom);
     }
 
     setIsAtBottom(isBottom);
     lastScrollTopRef.current = scrollTop;
-  };
-
-  const debouncedScroll = debounce(handleScroll, 100);
-
-  useEffect(() => {
-    const chatHistoryElement = chatHistoryRef.current;
-    if (chatHistoryElement) {
-      chatHistoryElement.addEventListener("scroll", debouncedScroll);
-      return () =>
-        chatHistoryElement.removeEventListener("scroll", debouncedScroll);
-    }
   }, []);
 
   const scrollToBottom = (smooth = false) => {
@@ -97,85 +84,82 @@ export default forwardRef(function (
     scrollToBottom,
   });
 
-  const saveEditedMessage = async ({
-    editedMessage,
-    chatId,
-    role,
-    attachments = [],
-    saveOnly = false,
-  }) => {
-    if (!editedMessage) return; // Don't save empty edits.
+  const saveEditedMessage = useCallback(
+    async ({
+      editedMessage,
+      chatId,
+      role,
+      attachments = [],
+      saveOnly = false,
+    }) => {
+      if (!editedMessage) return;
 
-    // "Save" on a user message: update the prompt text without regenerating
-    if (role === "user" && saveOnly) {
-      const updatedHistory = [...history];
-      const targetIdx = history.findIndex((msg) => msg.chatId === chatId);
-      if (targetIdx < 0) return;
-      updatedHistory[targetIdx].content = editedMessage;
-      updateHistory(updatedHistory);
-      await Workspace.updateChat(
+      if (role === "user" && saveOnly) {
+        const updatedHistory = [...history];
+        const targetIdx = history.findIndex((msg) => msg.chatId === chatId);
+        if (targetIdx < 0) return;
+        updatedHistory[targetIdx].content = editedMessage;
+        updateHistory(updatedHistory);
+        await Workspace.updateChat(
+          workspace.slug,
+          threadSlug,
+          chatId,
+          editedMessage,
+          "user"
+        );
+        return;
+      }
+
+      if (role === "user") {
+        const updatedHistory = history.slice(
+          0,
+          history.findIndex((msg) => msg.chatId === chatId) + 1
+        );
+        updatedHistory[updatedHistory.length - 1].content = editedMessage;
+        await Workspace.deleteEditedChats(workspace.slug, threadSlug, chatId);
+        sendCommand({
+          text: editedMessage,
+          autoSubmit: true,
+          history: updatedHistory,
+          attachments,
+        });
+        return;
+      }
+
+      if (role === "assistant") {
+        const updatedHistory = [...history];
+        const targetIdx = history.findIndex(
+          (msg) => msg.chatId === chatId && msg.role === role
+        );
+        if (targetIdx < 0) return;
+        updatedHistory[targetIdx].content = editedMessage;
+        updateHistory(updatedHistory);
+        await Workspace.updateChat(
+          workspace.slug,
+          threadSlug,
+          chatId,
+          editedMessage
+        );
+        return;
+      }
+    },
+    [history, workspace.slug, threadSlug, updateHistory, sendCommand]
+  );
+
+  const forkThread = useCallback(
+    async (chatId) => {
+      const newThreadSlug = await Workspace.forkThread(
         workspace.slug,
         threadSlug,
-        chatId,
-        editedMessage,
-        "user"
+        chatId
       );
-      return;
-    }
-
-    // "Submit" on a user message: auto-regenerate the response and delete all
-    // messages post modified message
-    if (role === "user") {
-      // remove all messages after the edited message
-      // technically there are two chatIds per-message pair, this will split the first.
-      const updatedHistory = history.slice(
-        0,
-        history.findIndex((msg) => msg.chatId === chatId) + 1
-      );
-
-      // update last message in history to edited message
-      updatedHistory[updatedHistory.length - 1].content = editedMessage;
-      // remove all edited messages after the edited message in backend
-      await Workspace.deleteEditedChats(workspace.slug, threadSlug, chatId);
-      sendCommand({
-        text: editedMessage,
-        autoSubmit: true,
-        history: updatedHistory,
-        attachments,
-      });
-      return;
-    }
-
-    // If role is an assistant we simply want to update the comment and save on the backend as an edit.
-    if (role === "assistant") {
-      const updatedHistory = [...history];
-      const targetIdx = history.findIndex(
-        (msg) => msg.chatId === chatId && msg.role === role
-      );
-      if (targetIdx < 0) return;
-      updatedHistory[targetIdx].content = editedMessage;
-      updateHistory(updatedHistory);
-      await Workspace.updateChat(
+      window.location.href = paths.workspace.thread(
         workspace.slug,
-        threadSlug,
-        chatId,
-        editedMessage
+        newThreadSlug
       );
-      return;
-    }
-  };
-
-  const forkThread = async (chatId) => {
-    const newThreadSlug = await Workspace.forkThread(
-      workspace.slug,
-      threadSlug,
-      chatId
-    );
-    window.location.href = paths.workspace.thread(
-      workspace.slug,
-      newThreadSlug
-    );
-  };
+    },
+    [workspace.slug, threadSlug]
+  );
 
   const compiledHistory = useMemo(
     () =>

--- a/frontend/src/components/WorkspaceChat/index.jsx
+++ b/frontend/src/components/WorkspaceChat/index.jsx
@@ -135,7 +135,10 @@ function copyCodeSnippet(uuid) {
 }
 
 // Listens and hunts for all data-code-snippet clicks.
+let _codeSnippetDelegatorRegistered = false;
 export function setEventDelegatorForCodeSnippets() {
+  if (_codeSnippetDelegatorRegistered) return;
+  _codeSnippetDelegatorRegistered = true;
   document?.addEventListener("click", function (e) {
     const target = e.target.closest("[data-code-snippet]");
     const uuidCode = target?.dataset?.code;


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [x] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5817

### Description

Found a lot of perf issues with long-chat convo summaries - this is an AI generate list of what i found and fixed:

## High CPU in Long Conversations — Root Causes

### Bug 1: `useMemo` invalidated on every scroll frame

**Condition:** Any conversation with enough messages to require scrolling (the longer the conversation, the worse it gets).

**Mechanism:** `saveEditedMessage` and `forkThread` were plain inline functions — new identity on every render. Both were listed in the `compiledHistory` useMemo dependency array. Every scroll event triggers `setState` → re-render → new function refs → memo invalidates → `buildMessages()` re-runs over the entire message array → React reconciles all message elements → browser lays out the full DOM.

**Impact formula:** `scroll_events_per_second × buildMessages_cost(n_messages)`. At 1000 messages, that's ~60fps × ~98ms = the main thread is permanently blocked.

### Bug 2: Duplicate scroll handlers (raw + debounced `addEventListener`)

**Condition:** Always active once a chat is open.

**Mechanism:** Two scroll handlers were registered — `onScroll={handleScroll}` (raw, ~60fps) plus `addEventListener("scroll", debouncedScroll)` (debounced at 100ms). Both called `setIsAtBottom()` and `setIsUserScrolling()`. The raw handler alone was firing ~18 state updates per 2 seconds of scrolling. Each state update triggered a re-render, compounding Bug 1.

Additionally, `debouncedScroll` was created in the render body (not memoized) so a new debounce instance was created every render, and the `useEffect` with `[]` deps only ever attached the first one.

### Bug 3: Hidden `<video autoPlay loop>` decoder bloat

**Condition:** Conversations with chain-of-thought / "thinking" models (Claude, o1, etc.) where thought chains appear in history.

**Mechanism:** For every completed thought chain, both a `<video autoPlay loop>` and an `<img>` were rendered, toggling visibility via CSS (`hidden`, `opacity-0`). Browsers allocate video decoder resources for all `<video autoPlay>` elements regardless of CSS visibility. A long conversation with 200+ thought chains = 200+ active video decoders consuming CPU and GPU memory for videos that are never visible.

**Impact:** This is what pushes CPU from ~30% (Bugs 1+2 alone) to 96-100% on desktop where real conversations have many thought chains.

### Bug 4: Event listener leak on `document.click`

**Condition:** Navigating between workspaces or threads during a session.

**Mechanism:** `setEventDelegatorForCodeSnippets()` was called on every render of `WorkspaceChat` with no guard. Each call unconditionally added a new `document.click` listener. Over a session with multiple workspace navigations, dozens of duplicate listeners accumulate — all firing on every click anywhere in the document.

**Impact:** Gradual degradation rather than a spike. Not the primary CPU cause but compounds everything else.

---

### How they compound

```
User scrolls in a 1000-message conversation with 200 thought chains:

Bug 2: 60+ scroll events/sec (raw handler) + duplicate addEventListener
  → Bug 1: each event re-renders → useMemo invalidates → O(n) buildMessages
    → React reconciles 1000+ elements including...
      → Bug 3: 200 hidden video decoders consuming CPU/GPU
        → Bug 4: N duplicate click listeners firing on interaction

Result: 96-100% CPU, UI unresponsive
```

Remove any single bug and CPU drops significantly. Remove all four and scrolling becomes effectively free (memoized no-op re-renders + zero decoder overhead + single event listener).

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

For what it is worth, this seems like an issue that gets paved over in Chrome as it has better memory management that Electrons Chromium - but the fixes here will carry to that as well.

I noticed a sig perf hit with 500 messages, it was so bad the UI could freeze totally due to scroll handlers and other bloat. Now on even a lowend laptop and 10K messages the CPU stays flat/idle.

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
