### PR TITLE
feat: add Z.AI coding plan LLM provider (zaiCode)

### DIFF
--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -381,6 +381,14 @@ export const AVAILABLE_LLM_PROVIDERS = [
     description: "Run Z.AI's powerful GLM models.",
     requiredConfig: ["ZAiApiKey"],
   },
+    {
+    name: "Z.AICode",
+    value: "zaiCode",
+    logo: ZAiLogo,
+    options: (settings) => <ZAiLLMOptions settings={settings} />,
+    description: "Run Z.AI's powerful GLM models.",
+    requiredConfig: ["ZAiApiKey"],
+  },
   {
     name: "GiteeAI",
     value: "giteeai",

--- a/frontend/src/pages/OnboardingFlow/Steps/LLMPreference/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/LLMPreference/index.jsx
@@ -299,6 +299,13 @@ const LLMS = [
     options: (settings) => <ZAiLLMOptions settings={settings} />,
     description: "Run Z.AI's powerful GLM models.",
   },
+ {
+    name: "Z.AICode",
+    value: "zaiCode",
+    logo: ZAiLogo,
+    options: (settings) => <ZAiLLMOptions settings={settings} />,
+    description: "Run Z.AI's powerful GLM models.",
+  },
   {
     name: "Moonshot AI",
     value: "moonshotai",

--- a/server/endpoints/utils.js
+++ b/server/endpoints/utils.js
@@ -216,6 +216,9 @@ function getModelTag() {
     case "zai":
       model = process.env.ZAI_MODEL_PREF;
       break;
+    case "zaiCode":
+      model = process.env.ZAI_MODEL_PREF;
+      break;
     case "giteeai":
       model = process.env.GITEE_AI_MODEL_PREF;
       break;

--- a/server/utils/AiProviders/zaiCode/index.js
+++ b/server/utils/AiProviders/zaiCode/index.js
@@ -1,0 +1,184 @@
+const { NativeEmbedder } = require("../../EmbeddingEngines/native");
+const {
+  LLMPerformanceMonitor,
+} = require("../../helpers/chat/LLMPerformanceMonitor");
+const {
+  handleDefaultStreamResponseV2,
+} = require("../../helpers/chat/responses");
+const { MODEL_MAP } = require("../modelMap");
+
+class ZAiCodeLLM {
+  constructor(embedder = null, modelPreference = null) {
+    if (!process.env.ZAI_API_KEY) throw new Error("No Z.AI API key was set.");
+    this.className = "ZAiCodeLLM";
+    const { OpenAI: OpenAIApi } = require("openai");
+
+    this.openai = new OpenAIApi({
+      baseURL: "https://api.z.ai/api/coding/paas/v4",
+      apiKey: process.env.ZAI_API_KEY,
+    });
+    this.model = modelPreference || process.env.ZAI_MODEL_PREF || "glm-4.5";
+    this.limits = {
+      history: this.promptWindowLimit() * 0.15,
+      system: this.promptWindowLimit() * 0.15,
+      user: this.promptWindowLimit() * 0.7,
+    };
+
+    this.embedder = embedder ?? new NativeEmbedder();
+    this.defaultTemp = 0.7;
+    this.log(
+      `Initialized ${this.model} with context window ${this.promptWindowLimit()}`
+    );
+  }
+
+  log(text, ...args) {
+    console.log(`\x1b[36m[${this.className}]\x1b[0m ${text}`, ...args);
+  }
+
+  #appendContext(contextTexts = []) {
+    if (!contextTexts || !contextTexts.length) return "";
+    return (
+      "\nContext:\n" +
+      contextTexts
+        .map((text, i) => {
+          return `[CONTEXT ${i}]:\n${text}\n[END CONTEXT ${i}]\n\n`;
+        })
+        .join("")
+    );
+  }
+
+  streamingEnabled() {
+    return "streamGetChatCompletion" in this;
+  }
+
+  static promptWindowLimit(modelName) {
+    return MODEL_MAP.get("zai", modelName) ?? 131072;
+  }
+
+  promptWindowLimit() {
+    return MODEL_MAP.get("zai", this.model) ?? 131072;
+  }
+
+  async isValidChatCompletionModel(modelName = "") {
+    return !!modelName; // name just needs to exist
+  }
+
+  /**
+   * Generates appropriate content array for a message + attachments.
+   * @param {{userPrompt:string, attachments: import("../../helpers").Attachment[]}}
+   * @returns {string|object[]}
+   */
+  #generateContent({ userPrompt, attachments = [] }) {
+    if (!attachments.length) return userPrompt;
+
+    const content = [{ type: "text", text: userPrompt }];
+    for (let attachment of attachments) {
+      content.push({
+        type: "image_url",
+        image_url: {
+          url: attachment.contentString,
+        },
+      });
+    }
+    return content.flat();
+  }
+
+  /**
+   * Construct the user prompt for this model.
+   * @param {{attachments: import("../../helpers").Attachment[]}} param0
+   * @returns
+   */
+  constructPrompt({
+    systemPrompt = "",
+    contextTexts = [],
+    chatHistory = [],
+    userPrompt = "",
+    attachments = [],
+  }) {
+    const prompt = {
+      role: "system",
+      content: `${systemPrompt}${this.#appendContext(contextTexts)}`,
+    };
+    return [
+      prompt,
+      ...chatHistory,
+      {
+        role: "user",
+        content: this.#generateContent({ userPrompt, attachments }),
+      },
+    ];
+  }
+
+  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+    const result = await LLMPerformanceMonitor.measureAsyncFunction(
+      this.openai.chat.completions
+        .create({
+          model: this.model,
+          messages,
+          temperature,
+        })
+        .catch((e) => {
+          throw new Error(e.message);
+        })
+    );
+
+    if (
+      !result.output.hasOwnProperty("choices") ||
+      result.output.choices.length === 0
+    )
+      return null;
+
+    return {
+      textResponse: result.output.choices[0].message.content,
+      metrics: {
+        prompt_tokens: result.output.usage?.prompt_tokens || 0,
+        completion_tokens: result.output.usage?.completion_tokens || 0,
+        total_tokens: result.output.usage?.total_tokens || 0,
+        outputTps: result.output.usage?.completion_tokens / result.duration,
+        duration: result.duration,
+        model: this.model,
+        provider: this.className,
+        timestamp: new Date(),
+      },
+    };
+  }
+
+  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+    const measuredStreamRequest = await LLMPerformanceMonitor.measureStream({
+      func: this.openai.chat.completions.create({
+        model: this.model,
+        stream: true,
+        messages,
+        temperature,
+      }),
+      messages,
+      runPromptTokenCalculation: false,
+      modelTag: this.model,
+      provider: this.className,
+    });
+
+    return measuredStreamRequest;
+  }
+
+  handleStream(response, stream, responseProps) {
+    return handleDefaultStreamResponseV2(response, stream, responseProps);
+  }
+
+  // Simple wrapper for dynamic embedder & normalize interface for all LLM implementations
+  async embedTextInput(textInput) {
+    return await this.embedder.embedTextInput(textInput);
+  }
+  async embedChunks(textChunks = []) {
+    return await this.embedder.embedChunks(textChunks);
+  }
+
+  async compressMessages(promptArgs = {}, rawHistory = []) {
+    const { messageArrayCompressor } = require("../../helpers/chat");
+    const messageArray = this.constructPrompt(promptArgs);
+    return await messageArrayCompressor(this, messageArray, rawHistory);
+  }
+}
+
+module.exports = {
+  ZAiCodeLLM,
+};

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -1412,6 +1412,8 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
         return new Providers.XAIProvider({ model: config.model });
       case "zai":
         return new Providers.ZAIProvider({ model: config.model });
