### PR TITLE
add missing headers to ollama embeder engine isAlive method

### DIFF
--- a/server/utils/EmbeddingEngines/ollama/index.js
+++ b/server/utils/EmbeddingEngines/ollama/index.js
@@ -43,7 +43,11 @@ class OllamaEmbedder {
    * @returns {Promise<boolean>} - A promise that resolves to true if the service is alive, false otherwise.
    */
   async #isAlive() {
-    return await fetch(this.basePath)
+    const headers = this.authToken
+      ? { Authorization: `Bearer ${this.authToken}` }
+      : {};
+
+    return await fetch(this.basePath, { headers })
       .then((res) => res.ok)
       .catch((e) => {
         this.log(e.message);


### PR DESCRIPTION
### Pull Request Type
- [ ] ✨ feat (New feature)
- [X] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)
### Relevant Issues
resolves #5862
 
### Description
The `#isAlive()` method in the Ollama embedding engine makes an unauthenticated fetch to `this.basePath`. For Ollama instances that require a Bearer token, this returns a 401/403, causing the health check to fail even though the instance is running.
 
This PR adds the existing `this.authToken` as a Bearer header to the liveness check, matching how the rest of the engine already handles auth. Instances without auth are unaffected since the headers object defaults to empty.
 
### Visuals (if applicable)
N/A — no UI changes.
 
### Additional Information
Minimal, single-line change. No new dependencies or config required.
 
### Developer Validations
- [X] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [X] I have tested my code functionality
- [X] Docker build succeeds locally