### PR TITLE
fix: API update-embeddings fails with Prisma "filename is missing" on Windows paths

### DIFF
--- a/server/jobs/embedding-worker.js
+++ b/server/jobs/embedding-worker.js
@@ -90,7 +90,7 @@ async function processQueue() {
     const { pageContent: _pageContent, ...metadata } = data;
     const newDoc = {
       docId,
-      filename: filePath.split("/")[1],
+      filename: filePath.split(/[/\\]/).pop(),
       docpath: filePath,
       workspaceId,
       metadata: JSON.stringify(metadata),

--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -120,7 +120,7 @@ const Document = {
       const { pageContent: _pageContent, ...metadata } = data;
       const newDoc = {
         docId,
-        filename: path.split("/")[1],
+        filename: path.split(/[/\\]/).pop(),
         docpath: path,
         workspaceId: workspace.id,
         metadata: JSON.stringify(metadata),


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5901 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- The API update-embeddings path derived the document filename with `path.split("/")[1]`, which returns `undefined` when the incoming path uses Windows-style backslash separators
- This caused `workspace_documents.create()` to throw "Argument `filename` is missing", so the document vectorized but was never associated to the workspace
- Now splits on both forward and backward slashes and takes the final segment, so the filename resolves correctly regardless of separator
- Verified against the real database: the old derivation reproduces the exact Prisma error from the issue, the new derivation creates the record successfully (wrote test script to repro issue and confirmed the fix resolves the bug)

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
