### PR TITLE
fix: repair unescaped LaTeX/path backslashes in LLM tool-call JSON

### DIFF
--- a/server/__tests__/utils/http/repairJsonEscapes.test.js
+++ b/server/__tests__/utils/http/repairJsonEscapes.test.js
@@ -56,6 +56,34 @@ describe("repairJsonEscapes", () => {
     expect(parse(raw).content).toBe("# Title\n\nBody line\twith tab\r\n");
   });
 
+  // --- Documented, intentional trade-offs (pinned so they aren't "fixed" by
+  //     accident) -----------------------------------------------------------
+
+  // LaTeX Greek that collides with a whitespace escape (\nu, \tau, \rho) still
+  // decodes to a newline/tab/CR, because models overwhelmingly use \n/\r/\t for
+  // real markdown. This mangles the text but, unlike \f/\b, stays XML-legal so
+  // it never corrupts a generated document. See repairJsonEscapes JSDoc.
+  test("treats LaTeX \\nu/\\tau/\\rho as their whitespace escape (XML-legal)", () => {
+    expect(parse(String.raw`{"content":"$\nu$"}`).content).toBe("$\nu$");
+    expect(parse(String.raw`{"content":"$\tau$"}`).content).toBe("$\tau$");
+    expect(parse(String.raw`{"content":"$\rho$"}`).content).toBe("$\rho$");
+    // The whole point of the trade-off: no XML-illegal control char is emitted.
+    expect(parse(String.raw`{"content":"$\nu$"}`).content).not.toMatch(
+      ILLEGAL_XML_CONTROL
+    );
+  });
+
+  // A *well-formed* \uXXXX is a valid JSON escape, so repair preserves it even
+  // when it decodes to an XML-illegal control char (e.g. a \\u000c -> form feed).
+  // Removing those is the job of the downstream stripInvalidXmlChars guard
+  // (issue #5760), not this repair pass — they are defense-in-depth.
+  test("preserves a well-formed \\u00XX control escape (downstream strips it)", () => {
+    const raw = '{"content":"a\\u000cb"}';
+    const out = parse(raw).content;
+    expect(out.charCodeAt(1)).toBe(0x0c); // the form feed survives the parse
+    expect(out).toMatch(ILLEGAL_XML_CONTROL); // repair does NOT sanitize XML
+  });
+
   test("leaves already-escaped backslashes untouched", () => {
     const raw = String.raw`{"path":"C:\\Users\\me\\file.txt"}`;
     expect(parse(raw).path).toBe("C:\\Users\\me\\file.txt");

--- a/server/__tests__/utils/http/repairJsonEscapes.test.js
+++ b/server/__tests__/utils/http/repairJsonEscapes.test.js
@@ -1,0 +1,100 @@
+/* eslint-env jest */
+const { repairJsonEscapes, safeJsonParse } = require("../../../utils/http");
+
+/**
+ * Regression coverage for issue #5883: LLM tool calls emit LaTeX (and Windows
+ * paths) with unescaped backslashes inside JSON string values. Standard
+ * JSON.parse either decodes them into XML-illegal control characters (`\f`,
+ * `\b`) — which corrupts generated .docx/.xlsx/.pptx files and drops the
+ * consumed letter — or throws on an invalid escape (`\alpha`), dropping the
+ * whole tool call. repairJsonEscapes fixes the raw string before it is parsed.
+ *
+ * Note: every control character in this file is written as a visible escape
+ * (`\f`, `\x00`, etc.) — never as a literal byte — so the assertions stay
+ * readable and cannot be silently altered by an editor/formatter.
+ */
+describe("repairJsonEscapes", () => {
+  const parse = (raw) => safeJsonParse(raw, null, { repairLLMEscapes: true });
+
+  // The XML-illegal C0 control characters (everything below 0x20 except the
+  // three legal whitespace chars tab/LF/CR). Used to assert clean output.
+  // eslint-disable-next-line no-control-regex
+  const ILLEGAL_XML_CONTROL = /[\x00-\x08\x0B\x0C\x0E-\x1F]/;
+
+  test("preserves LaTeX \\frac (a plain parse corrupts it into a form feed)", () => {
+    const raw = String.raw`{"content":"$\frac{3}{5}$"}`;
+
+    // Baseline (the bug): a plain JSON.parse reads `\f` as a form feed (U+000C)
+    // and consumes the 'f', leaving an illegal control char + "rac".
+    const naive = JSON.parse(raw).content;
+    expect(naive.charCodeAt(1)).toBe(0x0c); // 2nd char is a form feed, not "\"
+    expect(naive).not.toContain("frac"); // the 'f' is gone -> "rac"
+    expect(naive).toMatch(ILLEGAL_XML_CONTROL);
+
+    // With repair: the literal backslash survives and no control char appears.
+    const fixed = parse(raw).content;
+    expect(fixed).toBe("$\\frac{3}{5}$");
+    expect(fixed).not.toMatch(ILLEGAL_XML_CONTROL);
+  });
+
+  test("preserves LaTeX \\binom (a plain parse corrupts it into a backspace)", () => {
+    const raw = String.raw`{"content":"$\binom{n}{k}$"}`;
+    expect(JSON.parse(raw).content.charCodeAt(1)).toBe(0x08); // backspace
+    expect(parse(raw).content).toBe("$\\binom{n}{k}$");
+    expect(parse(raw).content).not.toMatch(ILLEGAL_XML_CONTROL);
+  });
+
+  test("recovers tool calls that would otherwise fail to parse (\\alpha, \\gamma)", () => {
+    const raw = String.raw`{"content":"$\alpha + \gamma = \sqrt{2}\cdot\pi$"}`;
+    // Invalid JSON escapes make a plain parse throw -> the whole call is dropped.
+    expect(() => JSON.parse(raw)).toThrow();
+    expect(parse(raw).content).toBe("$\\alpha + \\gamma = \\sqrt{2}\\cdot\\pi$");
+  });
+
+  test("keeps intended whitespace escapes (\\n, \\r, \\t)", () => {
+    const raw = String.raw`{"content":"# Title\n\nBody line\twith tab\r\n"}`;
+    expect(parse(raw).content).toBe("# Title\n\nBody line\twith tab\r\n");
+  });
+
+  test("leaves already-escaped backslashes untouched", () => {
+    const raw = String.raw`{"path":"C:\\Users\\me\\file.txt"}`;
+    expect(parse(raw).path).toBe("C:\\Users\\me\\file.txt");
+  });
+
+  test("preserves a well-formed \\uXXXX escape", () => {
+    const raw = String.raw`{"content":"snowman ☃ here"}`;
+    expect(parse(raw).content).toBe("snowman ☃ here");
+  });
+
+  test("treats a malformed \\u (LaTeX \\underline) as a literal backslash", () => {
+    const raw = String.raw`{"content":"$\underline{x}$"}`;
+    expect(parse(raw).content).toBe("$\\underline{x}$");
+  });
+
+  test("handles escaped quotes inside the string without losing parser state", () => {
+    const raw = String.raw`{"content":"she said \"hi\" then \beta"}`;
+    expect(parse(raw).content).toBe('she said "hi" then \\beta');
+  });
+
+  test("does not touch backslashes outside string literals / clean JSON", () => {
+    const raw = `{"a":1,"b":"plain","c":[true,null]}`;
+    expect(repairJsonEscapes(raw)).toBe(raw); // byte-for-byte unchanged
+    expect(parse(raw)).toEqual({ a: 1, b: "plain", c: [true, null] });
+  });
+
+  test("is a no-op for strings without backslashes and for non-strings", () => {
+    expect(repairJsonEscapes('{"a":"no backslashes"}')).toBe(
+      '{"a":"no backslashes"}'
+    );
+    expect(repairJsonEscapes(null)).toBe(null);
+    expect(repairJsonEscapes(42)).toBe(42);
+  });
+
+  test("safeJsonParse leaves escapes alone when the flag is not set (default)", () => {
+    const raw = String.raw`{"content":"$\frac{1}{2}$"}`;
+    // Default behavior is unchanged: the form feed is still produced.
+    const out = safeJsonParse(raw).content;
+    expect(out.charCodeAt(1)).toBe(0x0c);
+    expect(out).not.toContain("frac");
+  });
+});

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -693,7 +693,8 @@ class Provider {
     if (!!result.functionCall?.arguments)
       result.functionCall.arguments = safeJsonParse(
         result.functionCall.arguments,
-        {}
+        {},
+        { repairLLMEscapes: true }
       );
 
     return {

--- a/server/utils/agents/aibitat/providers/anthropic.js
+++ b/server/utils/agents/aibitat/providers/anthropic.js
@@ -332,7 +332,8 @@ class AnthropicProvider extends Provider {
       if (result.functionCall) {
         result.functionCall.arguments = safeJsonParse(
           result.functionCall.arguments,
-          {}
+          {},
+          { repairLLMEscapes: true }
         );
         messages.push({
           role: "assistant",

--- a/server/utils/agents/aibitat/providers/gemini.js
+++ b/server/utils/agents/aibitat/providers/gemini.js
@@ -319,7 +319,8 @@ class GeminiProvider extends Provider {
       if (completion.functionCall) {
         completion.functionCall.arguments = safeJsonParse(
           completion.functionCall.arguments,
-          {}
+          {},
+          { repairLLMEscapes: true }
         );
         return {
           textResponse: completion.content,
@@ -395,7 +396,13 @@ class GeminiProvider extends Provider {
       const cost = this.getCost(response.usage);
       if (completion?.tool_calls?.length > 0) {
         const toolCall = completion.tool_calls[0];
-        let functionArgs = safeJsonParse(toolCall.function.arguments, {});
+        let functionArgs = safeJsonParse(
+          toolCall.function.arguments,
+          {},
+          {
+            repairLLMEscapes: true,
+          }
+        );
         return {
           textResponse: null,
           functionCall: {

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -272,7 +272,13 @@ async function tooledStream(
     result.functionCall = {
       id: firstToolCall.id,
       name: firstToolCall.name,
-      arguments: safeJsonParse(firstToolCall.arguments, {}),
+      arguments: safeJsonParse(
+        firstToolCall.arguments,
+        {},
+        {
+          repairLLMEscapes: true,
+        }
+      ),
     };
   }
 
@@ -337,7 +343,9 @@ async function tooledComplete(
 
   if (completion.tool_calls && completion.tool_calls.length > 0) {
     const toolCall = completion.tool_calls[0];
-    const functionArgs = safeJsonParse(toolCall.function.arguments, null);
+    const functionArgs = safeJsonParse(toolCall.function.arguments, null, {
+      repairLLMEscapes: true,
+    });
 
     if (functionArgs === null) {
       return {

--- a/server/utils/agents/aibitat/providers/helpers/untooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/untooled.js
@@ -157,7 +157,7 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
     const historyMessages = this.buildToolCallMessages(history, functions);
     const response = await chatCb({ messages: historyMessages });
 
-    const call = safeJsonParse(response, null);
+    const call = safeJsonParse(response, null, { repairLLMEscapes: true });
     if (call === null) return { toolCall: null, text: response }; // failed to parse, so must be text.
 
     const { valid, reason } = this.validFuncCall(call, functions);
@@ -214,7 +214,7 @@ ${JSON.stringify(def.parameters.properties, null, 4)}\n`;
       }
     }
 
-    const call = safeJsonParse(textResponse, null);
+    const call = safeJsonParse(textResponse, null, { repairLLMEscapes: true });
     if (call === null)
       return { toolCall: null, text: textResponse, uuid: msgUUID }; // failed to parse, so must be regular text response.
 

--- a/server/utils/agents/aibitat/providers/ollama.js
+++ b/server/utils/agents/aibitat/providers/ollama.js
@@ -245,7 +245,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       });
     }
 
-    const call = safeJsonParse(textResponse, null);
+    const call = safeJsonParse(textResponse, null, { repairLLMEscapes: true });
     if (call === null)
       return { toolCall: null, text: textResponse, uuid: msgUUID }; // failed to parse, so must be regular text response.
 
@@ -353,7 +353,13 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
         const toolCall = toolCalls[0];
         const args =
           typeof toolCall.function.arguments === "string"
-            ? safeJsonParse(toolCall.function.arguments, {})
+            ? safeJsonParse(
+                toolCall.function.arguments,
+                {},
+                {
+                  repairLLMEscapes: true,
+                }
+              )
             : toolCall.function.arguments || {};
 
         return {
@@ -521,7 +527,13 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
         const toolCall = response.message.tool_calls[0];
         const args =
           typeof toolCall.function.arguments === "string"
-            ? safeJsonParse(toolCall.function.arguments, {})
+            ? safeJsonParse(
+                toolCall.function.arguments,
+                {},
+                {
+                  repairLLMEscapes: true,
+                }
+              )
             : toolCall.function.arguments || {};
 
         return {

--- a/server/utils/agents/aibitat/providers/openai.js
+++ b/server/utils/agents/aibitat/providers/openai.js
@@ -215,7 +215,8 @@ class OpenAIProvider extends Provider {
       if (completion.functionCall) {
         completion.functionCall.arguments = safeJsonParse(
           completion.functionCall.arguments,
-          {}
+          {},
+          { repairLLMEscapes: true }
         );
         return {
           textResponse: completion.content,
@@ -299,7 +300,8 @@ class OpenAIProvider extends Provider {
       if (completion.functionCall) {
         completion.functionCall.arguments = safeJsonParse(
           completion.functionCall.arguments,
-          {}
+          {},
+          { repairLLMEscapes: true }
         );
         return {
           textResponse: completion.content,

--- a/server/utils/http/index.js
+++ b/server/utils/http/index.js
@@ -75,8 +75,107 @@ function parseAuthHeader(headerValue = null, apiKey = null) {
   return { [headerValue]: apiKey };
 }
 
-function safeJsonParse(jsonString, fallback = null) {
+/**
+ * Repairs improperly-escaped backslash sequences in a raw JSON string emitted
+ * by an LLM tool call, BEFORE it is parsed.
+ *
+ * LLMs routinely write LaTeX (and Windows paths) inside JSON string values
+ * without escaping the backslash — e.g. `"$\frac{1}{2}$"` instead of the valid
+ * `"$\\frac{1}{2}$"`. Standard JSON.parse then either:
+ *   - silently decodes the escape into a control character — `\f` -> U+000C
+ *     (form feed), `\b` -> U+0008 — which both consumes the following letter
+ *     (so `\frac` becomes `rac`) and embeds a character that is illegal in
+ *     XML 1.0, making the generated .docx/.xlsx/.pptx unopenable; or
+ *   - throws on an invalid escape (`\a` in `\alpha`, `\g` in `\gamma`, ...),
+ *     causing safeJsonParse to fall back and the whole tool call to be dropped.
+ *
+ * This walks the string and, only inside JSON string literals, rewrites any
+ * backslash that is NOT a safe/intended escape into a literal backslash (`\\`)
+ * so the original text survives the parse. Intentional escapes are preserved
+ * untouched: `\" \\ \/ \n \r \t` and a well-formed `\uXXXX`. `\f` and `\b` are
+ * treated as literal because a model that emits them almost always means LaTeX
+ * (`\frac`, `\beta`), not a control character.
+ *
+ * Note: `\n`, `\r`, `\t` are kept as whitespace because models overwhelmingly
+ * use them for real markdown newlines/tabs; the rare LaTeX collision (`\nu`,
+ * `\tau`, `\rho`) is an accepted trade-off and, unlike `\f`/`\b`, decodes to a
+ * character that is legal in XML so it never corrupts a generated document.
+ * @param {string} input - Raw JSON string from an LLM tool call.
+ * @returns {string} The same JSON with unsafe backslash escapes made literal.
+ */
+function repairJsonEscapes(input) {
+  if (typeof input !== "string" || !input.includes("\\")) return input;
+
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (ch !== "\\") {
+      if (ch === '"') inString = !inString;
+      out += ch;
+      continue;
+    }
+
+    // A backslash outside a string literal cannot start an escape in JSON —
+    // leave it for the parser/jsonrepair to handle.
+    if (!inString) {
+      out += ch;
+      continue;
+    }
+
+    const next = input[i + 1];
+
+    // Preserve intended escapes verbatim. Consuming `next` here also means an
+    // escaped quote (`\"`) does not flip the in-string state below.
+    if (
+      next === '"' ||
+      next === "\\" ||
+      next === "/" ||
+      next === "n" ||
+      next === "r" ||
+      next === "t"
+    ) {
+      out += ch + next;
+      i++;
+      continue;
+    }
+
+    // `\uXXXX` is only a valid escape with four hex digits; otherwise the
+    // backslash is literal (e.g. LaTeX `\underline`, `\unit`).
+    if (next === "u" && /^[0-9a-fA-F]{4}$/.test(input.slice(i + 2, i + 6))) {
+      out += input.slice(i, i + 6);
+      i += 5;
+      continue;
+    }
+
+    // Everything else (`\f` `\b` `\v` `\a` `\g` `\u`-non-hex, a trailing
+    // backslash, ...) is a literal backslash the model meant to keep.
+    out += "\\\\";
+    if (next !== undefined) {
+      out += next;
+      i++;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * @param {string|null} jsonString - The JSON string to parse.
+ * @param {*} fallback - Returned if the string cannot be parsed.
+ * @param {{repairLLMEscapes?: boolean}} [options] - When `repairLLMEscapes` is
+ * true the raw string is first run through {@link repairJsonEscapes} to recover
+ * unescaped LaTeX/path backslashes emitted by LLM tool calls. Off by default so
+ * behavior is unchanged for all existing (non tool-call) callers.
+ */
+function safeJsonParse(
+  jsonString,
+  fallback = null,
+  { repairLLMEscapes = false } = {}
+) {
   if (jsonString === null) return fallback;
+  if (repairLLMEscapes) jsonString = repairJsonEscapes(jsonString);
 
   try {
     return JSON.parse(jsonString);
@@ -135,6 +234,7 @@ module.exports = {
   userFromSession,
   parseAuthHeader,
   safeJsonParse,
+  repairJsonEscapes,
   isValidUrl,
   toValidNumber,
   decodeHtmlEntities,


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5883
connect #5756
connect #5760

### Description

**Problem:** LLMs write LaTeX inside tool-call JSON without escaping the backslash, e.g. `"$\frac{3}{5}$"`. When we `JSON.parse` that:

- `\f` becomes a form feed, which eats the `f` (`\frac` → `rac`) and is illegal in XML, so the generated `.docx`/`.xlsx`/`.pptx` won't open in Office.
- Invalid escapes like `\alpha` throw, so the whole tool call is dropped.

#5760 only stripped the bad characters from the finished file (a symptom fix) — the text was still wrong and dropped tool calls weren't addressed. The real problem is at parse time.

**Fix:** A new `repairJsonEscapes()` helper fixes unescaped backslashes *before* parsing, so the original text survives. It's enabled via `safeJsonParse(str, fallback, { repairLLMEscapes: true })`, which is **off by default** (existing callers unchanged) and turned on only where tool-call arguments are parsed, across all providers.

It keeps real escapes (`\n \r \t \" \\ \uXXXX`) and treats LaTeX-style backslashes (`\frac`, `\alpha`, etc.) as literal text. This works alongside #5760's strip as a safety net.

### Visuals (if applicable)

N/A

### Additional Information

A fractions-quiz `.docx` request now opens correctly and keeps `\frac`/`\binom`/`\alpha` intact, instead of producing a corrupt file.

Tests: `server/__tests__/utils/http/repairJsonEscapes.test.js` (13 cases).

```sh
# from server/
npx jest __tests__/utils/http/repairJsonEscapes.test.js
```

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
