### PR TITLE
fix: disable temperature for claude-sonnet-5 model

### DIFF
--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -20,6 +20,7 @@ class AnthropicLLM {
   noTemperatureModels = [
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-sonnet-5",
     // Add other models here if identified
   ];
 

--- a/server/utils/AiProviders/bedrock/index.js
+++ b/server/utils/AiProviders/bedrock/index.js
@@ -28,6 +28,7 @@ class AWSBedrockLLM {
   noTemperatureModels = [
     "anthropic.claude-opus-4-7",
     "anthropic.claude-opus-4-8",
+    "anthropic.claude-sonnet-5",
     // Add other models here if identified
   ];
 


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->
Added `claude-sonnet-5` (and its AWS Bedrock equivalent `anthropic.claude-sonnet-5`) to the `noTemperatureModels` list in both the Anthropic and AWS Bedrock AI providers.

Certain Anthropic models strictly reject inference parameters like `temperature`, returning a 400 error if provided. This change ensures that we gracefully strip the `temperature` parameter when a user selects the `claude-sonnet-5` model, preventing API request failures in both direct Anthropic and AWS Bedrock integrations.

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->
*(Not applicable)*

### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->
Files modified:
- `server/utils/AiProviders/anthropic/index.js`
- `server/utils/AiProviders/bedrock/index.js`

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally