### PR TITLE
Report attached & pinned documents as citations in agent chat

### DIFF
--- a/server/__tests__/utils/agents/aibitat/utils/parsedFileSources.test.js
+++ b/server/__tests__/utils/agents/aibitat/utils/parsedFileSources.test.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+const {
+  documentToCitationSource,
+} = require("../../../../../utils/agents/aibitat/utils/parsedFileSources");
+
+describe("documentToCitationSource", () => {
+  test("builds a citation source for a parsed/uploaded document", () => {
+    const doc = {
+      id: "doc-123",
+      title: "report.pdf",
+      pageContent: "The quarterly revenue grew by 12%.",
+      chunkSource: "",
+    };
+
+    expect(documentToCitationSource(doc, "Uploaded Document")).toEqual({
+      id: "doc-123",
+      title: "report.pdf",
+      text: "The quarterly revenue grew by 12%....continued on in source document...",
+      chunkSource: "",
+      score: null,
+    });
+  });
+
+  test("falls back to the provided title when the document has none", () => {
+    const source = documentToCitationSource(
+      { id: "doc-123", pageContent: "content" },
+      "Uploaded Document"
+    );
+    expect(source.title).toBe("Uploaded Document");
+  });
+
+  test("falls back to nested metadata title for pinned documents", () => {
+    const source = documentToCitationSource(
+      { id: "pin-1", metadata: { title: "pinned.txt" }, pageContent: "content" },
+      "Pinned Document"
+    );
+    expect(source.title).toBe("pinned.txt");
+  });
+
+  test("uses the fallback title as id when the document has no id", () => {
+    const source = documentToCitationSource(
+      { pageContent: "content" },
+      "Uploaded Document"
+    );
+    expect(source.id).toBe("Uploaded Document");
+  });
+
+  test("truncates the citation text to the first 1000 characters", () => {
+    const longContent = "a".repeat(5000);
+    const source = documentToCitationSource(
+      { id: "doc-123", title: "big.txt", pageContent: longContent },
+      "Uploaded Document"
+    );
+    expect(source.text).toBe(
+      "a".repeat(1000) + "...continued on in source document..."
+    );
+  });
+
+  test("preserves the chunkSource so the frontend can resolve the source type", () => {
+    const source = documentToCitationSource(
+      {
+        id: "doc-123",
+        title: "page",
+        pageContent: "content",
+        chunkSource: "link://https://example.com",
+      },
+      "Uploaded Document"
+    );
+    expect(source.chunkSource).toBe("link://https://example.com");
+  });
+
+  test("handles missing/invalid pageContent without throwing", () => {
+    const source = documentToCitationSource(
+      { id: "doc-123", title: "empty" },
+      "Uploaded Document"
+    );
+    expect(source.text).toBe("...continued on in source document...");
+  });
+});

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -839,7 +839,8 @@ ${this.getHistory({ to: route.to })
 
     // Fetch fresh parsed file context and inject into the last user message
     if (this.fetchParsedFileContext) {
-      const parsedContext = await this.fetchParsedFileContext();
+      const { context: parsedContext = "", sources: parsedSources = [] } =
+        (await this.fetchParsedFileContext()) || {};
       if (parsedContext) {
         // Find the last user message and append context to it
         for (let i = chatHistory.length - 1; i >= 0; i--) {
@@ -851,6 +852,21 @@ ${this.getHistory({ to: route.to })
             break;
           }
         }
+      }
+
+      // Surface the injected documents (drag-and-dropped/parsed files and
+      // pinned docs) as citations so they appear under the agent reply, the
+      // same way non-agent chat reports them. Dedupe against already-pending
+      // citations so reply() running multiple times within a single response
+      // (e.g. tool calls) does not cite the same document repeatedly.
+      if (parsedSources.length) {
+        const existingCitationIds = new Set(
+          this._pendingCitations.map((citation) => citation.id)
+        );
+        const newSources = parsedSources.filter(
+          (source) => !existingCitationIds.has(source.id)
+        );
+        if (newSources.length) this.addCitation(newSources);
       }
     }
 

--- a/server/utils/agents/aibitat/utils/parsedFileSources.js
+++ b/server/utils/agents/aibitat/utils/parsedFileSources.js
@@ -1,0 +1,31 @@
+/**
+ * Build a citation/source object for a document that is injected into an
+ * agent's context - namely drag-and-dropped/parsed files and pinned documents.
+ *
+ * Non-agent chat (see `server/utils/chats/stream.js`) reports these documents
+ * as `sources` so they render as citations under a reply. Agent chat injects
+ * the same documents into the user message but historically never registered
+ * them as citations, so the answer used the document content without surfacing
+ * where it came from. This helper produces a citation object in the shape the
+ * frontend expects so agent replies can cite injected documents too.
+ *
+ * @param {{id?: string, title?: string, pageContent?: string, chunkSource?: string, metadata?: {title?: string}}} doc
+ * @param {string} fallbackTitle - Title to use when the document has none.
+ * @returns {{id: string, title: string, text: string, chunkSource: string, score: null}}
+ */
+function documentToCitationSource(
+  doc = {},
+  fallbackTitle = "Uploaded Document"
+) {
+  const pageContent =
+    typeof doc?.pageContent === "string" ? doc.pageContent : "";
+  return {
+    id: doc?.id || fallbackTitle,
+    title: doc?.title || doc?.metadata?.title || fallbackTitle,
+    text: pageContent.slice(0, 1_000) + "...continued on in source document...",
+    chunkSource: doc?.chunkSource || "",
+    score: null,
+  };
+}
+
+module.exports = { documentToCitationSource };

--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -9,6 +9,9 @@ const { Workspace } = require("../../models/workspace");
 const { WorkspaceChats } = require("../../models/workspaceChats");
 const { WorkspaceParsedFiles } = require("../../models/workspaceParsedFiles");
 const { DocumentManager } = require("../DocumentManager");
+const {
+  documentToCitationSource,
+} = require("./aibitat/utils/parsedFileSources");
 const { safeJsonParse } = require("../http");
 const {
   USER_AGENT,
@@ -425,10 +428,11 @@ class EphemeralAgentHandler extends AgentHandler {
   /**
    * Fetch fresh parsed files and pinned documents, format them for injection into user messages.
    * Called on every chat turn to ensure context is always up-to-date.
-   * @returns {Promise<string>} Formatted context string to append to user message
+   * @returns {Promise<{context: string, sources: Array<{id: string, title: string, text: string, chunkSource: string, score: null}>}>}
+   * Formatted context string to append to the user message and the citation sources for the injected documents.
    */
   async #fetchParsedFileContext() {
-    if (!this.#workspace) return "";
+    if (!this.#workspace) return { context: "", sources: [] };
 
     const user = this.#userId ? { id: this.#userId } : null;
     const thread = this.#threadId ? { id: this.#threadId } : null;
@@ -445,14 +449,16 @@ class EphemeralAgentHandler extends AgentHandler {
           ...(parsedFiles || []).map((doc) => ({
             name: doc.title || "Uploaded Document",
             content: doc.pageContent,
+            source: documentToCitationSource(doc, "Uploaded Document"),
           })),
           ...(pinnedDocs || []).map((doc) => ({
             name: doc.title || doc.metadata?.title || "Pinned Document",
             content: doc.pageContent,
+            source: documentToCitationSource(doc, "Pinned Document"),
           })),
         ];
 
-        if (allDocuments.length === 0) return "";
+        if (allDocuments.length === 0) return { context: "", sources: [] };
 
         if (parsedFiles?.length > 0)
           this.log(
@@ -463,7 +469,7 @@ class EphemeralAgentHandler extends AgentHandler {
             `Injecting ${pinnedDocs.length} pinned document(s) into user message`
           );
 
-        return (
+        const context =
           "\n\n<attached_documents>\n" +
           allDocuments
             .map((doc, i) => {
@@ -471,12 +477,13 @@ class EphemeralAgentHandler extends AgentHandler {
               return `<document name="${filename}">\n${doc.content}\n</document>`;
             })
             .join("\n") +
-          "\n</attached_documents>"
-        );
+          "\n</attached_documents>";
+
+        return { context, sources: allDocuments.map((doc) => doc.source) };
       })
       .catch((e) => {
         this.log("Error fetching parsed file context", e.message);
-        return "";
+        return { context: "", sources: [] };
       });
   }
 

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -14,6 +14,9 @@ const { AgentFlows } = require("../agentFlows");
 const MCPCompatibilityLayer = require("../MCP");
 const { getAndClearInvocationAttachments } = require("../chats/agents");
 const { DocumentManager } = require("../DocumentManager");
+const {
+  documentToCitationSource,
+} = require("./aibitat/utils/parsedFileSources");
 
 class AgentHandler {
   #invocationUUID;
@@ -712,7 +715,8 @@ class AgentHandler {
   /**
    * Fetch fresh parsed files and pinned documents, format them for injection into user messages.
    * Called on every chat turn to ensure context is always up-to-date.
-   * @returns {Promise<string>} Formatted context string to append to user message
+   * @returns {Promise<{context: string, sources: Array<{id: string, title: string, text: string, chunkSource: string, score: null}>}>}
+   * Formatted context string to append to the user message and the citation sources for the injected documents.
    */
   async #fetchParsedFileContext() {
     const user = this.invocation.user_id
@@ -738,14 +742,16 @@ class AgentHandler {
           ...(parsedFiles || []).map((doc) => ({
             name: doc.title || "Uploaded Document",
             content: doc.pageContent,
+            source: documentToCitationSource(doc, "Uploaded Document"),
           })),
           ...(pinnedDocs || []).map((doc) => ({
             name: doc.title || doc.metadata?.title || "Pinned Document",
             content: doc.pageContent,
+            source: documentToCitationSource(doc, "Pinned Document"),
           })),
         ];
 
-        if (allDocuments.length === 0) return "";
+        if (allDocuments.length === 0) return { context: "", sources: [] };
         if (parsedFiles?.length > 0)
           this.log(
             `Injecting ${parsedFiles.length} parsed file(s) into user message`
@@ -755,7 +761,7 @@ class AgentHandler {
             `Injecting ${pinnedDocs.length} pinned document(s) into user message`
           );
 
-        return (
+        const context =
           "\n\n<attached_documents>\n" +
           allDocuments
             .map((doc, i) => {
@@ -763,12 +769,13 @@ class AgentHandler {
               return `<document name="${filename}">\n${doc.content}\n</document>`;
             })
             .join("\n") +
-          "\n</attached_documents>"
-        );
+          "\n</attached_documents>";
+
+        return { context, sources: allDocuments.map((doc) => doc.source) };
       })
       .catch((e) => {
         this.log("Error fetching parsed file context", e.message);
-        return "";
+        return { context: "", sources: [] };
       });
   }
 


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5840

### Description

When a document is drag-and-dropped into an agent chat (a "parsed" file) or a document is pinned, its content is injected into the user message via `fetchParsedFileContext()` so the agent can answer from it. However, those documents were never registered as citations, so agent replies returned document-based answers with **no citations** — unlike non-agent chat (`server/utils/chats/stream.js`), which pushes both parsed files and pinned docs into `sources`.

This change makes the agent flow mirror non-agent chat:

- `fetchParsedFileContext()` (in both `AgentHandler` and `EphemeralAgentHandler`) now returns `{ context, sources }`, where `sources` are citation objects built for each injected parsed/pinned document.
- `AIbitat.reply()` injects the context as before and registers the document sources via the existing `addCitation()` mechanism, so they flush to the UI and persist with the chat exactly like other agent citations (web browsing, etc.).
- Sources are deduped against already-pending citations so a multi-turn reply (e.g. tool calls cause `reply()` to run more than once within a single response) does not cite the same document repeatedly.

Citation objects use the same shape the frontend already expects (`{ id, title, text, chunkSource, score }`). For uploaded files `chunkSource` is empty, which the frontend resolves to the standard file icon.

A small pure helper `documentToCitationSource()` was extracted (`server/utils/agents/aibitat/utils/parsedFileSources.js`) and unit tested.

### Visuals (if applicable)

N/A — citations now appear under agent replies that use attached/pinned documents.

### Additional Information

New unit tests in `server/__tests__/utils/agents/aibitat/utils/parsedFileSources.test.js` cover the citation shape, title/id fallbacks, text truncation, and `chunkSource` passthrough.

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

> Note: code was hand-formatted to match the repo's Prettier config; the new helper is covered by passing unit tests (`parsedFileSources.test.js`).
