### PR TITLE
Gate Workspace System Prompt Override in `Workspace.new()`

### DIFF
--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -202,13 +202,15 @@ const Workspace = {
       slug = this.slugify(`${name}-${slugSeed}`, { lower: true });
     }
 
-    // Get the default system prompt
-    const defaultSystemPrompt = await SystemSettings.get({
-      label: "default_system_prompt",
-    });
-    if (!!defaultSystemPrompt?.value)
-      additionalFields.openAiPrompt = defaultSystemPrompt.value;
-    else additionalFields.openAiPrompt = this.defaultPrompt;
+    // If system prompt wasn't sent, apply the system default system prompt
+    if (!additionalFields.openAiPrompt) {
+      const defaultSystemPrompt = await SystemSettings.get({
+        label: "default_system_prompt",
+      });
+      additionalFields.openAiPrompt = !!defaultSystemPrompt?.value
+        ? defaultSystemPrompt.value
+        : this.defaultPrompt;
+    }
 
     try {
       const workspace = await prisma.workspaces.create({


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5962 

### Description

`Workspace.new()` would override the given workspace system prompt via parameter (`additionalFields.openAiPrompt`) with the default system prompt regardless of the values truthiness. This resulted in the developer API workspace creation endpoin `POST -> api/v1/workspace/new` to ignore the `openAiPrompt` request body property. This PR gates that the default system prompt override only happens if `additionalFields.openAiPrompt` is falsy, otherwise use the given value.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
