### PR TITLE
Normalize spacing across workspace chat settings sections

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatHistorySettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatHistorySettings/index.jsx
@@ -3,11 +3,11 @@ export default function ChatHistorySettings({ workspace, setHasChanges }) {
   const { t } = useTranslation();
   return (
     <div>
-      <div className="flex flex-col gap-y-1 mb-4">
-        <label htmlFor="name" className="block mb-2 input-label">
+      <div className="flex flex-col">
+        <label htmlFor="name" className="block input-label">
           {t("chat.history.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium">
+        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
           {t("chat.history.desc-start")}
           <i> {t("chat.history.recommend")} </i>
           {t("chat.history.desc-end")}
@@ -21,7 +21,7 @@ export default function ChatHistorySettings({ workspace, setHasChanges }) {
         step={1}
         onWheel={(e) => e.target.blur()}
         defaultValue={workspace?.openAiHistory ?? 20}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
         placeholder="20"
         required={true}
         autoComplete="off"

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatTemperatureSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatTemperatureSettings/index.jsx
@@ -37,7 +37,7 @@ export default function ChatTemperatureSettings({
         step={0.1}
         onWheel={(e) => e.target.blur()}
         defaultValue={workspace?.openAiTemp ?? defaults.temp}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
         placeholder="0.7"
         required={true}
         autoComplete="off"

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
@@ -82,7 +82,7 @@ export default function WorkspaceLLMSelection({
         </p>
       </div>
 
-      <div className="relative">
+      <div className="relative mt-2">
         <input type="hidden" name="chatProvider" value={selectedLLM} />
         {searchMenuOpen && (
           <div


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [x] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #4995

### Description

The sections on **Workspace Settings → Chat Settings** use inconsistent vertical spacing:

- **Chat History** builds its heading differently from every other section. It uses a `flex flex-col gap-y-1 mb-4` wrapper with an `mb-2` label and a description that has no padding, whereas the other sections use `flex flex-col` with a `py-1.5` description. This makes both its label→description and description→input gaps look off relative to its neighbors.
- The gap between a section's description and its control is uneven across sections — `mt-2` on the query‑refusal textarea, nothing on the temperature input, and the `mb-4` wrapper on chat history.

This aligns the sections onto the spacing pattern the majority already use (LLM selection, query refusal, temperature): a `py-1.5` description under the label and an `mt-2` gap before the control. The result is a consistent `label → description → input` rhythm within each section, while the existing `gap-y-6` between sections is left untouched.

Only Tailwind `className` strings change — no logic or behavior is affected.

Files:
- `ChatHistorySettings/index.jsx` — heading brought in line with the shared pattern, `mt-2` on the input.
- `ChatTemperatureSettings/index.jsx` — `mt-2` on the input so its description→input gap matches the others.
- `WorkspaceLLMSelection/index.jsx` — `mt-2` on the selector so its description→control gap matches.

`ChatModeSelection` (a mode toggle whose explanation renders below the control) and `ChatPromptSettings` (the rich prompt editor) keep their layouts since they aren't a plain label/description/input, but they already use the same `py-1.5` description style.

### Visuals (if applicable)

The target rhythm is the "design spacing" reference attached to #4995 (small label→description gap, consistent description→input gap, larger gap between sections). After this change the chat-history, query-refusal, temperature and LLM-selection sections share the same internal spacing instead of each using its own.

### Additional Information

The spacing tokens used here (`input-label`, `py-1.5` description, `mt-2`) are the ones already used by the other sections in this folder, so this normalizes toward the existing convention rather than introducing new values.

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

Notes on validation: the three changed files pass the repo's Prettier config (`prettier --check`). I confirmed the resulting spacing by reproducing the affected components with their resolved Tailwind values side by side (before/after) and checking that the four sections line up on the same rhythm. I did not run the full root `yarn lint` (eslint over the whole `src`) or a Docker build for this className-only change.
