### PR TITLE
Harden agent web-scraping tool against SSRF to internal hosts

### DIFF
--- a/server/__tests__/utils/agents/aibitat/plugins/web-scraping.test.js
+++ b/server/__tests__/utils/agents/aibitat/plugins/web-scraping.test.js
@@ -1,0 +1,114 @@
+// Behavior-level regression for the agent web-scraping SSRF guard.
+//
+// On a vulnerable build the plugin forwards ANY model-supplied URL straight to
+// the collector (CollectorApi.getLinkContent), so a loopback URL would reach
+// the network sink. With the guard in place the loopback call must be refused
+// BEFORE getLinkContent is ever invoked, while ordinary public URLs still pass.
+//
+// CollectorApi is mocked so the test performs no real HTTP egress.
+
+const mockGetLinkContent = jest.fn();
+jest.mock("../../../../../utils/collectorApi", () => ({
+  CollectorApi: jest.fn().mockImplementation(() => ({
+    getLinkContent: mockGetLinkContent,
+  })),
+}));
+
+// Avoid loading the heavy provider/token machinery (and its langchain deps)
+// that the plugin pulls in for the post-fetch summarization path. None of it
+// is exercised by the SSRF guard, which runs before any of it.
+jest.mock("../../../../../utils/agents/aibitat/utils/summarize", () => ({
+  summarizeContent: jest.fn(async () => "summarized"),
+}));
+jest.mock("../../../../../utils/agents/aibitat/providers/ai-provider", () => ({
+  contextLimit: () => 1_000_000,
+}));
+jest.mock("../../../../../utils/helpers/tiktoken", () => ({
+  TokenManager: jest.fn().mockImplementation(() => ({
+    countFromString: () => 1,
+  })),
+}));
+
+const {
+  webScraping,
+} = require("../../../../../utils/agents/aibitat/plugins/web-scraping");
+
+/**
+ * Build a minimal "scrape" closure with the same surface the plugin relies on,
+ * mirroring how aibitat.function binds the handler object.
+ */
+function buildScraper() {
+  const introspections = [];
+  const pluginInstance = webScraping.plugin();
+  let captured = null;
+
+  const fakeAibitat = {
+    function: (def) => {
+      captured = def;
+    },
+    introspect: (m) => introspections.push(m),
+    handlerProps: { log: () => {} },
+    emitter: { on: () => {}, removeListener: () => {} },
+    provider: "openai",
+    model: "gpt-4o",
+    addCitation: () => {},
+  };
+
+  pluginInstance.setup(fakeAibitat);
+  captured.super = fakeAibitat;
+  captured.caller = "tester";
+  return { scrape: captured.scrape.bind(captured), introspections };
+}
+
+describe("web-scraping plugin SSRF guard (behavior)", () => {
+  const ORIGINAL_ENV = process.env.COLLECTOR_ALLOW_ANY_IP;
+
+  beforeEach(() => {
+    mockGetLinkContent.mockReset();
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    else process.env.COLLECTOR_ALLOW_ANY_IP = ORIGINAL_ENV;
+  });
+
+  it("does NOT forward a loopback URL to the collector", async () => {
+    const { scrape } = buildScraper();
+    await expect(scrape("http://127.0.0.1:8080/canary")).rejects.toThrow();
+    expect(mockGetLinkContent).not.toHaveBeenCalled();
+  });
+
+  it("does NOT forward the cloud metadata endpoint to the collector", async () => {
+    const { scrape } = buildScraper();
+    await expect(
+      scrape("http://169.254.169.254/latest/meta-data/")
+    ).rejects.toThrow();
+    expect(mockGetLinkContent).not.toHaveBeenCalled();
+  });
+
+  it("DOES forward a public IP literal to the collector", async () => {
+    mockGetLinkContent.mockResolvedValue({
+      success: true,
+      content: "hello world",
+    });
+    const { scrape } = buildScraper();
+    const out = await scrape("https://93.184.216.34/");
+    expect(mockGetLinkContent).toHaveBeenCalledWith("https://93.184.216.34/");
+    expect(out).toContain("hello world");
+  });
+
+  it("forwards loopback again when COLLECTOR_ALLOW_ANY_IP=true", async () => {
+    process.env.COLLECTOR_ALLOW_ANY_IP = "true";
+    mockGetLinkContent.mockResolvedValue({
+      success: true,
+      content: "internal-service-body",
+    });
+    const { scrape } = buildScraper();
+    const out = await scrape("http://127.0.0.1:8080/canary");
+    expect(mockGetLinkContent).toHaveBeenCalledWith(
+      "http://127.0.0.1:8080/canary"
+    );
+    expect(out).toContain("internal-service-body");
+  });
+});

