### PR TITLE
Give Downloaded Models its Own `<optgroup>` in Workspace Model Selector

### DIFF
--- a/frontend/src/components/EmbeddingSelection/LemonadeOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/LemonadeOptions/index.jsx
@@ -196,6 +196,8 @@ function LemonadeModelSelection({ settings, basePath = null }) {
     findCustomModels();
   }, [basePath]);
 
+  const downloadedModels = customModels.filter((model) => model?.downloaded);
+
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
@@ -231,8 +233,21 @@ function LemonadeModelSelection({ settings, basePath = null }) {
         required={true}
         className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
       >
+        {downloadedModels.length > 0 && (
+          <optgroup label="Downloaded models">
+            {downloadedModels.map((model) => (
+              <option
+                key={model.id}
+                value={model.id}
+                selected={settings.EmbeddingModelPref === model.id}
+              >
+                {model.id}
+              </option>
+            ))}
+          </optgroup>
+        )}
         {customModels.length > 0 && (
-          <optgroup label="Your loaded models">
+          <optgroup label="Discovered models">
             {customModels.map((model) => {
               return (
                 <option

--- a/frontend/src/components/SpeechToText/LemonadeOptions/index.jsx
+++ b/frontend/src/components/SpeechToText/LemonadeOptions/index.jsx
@@ -155,6 +155,8 @@ function LemonadeSTTModelSelection({ settings, basePath = null }) {
     findCustomModels();
   }, [basePath]);
 
+  const downloadedModels = customModels.filter((model) => model?.downloaded);
+
   if (loading || customModels.length === 0) {
     return (
       <div className="flex flex-col w-60">
@@ -190,7 +192,20 @@ function LemonadeSTTModelSelection({ settings, basePath = null }) {
         required={true}
         className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
       >
-        <optgroup label="Your loaded models">
+        {downloadedModels.length > 0 && (
+          <optgroup label="Downloaded models">
+            {downloadedModels.map((model) => (
+              <option
+                key={model.id}
+                value={model.id}
+                selected={settings?.STTLemonadeModelPref === model.id}
+              >
+                {model.id}
+              </option>
+            ))}
+          </optgroup>
+        )}
+        <optgroup label="Discovered models">
           {customModels.map((model) => (
             <option
               key={model.id}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
@@ -66,7 +66,7 @@ export default function ChatModelSelection({
         </optgroup>
       )}
       {downloadedModels.length > 0 && (
-        <optgroup label="Downloaded Models">
+        <optgroup label="Downloaded models">
           {downloadedModels.map((model) => (
             <option
               key={model.id}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
@@ -26,6 +26,19 @@ export default function ChatModelSelection({
     );
   }
 
+  const downloadedModels = [];
+
+  if (Array.isArray(customModels)) {
+    downloadedModels.push(...customModels.filter((model) => model?.downloaded));
+  } else {
+    // Break out downloaded models from the creator map
+    downloadedModels.push(
+      ...Object.values(customModels)
+        .flat()
+        .filter((model) => model?.downloaded)
+    );
+  }
+
   return (
     <select
       id="workspace-llm-model-select"
@@ -50,6 +63,19 @@ export default function ChatModelSelection({
               </option>
             );
           })}
+        </optgroup>
+      )}
+      {downloadedModels.length > 0 && (
+        <optgroup label="Downloaded Models">
+          {downloadedModels.map((model) => (
+            <option
+              key={model.id}
+              value={model.id}
+              selected={selectedLLMModel === model.id}
+            >
+              {model.name || model.id}
+            </option>
+          ))}
         </optgroup>
       )}
       {Array.isArray(customModels) && customModels.length > 0 && (

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
@@ -8,7 +8,7 @@ export default function ChatModelSelection({
   selectedLLMModel,
   setSelectedLLMModel,
 }) {
-  const { defaultModels, customModels, loading } =
+  const { defaultModels, customModels, loading, downloadedModels } =
     useGetProviderModels(provider);
   if (DISABLED_PROVIDERS.includes(provider)) return null;
 
@@ -23,19 +23,6 @@ export default function ChatModelSelection({
           -- waiting for models --
         </option>
       </select>
-    );
-  }
-
-  const downloadedModels = [];
-
-  if (Array.isArray(customModels)) {
-    downloadedModels.push(...customModels.filter((model) => model?.downloaded));
-  } else {
-    // Break out downloaded models from the creator map
-    downloadedModels.push(
-      ...Object.values(customModels)
-        .flat()
-        .filter((model) => model?.downloaded)
     );
   }
 

--- a/frontend/src/hooks/useGetProvidersModels.js
+++ b/frontend/src/hooks/useGetProvidersModels.js
@@ -54,6 +54,18 @@ export default function useGetProviderModels(provider = null) {
   const [defaultModels, setDefaultModels] = useState([]);
   const [customModels, setCustomModels] = useState([]);
   const [loading, setLoading] = useState(true);
+  const downloadedModels = [];
+
+  if (Array.isArray(customModels)) {
+    downloadedModels.push(...customModels.filter((model) => model?.downloaded));
+  } else {
+    // Break out downloaded models from the creator map
+    downloadedModels.push(
+      ...Object.values(customModels)
+        .flat()
+        .filter((model) => model?.downloaded)
+    );
+  }
 
   useEffect(() => {
     async function fetchProviderModels() {
@@ -77,5 +89,5 @@ export default function useGetProviderModels(provider = null) {
     fetchProviderModels();
   }, [provider]);
 
-  return { defaultModels, customModels, loading };
+  return { defaultModels, customModels, loading, downloadedModels };
 }

--- a/frontend/src/pages/GeneralSettings/ModelRouters/LLMProviderModelPicker/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ModelRouters/LLMProviderModelPicker/index.jsx
@@ -72,6 +72,8 @@ export default function LLMProviderModelPicker({
     fetchModels();
   }, [selectedProvider, settings]);
 
+  const downloadedModels = models.filter((model) => model?.downloaded);
+
   function handleProviderChange(e) {
     const value = e.target.value;
     setSelectedProvider(value);
@@ -171,11 +173,22 @@ export default function LLMProviderModelPicker({
               <option value="">
                 {t("model-router.provider-picker.select-model")}
               </option>
-              {models.map((model) => (
-                <option key={model.id} value={model.id}>
-                  {model.id}
-                </option>
-              ))}
+              {downloadedModels.length > 0 && (
+                <optgroup label="Downloaded models">
+                  {downloadedModels.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.name || model.id}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              <optgroup label="Discovered models">
+                {models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.id}
+                  </option>
+                ))}
+              </optgroup>
             </select>
           ) : (
             <input

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
@@ -39,7 +39,7 @@ export default function AgentModelSelection({
   setHasChanges,
 }) {
   const { slug } = useParams();
-  const { defaultModels, customModels, loading } =
+  const { defaultModels, customModels, loading, downloadedModels } =
     useGetProviderModels(provider);
 
   const { t } = useTranslation();
@@ -123,6 +123,19 @@ export default function AgentModelSelection({
                 </option>
               );
             })}
+          </optgroup>
+        )}
+        {downloadedModels.length > 0 && (
+          <optgroup label="Downloaded models">
+            {downloadedModels.map((model) => (
+              <option
+                key={model.id}
+                value={model.id}
+                selected={workspace?.agentModel === model.id}
+              >
+                {model.name || model.id}
+              </option>
+            ))}
           </optgroup>
         )}
         {Array.isArray(customModels) && customModels.length > 0 && (

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
@@ -8,7 +8,7 @@ export default function ChatModelSelection({
   workspace,
   setHasChanges,
 }) {
-  const { defaultModels, customModels, loading } =
+  const { defaultModels, customModels, loading, downloadedModels } =
     useGetProviderModels(provider);
   const { t } = useTranslation();
   if (DISABLED_PROVIDERS.includes(provider)) return null;
@@ -70,6 +70,19 @@ export default function ChatModelSelection({
                 </option>
               );
             })}
+          </optgroup>
+        )}
+        {downloadedModels.length > 0 && (
+          <optgroup label="Downloaded models">
+            {downloadedModels.map((model) => (
+              <option
+                key={model.id}
+                value={model.id}
+                selected={workspace?.chatModel === model.id}
+              >
+                {model.name || model.id}
+              </option>
+            ))}
           </optgroup>
         )}
         {Array.isArray(customModels) && customModels.length > 0 && (


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5960

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

Adds a **Downloaded Models** option group to the top of the workspace model selection dropdown. This group only appears when downloaded models are detected.

### What Constitutes a “Downloaded Model”

Local AI providers such as Ollama and LM Studio only return models that are already downloaded locally, so those models will not appear in this option group.

However, providers such as Lemonade and Docker Model Runner return **all available models from the provider**, along with a `downloaded` boolean. These are the providers impacted by this feature and will have the "Downloaded models" `<optgroup>`



### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
