### PR TITLE
fix: omit temperature for opus 4.7/4.8 in anthropic llm provider

### DIFF
--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -12,6 +12,17 @@ const {
 const { getAnythingLLMUserAgent } = require("../../../endpoints/utils");
 
 class AnthropicLLM {
+  /**
+   * List of Anthropic models that do not support the `temperature` inference parameter.
+   * These models reject `temperature`/`top_p`/`top_k` with a 400 error.
+   * @type {string[]}
+   */
+  noTemperatureModels = [
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    // Add other models here if identified
+  ];
+
   constructor(embedder = null, modelPreference = null) {
     if (!process.env.ANTHROPIC_API_KEY)
       throw new Error("No Anthropic API key was set.");
@@ -73,6 +84,18 @@ class AnthropicLLM {
     if (this.maxTokens) return this.maxTokens;
     this.maxTokens = await AnthropicLLM.fetchModelMaxTokens(this.model);
     return this.maxTokens;
+  }
+
+  /**
+   * Gets the temperature configuration for the Anthropic LLM.
+   * @param {number} temperature - The temperature to use.
+   * @returns {number|undefined} The temperature value or undefined if not supported.
+   */
+  temperatureParam(temperature = this.defaultTemp) {
+    if (typeof temperature !== "number") return undefined;
+    if (this.noTemperatureModels.some((model) => this.model.includes(model)))
+      return undefined;
+    return parseFloat(temperature);
   }
 
   /**
@@ -196,7 +219,7 @@ class AnthropicLLM {
           max_tokens: this.maxTokens,
           system: this.#buildSystemPrompt(systemContent),
           messages: messages.slice(1), // Pop off the system message
-          temperature: Number(temperature ?? this.defaultTemp),
+          temperature: this.temperatureParam(temperature),
         })
       );
 
@@ -231,7 +254,7 @@ class AnthropicLLM {
         max_tokens: this.maxTokens,
         system: this.#buildSystemPrompt(systemContent),
         messages: messages.slice(1), // Pop off the system message
-        temperature: Number(temperature ?? this.defaultTemp),
+        temperature: this.temperatureParam(temperature),
       }),
       messages,
       runPromptTokenCalculation: false,


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5880 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->
- The Anthropic LLM provider always sent `temperature` on every request, but Opus 4.7/4.8 reject `temperature`/`top_p`/`top_k` and return a 400 (`temperature is deprecated for this model`)
- Prior fixes (#5822) only patched the Bedrock provider, so the bug persisted on the native Anthropic LLM provider in Chat mode
- Adds a `noTemperatureModels` list and a `temperatureParam` helper that omits `temperature` for unsupported models, mirroring the existing Bedrock provider implementation
- Applies the guard to both the streaming (Chat) and non-streaming (Agent/Query) completion paths

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

- Tested all Anthropic models in chat mode with no issues
- Tested all Anthropic models in agent mode with no issues

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
