### PR TITLE
fix: throw on Anthropic getChatCompletion errors instead of returning the raw Error

### DIFF
--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -240,8 +240,10 @@ class AnthropicLLM {
         },
       };
     } catch (error) {
-      console.log(error);
-      return { textResponse: error, metrics: {} };
+      console.error(error);
+      throw new Error(
+        `AnthropicLLM::getChatCompletion failed to communicate with Anthropic. ${error.message}`
+      );
     }
   }
 


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5924

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- `AnthropicLLM.getChatCompletion` previously swallowed failures with `return { textResponse: error }`, returning the raw `Error` object as the response text
- This masked the real failure downstream: it serialized to an empty `{}` on the REST API chat path (#5925) and crashed string consumers with `s.includes is not a function` in the Meeting Assistant summary path (#5924)
- The underlying error being thrown was the Anthropic SDK's non-streaming timeout guard (`_calculateNonstreamingTimeout`) - the SDK throws for non-streaming requests whose `max_tokens` implies a possible response longer than 10 minutes, which is the case for recent Claude models with large max output (opus/sonnet 4.x report 64k-128k)
- Changed the catch to `throw` a real error message, matching the `openAi`/`genericOpenAi`/`gemini` providers, so every caller's existing error handling surfaces the actual message instead of a broken empty/Error-object response
- The streaming fix that avoids the 10-minute timeout guard itself is handled separately in #5941

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
