### PR TITLE
fix: expand system prompt variables with literal replacement values

### DIFF
--- a/server/__tests__/models/systemPromptVariables.test.js
+++ b/server/__tests__/models/systemPromptVariables.test.js
@@ -58,4 +58,27 @@ describe("SystemPromptVariables.expandSystemPromptVariables", () => {
     const variables = await SystemPromptVariables.expandSystemPromptVariables("Hello {invalid.variable} {user.password} the current user is {user.name} on workspace id #{workspace.id}", null, null);
     expect(variables).toBe("Hello {invalid.variable} [User password] the current user is [User name] on workspace id #[Workspace ID]");
   });
+
+  it("should treat '$' replacement patterns in variable values literally", async () => {
+    // Regression test: values are substituted with String.prototype.replace.
+    // Passing the value as the (string) replacement argument makes JS interpret
+    // "$$", "$&", "$`" and "$'" as special replacement patterns, corrupting the
+    // resolved prompt (e.g. "$&" re-injects the original "{variable}" token).
+    const dollarValue = "Cost $5, total $$10, ref $& tail $'";
+    prisma.system_prompt_variables.findMany = jest.fn().mockResolvedValue([
+      {
+        id: 99,
+        key: "pricing",
+        value: dollarValue,
+        description: "A value containing replacement-pattern characters",
+        type: "static",
+        userId: null,
+      },
+    ]);
+
+    const variables = await SystemPromptVariables.expandSystemPromptVariables(
+      "Price: {pricing}!"
+    );
+    expect(variables).toBe(`Price: ${dollarValue}!`);
+  });
 });

--- a/server/models/systemPromptVariables.js
+++ b/server/models/systemPromptVariables.js
@@ -289,7 +289,7 @@ const SystemPromptVariables = {
                 );
                 value = `[${variableTypeDisplay} ${prop}]`;
               }
-              result = result.replace(match, value);
+              result = result.replace(match, () => value);
             } else {
               let value;
               try {
@@ -306,11 +306,14 @@ const SystemPromptVariables = {
                 );
                 value = `[${variableTypeDisplay} ${prop}]`;
               }
-              result = result.replace(match, value);
+              result = result.replace(match, () => value);
             }
           } else {
             // If the variable is not a function, replace the match with the variable value
-            result = result.replace(match, `[${variableTypeDisplay} ${prop}]`);
+            result = result.replace(
+              match,
+              () => `[${variableTypeDisplay} ${prop}]`
+            );
           }
           continue;
         }
@@ -327,17 +330,17 @@ const SystemPromptVariables = {
           try {
             if (variable.value.constructor.name === "AsyncFunction") {
               const value = await variable.value(userId);
-              result = result.replace(match, value);
+              result = result.replace(match, () => value);
             } else {
               const value = variable.value();
-              result = result.replace(match, value);
+              result = result.replace(match, () => value);
             }
           } catch (error) {
             console.error(`Error processing dynamic variable ${key}:`, error);
-            result = result.replace(match, match);
+            result = result.replace(match, () => match);
           }
         } else {
-          result = result.replace(match, variable.value || match);
+          result = result.replace(match, () => variable.value || match);
         }
       }
       return result;


### PR DESCRIPTION
### Bug

`SystemPromptVariables.expandSystemPromptVariables` substitutes each `{variable}`
token using `String.prototype.replace(match, value)` where `value` is a string.

When that string is the *replacement* argument, JavaScript interprets the special
replacement patterns `$$`, `$&`, `` $` `` and `$'`. So whenever a resolved
variable value contains one of these sequences, the expanded prompt is silently
corrupted:

- `$$` collapses to a single `$`
- `$&` is replaced with the matched token, i.e. it re-injects the literal
  `{variable}` placeholder back into the prompt
- `` $` `` / `$'` are replaced with the text before/after the token

Example (a static variable whose value is `Cost $5, total $$10, ref $& tail $'`
expanded into `Price: {pricing}!`):

```
Expected: Price: Cost $5, total $$10, ref $& tail $'!
Actual:   Price: Cost $5, total $10, ref {pricing} tail !!
```

This affects any user/workspace/system/static variable value containing `$`
(prices, code snippets, regex fragments, etc.).

### Fix

Pass the resolved value through a replacer **function** (`() => value`) instead
of a replacement string. A function's return value is inserted verbatim and is
never subject to `$`-pattern interpretation. Applied uniformly to every
substitution site in `expandSystemPromptVariables` so all variable types behave
consistently.

### Verification

Added a regression test in `server/__tests__/models/systemPromptVariables.test.js`
that expands a variable whose value contains `$$`, `$&` and `$'` and asserts the
value is inserted literally.

```
$ npx jest server/__tests__/models/systemPromptVariables.test.js
PASS server/__tests__/models/systemPromptVariables.test.js
  SystemPromptVariables.expandSystemPromptVariables
    ✓ should expand user-defined system prompt variables
    ✓ should expand workspace-defined system prompt variables
    ✓ should expand user-defined system prompt variables
    ✓ should work with any combination of variables
    ✓ should fail gracefully with invalid variables that are undefined for any reason
    ✓ should treat '$' replacement patterns in variable values literally
Tests: 6 passed, 6 total
```

The new test fails before the change and passes after it.