--- a/server/__tests__/utils/agents/aibitat/utils/ssrf.test.js
+++ b/server/__tests__/utils/agents/aibitat/utils/ssrf.test.js
@@ -1,0 +1,116 @@
+const {
+  assertSafeAgentUrl,
+  isBlockedAddress,
+} = require("../../../../../utils/agents/aibitat/utils/ssrf");
+
+// Deterministic stub resolver so the test performs NO real DNS / network egress.
+const stubResolver = (map) => async (hostname) => {
+  if (!map[hostname]) {
+    const err = new Error(`getaddrinfo ENOTFOUND ${hostname}`);
+    throw err;
+  }
+  return map[hostname];
+};
+
+describe("assertSafeAgentUrl (agent web-scraping SSRF guard)", () => {
+  const ORIGINAL_ENV = process.env.COLLECTOR_ALLOW_ANY_IP;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    else process.env.COLLECTOR_ALLOW_ANY_IP = ORIGINAL_ENV;
+  });
+
+  it("BLOCKS a model-supplied loopback URL literal (the reported PoC)", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    const res = await assertSafeAgentUrl("http://127.0.0.1:8080/canary");
+    expect(res.ok).toBe(false);
+  });
+
+  it("BLOCKS 0.0.0.0 literal", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    const res = await assertSafeAgentUrl("http://0.0.0.0:7860/");
+    expect(res.ok).toBe(false);
+  });
+
+  it("BLOCKS the cloud metadata endpoint 169.254.169.254", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    const res = await assertSafeAgentUrl(
+      "http://169.254.169.254/latest/meta-data/"
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it("BLOCKS RFC1918 private ranges (literals)", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    for (const u of [
+      "http://10.0.0.5/",
+      "http://172.16.0.1/",
+      "http://192.168.1.1/",
+    ]) {
+      expect((await assertSafeAgentUrl(u)).ok).toBe(false);
+    }
+  });
+
+  it("BLOCKS IPv6 loopback and link-local literals", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    expect((await assertSafeAgentUrl("http://[::1]:8080/")).ok).toBe(false);
+    expect((await assertSafeAgentUrl("http://[fe80::1]/")).ok).toBe(false);
+    expect((await assertSafeAgentUrl("http://[fc00::1]/")).ok).toBe(false);
+    // IPv4-mapped loopback
+    expect((await assertSafeAgentUrl("http://[::ffff:127.0.0.1]/")).ok).toBe(
+      false
+    );
+  });
+
+  it("BLOCKS a hostname that RESOLVES to a private address (DNS-rebinding style)", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    const res = await assertSafeAgentUrl("http://evil.example.com/", {
+      resolver: stubResolver({ "evil.example.com": ["127.0.0.1"] }),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("BLOCKS when ANY resolved address is private (mixed result)", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    const res = await assertSafeAgentUrl("http://mixed.example.com/", {
+      resolver: stubResolver({
+        "mixed.example.com": ["93.184.216.34", "10.0.0.1"],
+      }),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("ALLOWS a normal public hostname", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    const res = await assertSafeAgentUrl("https://example.com/page", {
+      resolver: stubResolver({ "example.com": ["93.184.216.34"] }),
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("ALLOWS a public IP literal", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    expect((await assertSafeAgentUrl("https://93.184.216.34/")).ok).toBe(true);
+  });
+
+  it("REJECTS non-http(s) protocols", async () => {
+    delete process.env.COLLECTOR_ALLOW_ANY_IP;
+    expect((await assertSafeAgentUrl("file:///etc/passwd")).ok).toBe(false);
+    expect((await assertSafeAgentUrl("ftp://example.com/")).ok).toBe(false);
+  });
+
+  it("honors the COLLECTOR_ALLOW_ANY_IP operator escape hatch", async () => {
+    process.env.COLLECTOR_ALLOW_ANY_IP = "true";
+    // With the toggle on, loopback is permitted again (VPC/internal use case).
+    expect((await assertSafeAgentUrl("http://127.0.0.1:8080/")).ok).toBe(true);
+  });
+
+  it("isBlockedAddress classifies literals correctly", () => {
+    expect(isBlockedAddress("127.0.0.1")).toBe(true);
+    expect(isBlockedAddress("169.254.169.254")).toBe(true);
+    expect(isBlockedAddress("10.1.2.3")).toBe(true);
+    expect(isBlockedAddress("::1")).toBe(true);
+    expect(isBlockedAddress("8.8.8.8")).toBe(false);
+    expect(isBlockedAddress("not-an-ip")).toBe(false); // hostnames pass through to DNS
+  });
+});

--- a/server/utils/agents/aibitat/plugins/web-scraping.js
+++ b/server/utils/agents/aibitat/plugins/web-scraping.js
@@ -99,6 +99,22 @@ const webScraping = {
             this.super.introspect(
               `${this.caller}: Scraping the content of ${url}`
             );
+
+            // The URL here comes from model output (a tool call) and can be
+            // steered by prompt injection, so unlike user-submitted document
+            // collector URLs it must not be allowed to reach internal hosts by
+            // default. Operators can opt back in with COLLECTOR_ALLOW_ANY_IP=true.
+            const { assertSafeAgentUrl } = require("../utils/ssrf");
+            const safety = await assertSafeAgentUrl(url);
+            if (!safety.ok) {
+              this.super.introspect(
+                `${this.caller}: refused to scrape ${url} - ${safety.reason}`
+              );
+              throw new Error(
+                `URL could not be scraped: ${safety.reason} If this is an internal service you intended to reach, set COLLECTOR_ALLOW_ANY_IP=true.`
+              );
+            }
+
             const { success, content } =
               await new CollectorApi().getLinkContent(url);
 

--- a/server/utils/agents/aibitat/utils/ssrf.js
+++ b/server/utils/agents/aibitat/utils/ssrf.js
@@ -1,0 +1,174 @@
+const net = require("net");
+const dns = require("dns").promises;
+
+/**
+ * SSRF guard for the agent web-scraping/web-browsing tools.
+ *
+ * Context: AnythingLLM intentionally allows the *user-submitted* document
+ * collector to reach internal/loopback hosts (see
+ * collector/utils/url/index.js) because those URLs are entered by an
+ * authenticated human. That contract is preserved and NOT changed here.
+ *
+ * The agent tools are different: the URL originates from *model output*
+ * (a tool call), which can be steered by prompt injection from untrusted
+ * content. That makes the agent path an unauthenticated egress primitive,
+ * so by default we refuse to let the model dereference URLs that resolve to
+ * loopback / private / link-local / unique-local / cloud-metadata addresses.
+ *
+ * Operators who deliberately run AnythingLLM inside a VPC and want the agent
+ * to reach internal services can opt back in with the same toggle the
+ * collector already documents: COLLECTOR_ALLOW_ANY_IP=true.
+ */
+
+/**
+ * Whether the operator has explicitly opted out of the agent SSRF guard.
+ * Mirrors the collector's existing COLLECTOR_ALLOW_ANY_IP escape hatch so
+ * there is a single, documented switch for internal-network scraping.
+ * @returns {boolean}
+ */
+function allowAnyIp() {
+  return String(process.env.COLLECTOR_ALLOW_ANY_IP || "").trim() === "true";
+}
+
+/**
+ * Determine if an IPv4 address string points at a non-public range that the
+ * agent must not be allowed to reach by default.
+ * Covers loopback, RFC1918 private, link-local (incl. 169.254.169.254
+ * cloud-metadata), CGNAT, "this host" 0.0.0.0/8, and broadcast.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isBlockedIPv4(ip) {
+  const octets = ip.split(".").map((o) => Number(o));
+  if (octets.length !== 4 || octets.some((o) => Number.isNaN(o))) return true; // unpar. -> fail closed
+  const [a, b] = octets;
+
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local + metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 255 && b === 255) return true; // 255.255.255.255 broadcast (approx)
+  return false;
+}
+
+/**
+ * Determine if an IPv6 address string points at a non-public range that the
+ * agent must not be allowed to reach by default.
+ * Covers loopback (::1), unspecified (::), unique-local (fc00::/7),
+ * link-local (fe80::/10), and IPv4-mapped (::ffff:a.b.c.d) which is
+ * delegated to the IPv4 check.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isBlockedIPv6(ip) {
+  const addr = ip.toLowerCase().split("%")[0]; // strip zone id if present
+  if (addr === "::1" || addr === "::") return true; // loopback / unspecified
+
+  // IPv4-mapped / IPv4-compatible addresses -> evaluate embedded IPv4.
+  const mapped = addr.match(/^::(?:ffff:)?(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mapped) return isBlockedIPv4(mapped[1]);
+
+  const firstHextet = addr.split(":")[0] || "";
+  const head = parseInt(firstHextet, 16);
+  if (Number.isNaN(head)) return true; // fail closed on anything we cannot parse
+  if ((head & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((head & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  return false;
+}
+
+/**
+ * Returns true when a literal/numeric IP address must be blocked for the
+ * agent path. Non-IP strings return false (they still need DNS resolution).
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isBlockedAddress(ip) {
+  const kind = net.isIP(ip);
+  if (kind === 4) return isBlockedIPv4(ip);
+  if (kind === 6) return isBlockedIPv6(ip);
+  return false; // not a bare IP literal
+}
+
+/**
+ * Validate that a model-supplied URL is safe for the agent to dereference.
+ * - Only http(s) is permitted.
+ * - The hostname is resolved (A + AAAA) and EVERY resolved address must be a
+ *   public address; any private/loopback/link-local/ULA/metadata address
+ *   causes a rejection (defends against DNS-rebinding-to-internal as well).
+ * - Bare IP literals are checked directly without a DNS round-trip.
+ *
+ * Bypassed entirely when COLLECTOR_ALLOW_ANY_IP=true.
+ *
+ * @param {string} url - The URL the model asked to scrape.
+ * @param {{ resolver?: (hostname: string) => Promise<string[]> }} [deps]
+ *   Optional dependency injection for tests (DNS resolver).
+ * @returns {Promise<{ ok: boolean, reason?: string }>}
+ */
+async function assertSafeAgentUrl(url, deps = {}) {
+  if (allowAnyIp()) return { ok: true };
+
+  let parsed;
+  try {
+    parsed = new URL(String(url));
+  } catch {
+    return { ok: false, reason: "Invalid URL." };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+    return { ok: false, reason: `Unsupported protocol "${parsed.protocol}".` };
+
+  // URL.hostname keeps IPv6 literals wrapped in brackets - strip them.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (!hostname) return { ok: false, reason: "URL has no host." };
+
+  // Direct IP literal - no DNS needed.
+  if (net.isIP(hostname)) {
+    if (isBlockedAddress(hostname))
+      return {
+        ok: false,
+        reason:
+          "Refusing to scrape a private, loopback, or link-local address from an agent tool call.",
+      };
+    return { ok: true };
+  }
+
+  // Hostname -> resolve and verify every address it maps to.
+  const resolver =
+    deps.resolver ||
+    (async (host) => {
+      const results = await dns.lookup(host, { all: true });
+      return results.map((r) => r.address);
+    });
+
+  let addresses = [];
+  try {
+    addresses = await resolver(hostname);
+  } catch {
+    return { ok: false, reason: `Could not resolve host "${hostname}".` };
+  }
+
+  if (!Array.isArray(addresses) || addresses.length === 0)
+    return { ok: false, reason: `Could not resolve host "${hostname}".` };
+
+  for (const address of addresses) {
+    if (isBlockedAddress(address))
+      return {
+        ok: false,
+        reason:
+          "Refusing to scrape a host that resolves to a private, loopback, or link-local address from an agent tool call.",
+      };
+  }
+
+  return { ok: true };
+}
+
+module.exports = {
+  assertSafeAgentUrl,
+  isBlockedAddress,
+  isBlockedIPv4,
+  isBlockedIPv6,
+  allowAnyIp,
+};


### PR DESCRIPTION

### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

Resolves #5876

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

This hardens the built-in **`web-scraping` agent skill** so it cannot be used as an egress primitive against the host's own internal network, while **leaving the user-submitted document-collector behavior unchanged**.

**Scope — this is the model-driven path, not the user-submitted one.** I want to be explicit up front because the repo (rightly) treats "scrape an internal host that a human typed into the collector" as out of scope (`collector/utils/url/index.js` lines 2-13, and `SECURITY.md` → Invalid Report Types). This change does **not** touch that path or that contract.

The agent tool is different: its `url` argument comes **directly from model output** (a tool call), so the "a human chose this URL" assumption does not hold. The model can be steered by untrusted content it is processing (a scraped page, an uploaded document, a chat message), and the default skill set exposes `web-scraping` unless an admin disables it. On that path the model's chosen URL is forwarded to the collector with no guard, so a request for a loopback / private / link-local / cloud-metadata endpoint reachable from the AnythingLLM host or container is dereferenced and its body is returned into the chat.

**Affected sites (the model-driven path, source → sink):**
- `server/utils/agents/aibitat/plugins/web-scraping.js:49` — the built-in tool handler takes the model `url` and calls `this.scrape(url)` (no approval gate).
- `server/utils/collectorApi/index.js` `getLinkContent` — POSTs the model URL to the collector `util/get-link`.
- `collector/utils/url/index.js:51` — the collector's URL check is documented as *not* a security feature and explicitly allows `127.0.0.1` / `0.0.0.0`, so a model-emitted internal URL passes straight through.
- `collector/processLink/convert/generic.js:221` — the approved link is dereferenced (`await fetch(link, …)`; the primary path also loads it via `PuppeteerWebBaseLoader(link)`). **Decisive sink.**

**Root cause:** the `web-scraping` tool trusts a model-supplied URL the same way the collector trusts a human-supplied one.

**The change (one minimal, default-safe guard on the agent boundary):**

- **New** `server/utils/agents/aibitat/utils/ssrf.js` — `assertSafeAgentUrl(url)`:
  - permits only `http` / `https`;
  - checks bare IP literals directly, and resolves hostnames (A/AAAA) so that **every** resolved address must be public;
  - rejects loopback, RFC1918 private, CGNAT, link-local (including the `169.254.169.254` metadata address), IPv6 unique-local / link-local, and IPv4-mapped equivalents;
  - if a hostname resolves to multiple addresses and **any** one is internal, the request is refused (this also covers rebinding-to-internal);
  - validates **before** the request is dispatched, and fails closed on anything it cannot parse.
- **Wired** into `server/utils/agents/aibitat/plugins/web-scraping.js` `scrape()` before it calls the collector (`getLinkContent`). On refusal it returns a clear, actionable message that also tells operators how to opt back in.

Because the guard sits at the single point where the untrusted model URL enters (`scrape()`), it closes the whole class for the agent path in one place.

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->

N/A — backend / agent-tool behavior only; no UI changes.

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

**Backwards compatibility / opt-out**
- The check is bypassed when `COLLECTOR_ALLOW_ANY_IP=true` — the **same** environment toggle the collector already documents for internal-network scraping. Operators running inside a VPC who want the agent to reach internal services set that one variable and see no behavior change.
- The public `scrape(url)` signature is unchanged.
- **No new dependencies** — Node standard library (`dns`, `net`) only.
- The user-submitted document-collector path, the collector URL guard, and every user-facing upload flow are untouched — human/API document uploads behave identically.

**Why scoped this way / open to direction**
- This intentionally does **not** reopen the "scrape an internal host" discussion for user-submitted URLs; it only constrains the model-driven agent tool, with an explicit env opt-out that mirrors the existing collector toggle.
- Happy to adjust to project conventions — e.g. gate behind a dedicated agent-specific flag instead of reusing `COLLECTOR_ALLOW_ANY_IP`, or align the naming / wording.
- I kept the write-up hardening-focused and did not include reproduction steps here; happy to share details privately (Huntr / team@mintplexlabs.com) if you'd prefer to coordinate that way.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

**Tests** (run via the repo's existing `jest` setup; the `Run backend tests` workflow covers `server/**.js`):

- `server/__tests__/utils/agents/aibitat/utils/ssrf.test.js` — unit coverage for IPv4 / IPv6 literals, the metadata address, hostnames that resolve to internal addresses, mixed public/private resolution, public allow-through, protocol rejection, and the env opt-out. DNS is stubbed via dependency injection, so the tests perform no real network or DNS lookups.
- `server/__tests__/utils/agents/aibitat/plugins/web-scraping.test.js` — drives the actual plugin handler and asserts it no longer forwards an internal URL to the collector, still forwards public URLs, and forwards again when `COLLECTOR_ALLOW_ANY_IP=true`. `CollectorApi` is mocked, so no outbound requests are made.

All 16 added tests pass on this branch. The plugin-level tests fail on the unpatched tree (the unguarded plugin forwards the internal URL straight to the collector — e.g. `http://127.0.0.1:8080/canary` and `http://169.254.169.254/latest/meta-data/`), which is what demonstrates the regression coverage. The `yarn lint` item above is left unchecked pending a clean root-`yarn lint` run on your side; the changed files were formatted with the repo's Prettier config (`prettier --check` reports all changed files use the repo style).