+      case "zaiCode":
+        return new Providers.ZAICodeProvider({ model: config.model });
       case "novita":
         return new Providers.NovitaProvider({ model: config.model });
       case "ppio":

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -284,6 +284,14 @@ class Provider {
           apiKey: process.env.ZAI_API_KEY ?? null,
           ...config,
         });
+      case "zaiCode":
+        return new ChatOpenAI({
+          configuration: {
+            baseURL: "https://api.z.ai/api/coding/paas/v4",
+          },
+          apiKey: process.env.ZAI_API_KEY ?? null,
+          ...config,
+        }); 
       case "novita":
         return new ChatOpenAI({
           configuration: {

--- a/server/utils/agents/aibitat/providers/index.js
+++ b/server/utils/agents/aibitat/providers/index.js
@@ -19,6 +19,7 @@ const LiteLLMProvider = require("./litellm.js");
 const ApiPieProvider = require("./apipie.js");
 const XAIProvider = require("./xai.js");
 const ZAIProvider = require("./zai.js");
+const ZAICodeProvider = require("./zaiCode.js");
 const NovitaProvider = require("./novita.js");
 const NvidiaNimProvider = require("./nvidiaNim.js");
 const PPIOProvider = require("./ppio.js");
@@ -57,6 +58,7 @@ module.exports = {
   ApiPieProvider,
   XAIProvider,
   ZAIProvider,
+  ZAICodeProvider,
   NovitaProvider,
   CometApiProvider,
   NvidiaNimProvider,

--- a/server/utils/agents/aibitat/providers/zaiCode.js
+++ b/server/utils/agents/aibitat/providers/zaiCode.js
@@ -1,0 +1,144 @@
+const OpenAI = require("openai");
+const Provider = require("./ai-provider.js");
+const InheritMultiple = require("./helpers/classes.js");
+const UnTooled = require("./helpers/untooled.js");
+const { tooledStream, tooledComplete } = require("./helpers/tooled.js");
+const { RetryError } = require("../error.js");
+
+class ZAICodeProvider extends InheritMultiple([Provider, UnTooled]) {
+  model;
+
+  constructor(config = {}) {
+    const { model = "glm-5.1" } = config;
+    super();
+    this.providerTag = "zaiCode"
+    const client = new OpenAI({
+      baseURL: "https://api.z.ai/api/coding/paas/v4",
+      apiKey: process.env.ZAI_API_KEY,
+    });
+
+    this._client = client;
+    this.model = model;
+    this.verbose = true;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  get supportsAgentStreaming() {
+    return true;
+  }
+
+  async #handleFunctionCallChat({ messages = [] }) {
+    return await this.client.chat.completions
+      .create({
+        model: this.model,
+        messages,
+      })
+      .then((result) => {
+        if (!result.hasOwnProperty("choices"))
+          throw new Error("Z.AI chat: No results!");
+        if (result.choices.length === 0)
+          throw new Error("Z.AI chat: No results length!");
+        return result.choices[0].message.content;
+      })
+      .catch((_) => {
+        return null;
+      });
+  }
+
+  async #handleFunctionCallStream({ messages = [] }) {
+    return await this.client.chat.completions.create({
+      model: this.model,
+      stream: true,
+      messages,
+    });
+  }
+
+  async stream(messages, functions = [], eventHandler = null) {
+    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+
+    if (!useNative) {
+      return await UnTooled.prototype.stream.call(
+        this,
+        messages,
+        functions,
+        this.#handleFunctionCallStream.bind(this),
+        eventHandler
+      );
+    }
+
+    this.providerLog(
+      "Provider.stream (tooled) - will process this chat completion."
+    );
+
+    try {
+      return await tooledStream(
+        this.client,
+        this.model,
+        messages,
+        functions,
+        eventHandler,
+        { provider: this }
+      );
+    } catch (error) {
+      console.error(error.message, error);
+      if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (
+        error instanceof OpenAI.RateLimitError ||
+        error instanceof OpenAI.InternalServerError ||
+        error instanceof OpenAI.APIError
+      ) {
+        throw new RetryError(error.message);
+      }
+      throw error;
+    }
+  }
+
+  async complete(messages, functions = []) {
+    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+
+    if (!useNative) {
+      return await UnTooled.prototype.complete.call(
+        this,
+        messages,
+        functions,
+        this.#handleFunctionCallChat.bind(this)
+      );
+    }
+
+    try {
+      const result = await tooledComplete(
+        this.client,
+        this.model,
+        messages,
+        functions,
+        this.getCost.bind(this),
+        { provider: this }
+      );
+
+      if (result.retryWithError) {
+        return this.complete([...messages, result.retryWithError], functions);
+      }
+
+      return result;
+    } catch (error) {
+      if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (
+        error instanceof OpenAI.RateLimitError ||
+        error instanceof OpenAI.InternalServerError ||
+        error instanceof OpenAI.APIError
+      ) {
+        throw new RetryError(error.message);
+      }
+      throw error;
+    }
+  }
+
+  getCost(_usage) {
+    return 0;
+  }
+}
+
+module.exports = ZAICodeProvider;

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -209,6 +209,10 @@ class AgentHandler {
         if (!process.env.ZAI_API_KEY)
           throw new Error("Z.AI API Key must be provided to use agents.");
         break;
+      case "zaiCode":
+        if (!process.env.ZAI_API_KEY)
+          throw new Error("Z.AI API Key must be provided to use agents.");
+        break;
       case "novita":
         if (!process.env.NOVITA_LLM_API_KEY)
           throw new Error("Novita API Key must be provided to use agents.");
@@ -338,6 +342,8 @@ class AgentHandler {
       case "xai":
         return process.env.XAI_LLM_MODEL_PREF ?? "grok-beta";
       case "zai":
+        return process.env.ZAI_MODEL_PREF ?? "glm-4.5";
+      case "zaiCode":
         return process.env.ZAI_MODEL_PREF ?? "glm-4.5";
       case "novita":
         return process.env.NOVITA_LLM_MODEL_PREF ?? "deepseek/deepseek-r1";

--- a/server/utils/helpers/customModels.js
+++ b/server/utils/helpers/customModels.js
@@ -43,6 +43,7 @@ const SUPPORT_CUSTOM_MODELS = [
   "foundry",
   "cohere",
   "zai",
+  "zaiCode",
   "giteeai",
   "docker-model-runner",
   "privatemode",
@@ -130,6 +131,8 @@ async function getCustomModels(
       return await getCohereModels(apiKey, "chat");
     case "zai":
       return await getZAiModels(apiKey);
+    case "zaiCode":
+      return await getZAiCodeModels(apiKey);
     case "native-embedder":
       return await getNativeEmbedderModels();
     case "cohere-embedder":
@@ -995,6 +998,29 @@ async function getZAiModels(_apiKey = null) {
     .then((results) => results.data)
     .catch((e) => {
       console.error(`Z.AI:listModels`, e.message);
+      return [];
+    });
+
+  // Api Key was successful so lets save it for future uses
+  if (models.length > 0 && !!apiKey) process.env.ZAI_API_KEY = apiKey;
+  return { models, error: null };
+}
+
+async function getZAiCodeModels(_apiKey = null) {
+  const { OpenAI: OpenAIApi } = require("openai");
+  const apiKey =
+    _apiKey === true
+      ? process.env.ZAI_API_KEY
+      : _apiKey || process.env.ZAI_API_KEY || null;
+  const openai = new OpenAIApi({
+    baseURL: "https://api.z.ai/api/coding/paas/v4",
+    apiKey,
+  });
+  const models = await openai.models
+    .list()
+    .then((results) => results.data)
+    .catch((e) => {
+      console.error(`Z.AICode:listModels`, e.message);
       return [];
     });
 

--- a/server/utils/helpers/index.js
+++ b/server/utils/helpers/index.js
@@ -225,6 +225,9 @@ function getLLMProvider({ provider = null, model = null } = {}) {
     case "zai":
       const { ZAiLLM } = require("../AiProviders/zai");
       return new ZAiLLM(embedder, model);
+    case "zaiCode":
+      const { ZAiCodeLLM } = require("../AiProviders/zaiCode");
+      return new ZAiCodeLLM(embedder, model);
     case "giteeai":
       const { GiteeAILLM } = require("../AiProviders/giteeai");
       return new GiteeAILLM(embedder, model);
@@ -413,6 +416,9 @@ function getLLMProviderClass({ provider = null } = {}) {
     case "zai":
       const { ZAiLLM } = require("../AiProviders/zai");
       return ZAiLLM;
+    case "zaiCode":
+      const { ZAiCodeLLM } = require("../AiProviders/zaiCode");
+      return ZAiCodeLLM;
     case "giteeai":
       const { GiteeAILLM } = require("../AiProviders/giteeai");
       return GiteeAILLM;
@@ -508,6 +514,8 @@ function getBaseLLMProviderModel({ provider = null } = {}) {
     case "foundry":
       return process.env.FOUNDRY_MODEL_PREF;
     case "zai":
+      return process.env.ZAI_MODEL_PREF;
+    case "zaiCode":
       return process.env.ZAI_MODEL_PREF;
     case "giteeai":
       return process.env.GITEE_AI_MODEL_PREF;

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -1043,6 +1043,7 @@ function supportedLLM(input = "") {
     "cometapi",
     "foundry",
     "zai",
+    "zaiCode",
     "giteeai",
     "docker-model-runner",
     "privatemode",


### PR DESCRIPTION
## Summary

Adds full `zaiCode` LLM provider support, enabling users on the [Z.AI coding plan](https://z.ai/model-api) to select and use GLM models via the dedicated coding API endpoint (`https://api.z.ai/api/coding/paas/v4`).

Resolves #4960.

## Problem

The Z.AI coding plan uses a separate API endpoint (`/api/coding/paas/v4`) from the standard plan (`/api/paas/v4`). 

## Changes

**New files:**
- `server/utils/AiProviders/zaiCode/index.js` — `ZAiCodeLLM` class (main chat provider, coding baseURL)
- `server/utils/agents/aibitat/providers/zaiCode.js` — `ZAICodeProvider` class (agent/tool-calling provider)

**Server-side wiring:**
- `server/utils/helpers/index.js` — `case "zaiCode"` in `getLLMProvider`, `getLLMProviderClass`, `getBaseLLMProviderModel`
- `server/utils/helpers/updateENV.js` — added `"zaiCode"` to valid providers list
- `server/utils/helpers/customModels.js` — `getZAiCodeModels()` + provider registration
- `server/endpoints/utils.js` — model lookup case

**Agent subsystem:**
- `server/utils/agents/aibitat/index.js` — `case "zaiCode"` in `getProviderForConfig`
- `server/utils/agents/aibitat/providers/index.js` — `ZAICodeProvider` added to exports
- `server/utils/agents/aibitat/providers/ai-provider.js` — ChatOpenAI config with coding baseURL
- `server/utils/agents/index.js` — API key validation + default model

**Frontend:**
- `frontend/src/pages/GeneralSettings/LLMPreference/index.jsx` — "Z.AICode" provider option
- `frontend/src/pages/OnboardingFlow/Steps/LLMPreference/index.jsx` — "Z.AICode" provider option

## Design notes

- `zaiCode` reuses `ZAI_API_KEY` and `ZAI_MODEL_PREF` env vars (same as `zai`), matching the existing agent provider pattern. One API key, one model setting — only the endpoint differs.
- Context window lookups use the same `MODEL_MAP.get("zai", ...)` key since the GLM models are identical across both endpoints.

## Testing

- Verified on Node v22.23.1 that `getLLMProviderClass({ provider: "zaiCode" })` returns `ZAiCodeLLM`
- Verified `getProviderForConfig({ provider: "zaiCode" })` returns `ZAICodeProvider` with `baseURL: https://api.z.ai/api/coding/paas/v4`
- Confirmed `zai` provider still resolves correctly (no regression)
- Confirmed invalid providers still rejected by validation
- Server starts cleanly and workspace loads without `Unknown provider` error