### PR TITLE
feat: add a per-message "Thinking" toggle to suppress reasoning

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import debounce from "lodash.debounce";
-import { ArrowUp, At } from "@phosphor-icons/react";
+import { ArrowUp, At, Brain } from "@phosphor-icons/react";
 import StopGenerationButton from "./StopGenerationButton";
 import SpeechToText from "./SpeechToText";
 import { Tooltip } from "react-tooltip";
@@ -22,6 +22,12 @@ import { useIsAgentSessionActive } from "@/utils/chat/agent";
 export const PROMPT_INPUT_ID = "primary-prompt-input";
 export const PROMPT_INPUT_EVENT = "set_prompt_input";
 const MAX_EDIT_STACK_SIZE = 100;
+
+// Per-workspace localStorage key for the "suppress thinking" toggle.
+// When set to "true", the server prefills an empty <think></think> block so
+// reasoning models answer directly. Read at send-time in ChatContainer.
+export const suppressThinkingKey = (slug = "") =>
+  `anythingllm_suppress_thinking_${slug}`;
 
 /**
  * @param {Workspace} props.workspace - workspace object
@@ -49,6 +55,25 @@ export default function PromptInput({
   const agentSessionActive = useIsAgentSessionActive();
   const [promptInput, setPromptInput] = useState("");
   const [showTools, setShowTools] = useState(false);
+
+  // "Thinking" toggle: ON by default (reasoning enabled). When turned OFF the
+  // server prefills an empty <think></think> so reasoning models answer directly.
+  // Persisted per-workspace in localStorage; read at send-time in ChatContainer.
+  const thinkingSlug = workspace?.slug || workspaceSlug || "";
+  const [suppressThinking, setSuppressThinking] = useState(
+    () =>
+      window.localStorage.getItem(suppressThinkingKey(thinkingSlug)) === "true"
+  );
+  const toggleThinking = () => {
+    setSuppressThinking((prev) => {
+      const next = !prev;
+      window.localStorage.setItem(
+        suppressThinkingKey(thinkingSlug),
+        String(next)
+      );
+      return next;
+    });
+  };
   const autoOpenedToolsRef = useRef(false);
   const toolsHighlightRef = useRef(-1);
   const formRef = useRef(null);
@@ -385,6 +410,10 @@ export default function PromptInput({
                     textareaRef={textareaRef}
                     autoOpenedToolsRef={autoOpenedToolsRef}
                   />
+                  <ThinkingButton
+                    suppressThinking={suppressThinking}
+                    toggleThinking={toggleThinking}
+                  />
                 </div>
                 <div className="flex gap-x-2 items-center">
                   <SpeechToText sendCommand={sendCommand} />
@@ -481,6 +510,46 @@ function ToolsButton({
         }`}
       >
         {t("chat_window.tools")}
+      </span>
+    </button>
+  );
+}
+
+function ThinkingButton({ suppressThinking, toggleThinking }) {
+  const thinkingOn = !suppressThinking;
+  return (
+    <button
+      id="thinking-btn"
+      type="button"
+      onClick={toggleThinking}
+      title={
+        thinkingOn
+          ? "Thinking ON — model reasons before answering. Click to answer directly (faster)."
+          : "Thinking OFF — model answers directly. Click to re-enable reasoning."
+      }
+      className={`group border-none cursor-pointer flex items-center gap-x-1 h-6 px-2 rounded-full ${
+        thinkingOn
+          ? "bg-zinc-700 light:bg-slate-200"
+          : "hover:bg-zinc-700 light:hover:bg-slate-200"
+      }`}
+    >
+      <Brain
+        size={16}
+        weight={thinkingOn ? "fill" : "regular"}
+        className={
+          thinkingOn
+            ? "text-white light:text-slate-800"
+            : "text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-800"
+        }
+      />
+      <span
+        className={`text-sm font-medium ${
+          thinkingOn
+            ? "text-white light:text-slate-800"
+            : "text-zinc-300 light:text-slate-600 group-hover:text-white light:group-hover:text-slate-800"
+        }`}
+      >
+        Think
       </span>
     </button>
   );

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -4,6 +4,7 @@ import { CLEAR_ATTACHMENTS_EVENT, DndUploaderContext } from "./DnDWrapper";
 import PromptInput, {
   PROMPT_INPUT_EVENT,
   PROMPT_INPUT_ID,
+  suppressThinkingKey,
 } from "./PromptInput";
 import Workspace from "@/models/workspace";
 import handleChat, { ABORT_STREAM_EVENT } from "@/utils/chat";
@@ -326,6 +327,12 @@ export default function ChatContainer({
       const attachments = promptMessage?.attachments ?? parseAttachments();
       window.dispatchEvent(new CustomEvent(CLEAR_ATTACHMENTS_EVENT));
 
+      // Read the per-workspace "suppress thinking" toggle (set in PromptInput).
+      // Read at send-time from localStorage to stay decoupled & closure-safe.
+      const suppressThinking =
+        window.localStorage.getItem(suppressThinkingKey(workspace.slug)) ===
+        "true";
+
       await Workspace.multiplexStream({
         workspaceSlug: workspace.slug,
         threadSlug: activeThreadSlug,
@@ -340,6 +347,7 @@ export default function ChatContainer({
             setSocketId
           ),
         attachments,
+        suppressThinking,
       });
       return;
     }

--- a/frontend/src/models/workspace.js
+++ b/frontend/src/models/workspace.js
@@ -143,22 +143,31 @@ const Workspace = {
     prompt,
     chatHandler,
     attachments = [],
+    suppressThinking = false,
   }) {
     if (!!threadSlug)
       return this.threads.streamChat(
         { workspaceSlug, threadSlug },
         prompt,
         chatHandler,
-        attachments
+        attachments,
+        suppressThinking
       );
     return this.streamChat(
       { slug: workspaceSlug },
       prompt,
       chatHandler,
-      attachments
+      attachments,
+      suppressThinking
     );
   },
-  streamChat: async function ({ slug }, message, handleChat, attachments = []) {
+  streamChat: async function (
+    { slug },
+    message,
+    handleChat,
+    attachments = [],
+    suppressThinking = false
+  ) {
     const ctrl = new AbortController();
 
     // Listen for the ABORT_STREAM_EVENT key to be emitted by the client
@@ -172,7 +181,7 @@ const Workspace = {
 
     await fetchEventSource(`${API_BASE}/workspace/${slug}/stream-chat`, {
       method: "POST",
-      body: JSON.stringify({ message, attachments }),
+      body: JSON.stringify({ message, attachments, suppressThinking }),
       headers: baseHeaders(),
       signal: ctrl.signal,
       openWhenHidden: true,

--- a/frontend/src/models/workspaceThread.js
+++ b/frontend/src/models/workspaceThread.js
@@ -91,7 +91,8 @@ const WorkspaceThread = {
     { workspaceSlug, threadSlug },
     message,
     handleChat,
-    attachments = []
+    attachments = [],
+    suppressThinking = false
   ) {
     const ctrl = new AbortController();
 
@@ -108,7 +109,7 @@ const WorkspaceThread = {
       `${API_BASE}/workspace/${workspaceSlug}/thread/${threadSlug}/stream-chat`,
       {
         method: "POST",
-        body: JSON.stringify({ message, attachments }),
+        body: JSON.stringify({ message, attachments, suppressThinking }),
         headers: baseHeaders(),
         signal: ctrl.signal,
         openWhenHidden: true,

--- a/server/endpoints/chat.js
+++ b/server/endpoints/chat.js
@@ -26,7 +26,11 @@ function chatEndpoints(app) {
     async (request, response) => {
       try {
         const user = await userFromSession(request, response);
-        const { message, attachments = [] } = reqBody(request);
+        const {
+          message,
+          attachments = [],
+          suppressThinking = false,
+        } = reqBody(request);
         const workspace = response.locals.workspace;
 
         if (typeof message !== "string" || message.trim().length === 0) {
@@ -66,7 +70,8 @@ function chatEndpoints(app) {
           workspace?.chatMode,
           user,
           null,
-          attachments
+          attachments,
+          suppressThinking
         );
         await Telemetry.sendTelemetry("sent_chat", {
           multiUserMode: multiUserMode(response),
@@ -112,7 +117,11 @@ function chatEndpoints(app) {
     async (request, response) => {
       try {
         const user = await userFromSession(request, response);
-        const { message, attachments = [] } = reqBody(request);
+        const {
+          message,
+          attachments = [],
+          suppressThinking = false,
+        } = reqBody(request);
         const workspace = response.locals.workspace;
         const thread = response.locals.thread;
 
@@ -153,7 +162,8 @@ function chatEndpoints(app) {
           workspace?.chatMode,
           user,
           thread,
-          attachments
+          attachments,
+          suppressThinking
         );
 
         // If thread was renamed emit event to frontend via special `action` response.

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -15,6 +15,11 @@ const {
 
 const VALID_CHAT_MODE = ["automatic", "chat", "query"];
 
+// Empty assistant reasoning block. Prefilled when the user disables "thinking"
+// so reasoning-capable models (Qwen3, DeepSeek-R1, QwQ, etc. — all use <think>)
+// treat reasoning as already complete and answer directly.
+const REASONING_SUPPRESSION_PREFILL = "<think>\n\n</think>\n\n";
+
 async function streamChatWithWorkspace(
   response,
   workspace,
@@ -22,7 +27,8 @@ async function streamChatWithWorkspace(
   chatMode = "automatic",
   user = null,
   thread = null,
-  attachments = []
+  attachments = [],
+  suppressThinking = false
 ) {
   const uuid = uuidv4();
   const updatedMessage = await grepCommand(message, user);
@@ -272,6 +278,17 @@ async function streamChatWithWorkspace(
     },
     rawHistory
   );
+
+  // Reasoning suppression (decoupled, additive): when the user toggles thinking OFF,
+  // prefill an empty assistant <think></think> block so reasoning-capable models
+  // (Qwen3, DeepSeek-R1, etc.) treat reasoning as already done and answer directly.
+  // No-op for non-reasoning models. Default false => zero behavior change.
+  if (suppressThinking) {
+    messages.push({
+      role: "assistant",
+      content: REASONING_SUPPRESSION_PREFILL,
+    });
+  }
 
   // If streaming is not explicitly enabled for connector
   // we do regular waiting of a response and send a single chunk.


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)

### Relevant Issues

N/A

### Description

Reasoning-capable models (Qwen3, DeepSeek-R1, QwQ, etc.) emit a `<think>…</think>` block before their answer. AnythingLLM already **displays** this nicely (collapsible reasoning), but there is currently no way to **skip** it. For quick or generative tasks (short writing, formatting, casual chat) the model can spend most — or all — of its token budget reasoning and never reach the answer.

This PR adds a per-message **"Thinking" toggle** to the chat input bar. When turned **off**, the server prefills an empty assistant `<think>\n\n</think>` block so the model treats reasoning as already complete and answers directly. Default is **on** (current behavior — zero change for existing users).

It complements the existing reasoning *display* (`stripThinkingFromText`) by adding reasoning *suppression*.

**Design — intentionally minimal & decoupled:**
- Core change is a single injection in `server/utils/chats/stream.js` (right after the messages array is assembled). No LLM provider classes are modified.
- Everything else just threads an optional `suppressThinking` flag (forward-compatible additions): chat endpoints → `streamChatWithWorkspace` → frontend request body / models.
- Toggle state is persisted per-workspace in `localStorage` and read at send-time, so there is **no schema/DB change**.

### Visuals (if applicable)

A 🧠 **Think** toggle appears in the input bar next to **Tools**. Highlighted = reasoning on (default); click to dim = answer directly.

![Thinking toggle in the chat input bar](https://raw.githubusercontent.com/dennisliu1112/anything-llm/pr-assets/think-toggle.png)

### Additional Information

- The empty-think prefill `"<think>\n\n</think>\n\n"` is the de-facto token shared by Qwen3 / DeepSeek-R1 / QwQ. It is extracted to a named constant (`REASONING_SUPPRESSION_PREFILL`) — happy to promote it to a configurable per-workspace setting if maintainers prefer.
- Applies to **chat / query** mode. In **agent** mode the flow exits early (native tool calling), so the toggle has no effect there — by design.
- Harmless for non-reasoning models (an empty assistant turn is a no-op).

**Testing:** verified end-to-end against a local LM Studio serving a Qwen3.5-35B-A3B reasoning model:
- Toggle **off** → response contains no `<think>`, answers directly (~3.5s).
- Toggle **on** → reasons first (`<think>` present, ~37s).

### Developer Validations

- [x] `eslint` passes on the changed files and `vite build` succeeds (lint clean)
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
