### PR TITLE
feat: add real-time token estimator to prompt input UI

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -385,6 +385,11 @@ export default function PromptInput({
                     textareaRef={textareaRef}
                     autoOpenedToolsRef={autoOpenedToolsRef}
                   />
+                  {promptInput.length > 0 && (
+                    <span className="text-xs text-zinc-500 light:text-slate-400 ml-2 select-none hidden sm:block">
+                      ~{Math.ceil(promptInput.length / 4)} tokens
+                    </span>
+                  )}
                 </div>
                 <div className="flex gap-x-2 items-center">
                   <SpeechToText sendCommand={sendCommand} />


### PR DESCRIPTION
# Pull Request Description: Live Token Estimator

*Note: When you are ready to submit your code to GitHub, copy and paste everything below this line into the GitHub Pull Request description box. This is written specifically so the project maintainers ("other people") understand exactly why you built this and what files you changed.*

---

## 🚀 What does this PR do?
This PR introduces a **Live Token Estimator** into the chat interface (`PromptInput`). 

Often, users send extremely large prompts without realizing how many tokens they are consuming, leading to high API costs or unexpected context-limit errors. This PR adds a non-intrusive, real-time UI indicator in the chat box that estimates the token count of the current prompt before the user hits send.

## 💻 Technical Implementation
- **Targeted File:** `frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx`
- **Performance:** To prevent bloating the frontend bundle with heavy tokenization libraries like `tiktoken`, this feature relies on the standard `Math.ceil(chars / 4)` heuristic. This provides a fast, accurate-enough UI estimation without impacting client-side performance.
- **UI/UX:** 
  - The token count is injected next to the `ToolsButton`.
  - It utilizes conditional rendering (`promptInput.length > 0`) to remain hidden when the chat box is empty.
  - Styled with native Tailwind classes (`text-xs text-zinc-500 hidden sm:block`) to seamlessly blend with the existing dark/light mode aesthetic and hide on small mobile viewports to prevent UI clutter.

## 📸 Before and After
*Before:*
The chat input box only showed the text, with no indication of prompt size.

*After:*
As the user types, a subtle `~15 tokens` indicator dynamically updates in the bottom toolbar of the input box.

## 🔬 How to Test
1. Start the frontend development server.
2. Open any workspace chat.
3. Begin typing in the prompt input field.
4. Observe the token estimator appear and dynamically update in the bottom right corner of the input box.
5. Clear the input field and verify the estimator disappears.
