### PR TITLE
docs: add local deployment guides for RAG, Ollama, and memories

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Mintplex Labs & the community maintain a number of deployment methods, scripts, 
 - `yarn dev:frontend` To boot the frontend locally (from root of repo).
 - `yarn dev:collector` To then run the document collector (from root of repo).
 
-[Learn about documents](./server/storage/documents/DOCUMENTS.md)
+[Learn about documents](./server/storage/documents/DOCUMENTS.md) · [Workspace memories](./server/storage/MEMORY.md) · [Ollama troubleshooting](./server/utils/AiProviders/ollama/README.md)
 
 ## Telemetry & Privacy
 

--- a/docker/HOW_TO_USE_DOCKER.md
+++ b/docker/HOW_TO_USE_DOCKER.md
@@ -106,11 +106,11 @@ services:
       - STORAGE_DIR=/app/server/storage
       - JWT_SECRET="make this a large list of random numbers and letters 20+"
       - LLM_PROVIDER=ollama
-      - OLLAMA_BASE_PATH=http://127.0.0.1:11434
+      - OLLAMA_BASE_PATH=http://host.docker.internal:11434
       - OLLAMA_MODEL_PREF=llama2
       - OLLAMA_MODEL_TOKEN_LIMIT=4096
       - EMBEDDING_ENGINE=ollama
-      - EMBEDDING_BASE_PATH=http://127.0.0.1:11434
+      - EMBEDDING_BASE_PATH=http://host.docker.internal:11434
       - EMBEDDING_MODEL_PREF=nomic-embed-text:latest
       - EMBEDDING_MODEL_MAX_CHUNK_LENGTH=8192
       - VECTOR_DB=lancedb

--- a/server/storage/MEMORY.md
+++ b/server/storage/MEMORY.md
@@ -1,0 +1,88 @@
+# Workspace & user memories (self-hosted)
+
+AnythingLLM can remember facts about users across conversations — preferences, names, project context, and similar details. This complements document RAG by persisting **learned** information rather than uploaded files.
+
+> Full product guide: [docs.anythingllm.com/features/memories](https://docs.anythingllm.com/features/memories)
+
+## Memory scopes
+
+| Scope | Limit per user | Description |
+|-------|----------------|-------------|
+| **Global** | 5 | Applies across all workspaces for that user |
+| **Workspace** | 20 | Applies only within one workspace |
+
+At chat time, up to **5 workspace memories** are injected into the prompt alongside any global memories.
+
+Memories are stored in the SQLite database (`anythingllm.db`), not as files on disk.
+
+## Enabling memories
+
+### In the UI
+
+1. Open a chat and expand the **Memories** sidebar.
+2. Toggle **Personalization** on (sets `memory_enabled` system-wide).
+3. Optionally enable **automatic extraction** so a background job proposes new memories from chat history.
+
+### Via environment (Docker / bare metal)
+
+Memories are controlled by system settings persisted in the database. Initial toggles are set in the UI or Admin API, but background job timing can be configured in `.env`:
+
+```env
+# How often the extraction job runs (default: 3hr in code, 15m in .env.example comment)
+MEMORY_EXTRACTION_INTERVAL="3hr"
+
+# Minimum idle time since last chat before extraction (default: 1200000 ms / 20 min)
+# Set to 0 to disable the idle check
+MEMORY_IDLE_THRESHOLD_MS=1200000
+```
+
+Restart the server after changing these values.
+
+## How automatic extraction works
+
+1. A background worker (`extract-memories` job) scans unprocessed chats.
+2. An **observer** LLM proposes candidate facts.
+3. A **reflector** LLM deduplicates against existing memories and approves creates/updates.
+4. Approved memories are saved; chats are marked processed.
+
+Extraction requires:
+
+- `memory_enabled` = true
+- `memory_auto_extraction` = true
+- A working LLM provider (same requirements as chat)
+
+If extraction never runs, confirm both toggles are on and check server logs for `[MemoryExtraction]`.
+
+## Manual memory management
+
+Users can add, edit, and delete memories from the **Memories** sidebar. Workspace-scoped memories are isolated per workspace; global memories follow the user everywhere.
+
+When a workspace memory **updates** an existing fact, the reflector may consolidate rather than create duplicates. Global memories are append-only (no updates).
+
+## Troubleshooting
+
+### Memories not appearing in chat
+
+- Confirm personalization is enabled.
+- Check that memories exist in the sidebar for the current workspace scope.
+- Workspace limit is 20 — older memories may need pruning.
+
+### Automatic extraction not creating memories
+
+- Verify `memory_auto_extraction` is enabled in Admin → Settings.
+- Wait for the idle threshold after your last message (default 20 minutes).
+- Ensure the configured LLM can complete short structured JSON responses.
+- Check logs for extraction job errors.
+
+### Memories conflict with document RAG
+
+Memories and document chunks are separate context sources. If answers seem confused:
+
+- Review memory text for outdated facts and delete or edit them.
+- Use workspace-scoped memories for project-specific details; reserve global scope for stable user preferences.
+
+## Related guides
+
+- [Documents & RAG](./documents/DOCUMENTS.md)
+- [Storage layout & permissions](./README.md)
+- [Local model providers](../models/README.md)

--- a/server/storage/README.md
+++ b/server/storage/README.md
@@ -2,14 +2,33 @@
 
 This folder is for the local or disk storage of ready-to-embed documents, vector-cached embeddings, and the disk-storage of LanceDB and the local SQLite database.
 
-This folder should contain the following folders.
-`documents`
-`lancedb` (if using lancedb)
-`vector-cache`
-and a file named exactly `anythingllm.db`
+Set `STORAGE_DIR` in `server/.env` to an absolute path pointing here. In Docker, mount this directory as a volume so data persists across container updates. See [Docker guide](../../docker/HOW_TO_USE_DOCKER.md).
 
+## Expected layout
 
-### Common issues
+This folder should contain the following:
+
+| Path | Purpose |
+|------|---------|
+| `documents/` | Parsed document JSON produced by the collector |
+| `lancedb/` | LanceDB vector store (default vector DB) |
+| `vector-cache/` | Cached embedding vectors to speed up re-processing |
+| `models/` | Native ONNX models, GGUF files, downloaded weights — see [models README](./models/README.md) |
+| `anythingllm.db` | SQLite database (workspaces, users, memories, metadata) |
+
+User memories are stored in `anythingllm.db`, not as separate files. See [MEMORY.md](./MEMORY.md).
+
+For document formats, RAG tuning, and embedding troubleshooting, see [DOCUMENTS.md](./documents/DOCUMENTS.md).
+
+## Permissions (Docker)
+
+The default container user is UID/GID `1000`. If files on the mounted volume are owned by a different user, you may see write errors. Match `UID`/`GID` in `docker/.env` to your host user, or fix ownership:
+
+```bash
+sudo chown -R 1000:1000 /path/to/storage
+```
+
+## Common issues
 **SQLITE_FILE_CANNOT_BE_OPENED** in the server log = The DB file does not exist probably because the node instance does not have the correct permissions to write a file to the disk. To solve this..
 
 - Local dev

--- a/server/storage/documents/DOCUMENTS.md
+++ b/server/storage/documents/DOCUMENTS.md
@@ -1,10 +1,143 @@
-### What is this folder of documents?
+# Documents & RAG in AnythingLLM
 
-This is a temporary cache of the resulting files you have collected from `collector/`. You really should not be adding files manually to this folder. However the general format of this is you should partion data by how it was collected - it will be added to the appropriate namespace when you undergo vectorizing.
+AnythingLLM turns your files, links, and pasted text into searchable context for chat and agents. This guide covers how documents are stored on disk, which formats are supported, how retrieval (RAG) works, and how to troubleshoot common issues when self-hosting.
 
-You can manage these files from the frontend application.
+> For full product documentation, see [docs.anythingllm.com](https://docs.anythingllm.com/features/document-management).
 
-All files should be JSON files and in general there is only one main required key: `pageContent` all other keys will be inserted as metadata for each document inserted into the vector DB.
+## How documents flow through the system
 
-There is also a special reserved key called `published` that should be reserved for timestamps.
+1. **Upload** — Files are added via the UI, API, browser extension, or watched folders.
+2. **Collector** — The `collector` service parses the raw file (PDF, DOCX, audio, etc.) into plain text.
+3. **Storage** — Parsed content is written as JSON under `server/storage/documents/` (or your configured `STORAGE_DIR`).
+4. **Embedding** — Text is chunked, embedded, and stored in your vector database (LanceDB by default).
+5. **Retrieval** — During chat, relevant chunks are fetched and injected into the LLM prompt as context.
 
+The collector also uses a temporary **hot directory** at `collector/hotdir/` while files are being processed. You normally do not need to touch this folder.
+
+## On-disk storage layout
+
+When `STORAGE_DIR` is set (recommended for Docker and production), document data lives under:
+
+```
+<STORAGE_DIR>/
+├── documents/          # Parsed document JSON files (one per source)
+├── vector-cache/       # Cached embeddings to speed up re-embedding
+├── lancedb/            # Default vector database (if using LanceDB)
+└── anythingllm.db      # SQLite database (workspace + document metadata)
+```
+
+See [storage README](../README.md) for permission and database troubleshooting.
+
+## Supported file formats
+
+The collector supports the following extensions (defined in `collector/utils/constants.js`):
+
+| Category | Extensions |
+|----------|------------|
+| Plain text & markup | `.txt`, `.md`, `.org`, `.adoc`, `.rst`, `.html`, `.csv`, `.json` |
+| Office & open document | `.docx`, `.pptx`, `.xlsx`, `.odt`, `.odp` |
+| PDF & ebooks | `.pdf`, `.epub` |
+| Email archives | `.mbox` |
+| Audio (transcribed locally) | `.mp3`, `.wav`, `.ogg`, `.oga`, `.opus`, `.m4a`, `.webm` |
+| Video (audio track transcribed) | `.mp4`, `.mpeg` |
+| Images (OCR / vision parsing) | `.png`, `.jpg`, `.jpeg`, `.webp` |
+
+> **Note:** Legacy `.doc` (pre-Office-XML Word) is not currently supported.
+
+Unknown text-like files may be processed as `.txt`. Binary formats without a converter will be rejected.
+
+### Audio & video transcription
+
+By default, audio and video files are transcribed with the built-in local **whisper-small** ONNX model. See [native models README](../models/README.md#audiovideo-transcription). Large media files can take several minutes on CPU-only hosts.
+
+## Workspace RAG settings
+
+Each workspace controls how retrieved context is used:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Chat mode** | `automatic` | `chat` = no document retrieval; `query` = retrieval required; `automatic` = model decides |
+| **Similarity threshold** | `0.25` | Minimum vector similarity score (0–1) for a chunk to be included |
+| **Top N** | `4` | Maximum number of chunks injected per query |
+
+Tune these in **Workspace Settings → Chat Settings** when answers miss relevant sources or include irrelevant ones.
+
+### Global chunking settings (admin)
+
+Admins can adjust text splitting under **Settings → Embedding**:
+
+- `text_splitter_chunk_size` — Target characters per chunk
+- `text_splitter_chunk_overlap` — Overlap between adjacent chunks
+- `max_embed_chunk_size` — Hard cap sent to the embedder
+
+Smaller chunks improve precision; larger chunks preserve more surrounding context.
+
+## Embedding engine & vector dimensions
+
+RAG quality depends on matching your embedder output to your vector database:
+
+| Engine | Typical dimensions | Notes |
+|--------|-------------------|-------|
+| **Native** (default) | 384 | ONNX all-MiniLM-L6-v2 — runs fully on-instance |
+| **Ollama** | Model-dependent | Use an embedding model such as `nomic-embed-text` |
+| **OpenAI** | 1536+ | Depends on model |
+| **LM Studio / LocalAI** | Model-dependent | Must match vector DB configuration |
+
+If you change embedders after documents are embedded, **re-embed** existing documents or create a new workspace to avoid dimension mismatches.
+
+## Common troubleshooting
+
+### Document upload fails or stays "processing"
+
+- Confirm the **collector** process is running (`yarn dev:collector` in dev; bundled in Docker/production).
+- Check server logs for `[Collector]` errors.
+- Verify the file extension is in the supported list above.
+- For Docker: ensure `collector/hotdir` and `collector/outputs` volumes are writable. See [storage README](../README.md).
+
+### Embedding fails / documents never show as embedded
+
+- Confirm your **embedding engine** is online (native engine needs no external service; Ollama/OpenAI/etc. must be reachable).
+- For Docker + Ollama/LM Studio on the host, use `http://host.docker.internal:<port>` — not `localhost`. See [Ollama troubleshooting](../../utils/AiProviders/ollama/README.md).
+- Check that `max_embed_chunk_size` is within your embedder's limit.
+- Review server logs for `[NativeEmbedder]`, `[OllamaEmbedder]`, or provider-specific errors.
+
+### Chat ignores my documents / "I don't have information on that"
+
+- Confirm documents show as **embedded** in the workspace document list.
+- Lower the **similarity threshold** (try `0.15`–`0.20`) or increase **Top N**.
+- Switch chat mode to `query` to force retrieval on every message.
+- Rephrase questions to overlap with document vocabulary.
+- Ensure you are chatting in the **correct workspace** — documents are workspace-scoped.
+
+### Answers cite wrong or irrelevant sources
+
+- Raise the **similarity threshold** (try `0.30`–`0.40`).
+- Reduce **Top N** to limit noise.
+- Split large catch-all documents into focused files.
+
+### Vector database connection errors
+
+- LanceDB (default) stores data under `<STORAGE_DIR>/lancedb/` — no external service required.
+- External providers (Chroma, Pinecone, Qdrant, etc.) need reachable endpoints. In Docker, replace `localhost` with `host.docker.internal` or the service container name.
+- Setup guides live under `server/utils/vectorDbProviders/*/`.
+
+### Re-embedding after configuration changes
+
+After changing embedder, vector DB, or chunk settings:
+
+1. Remove documents from the workspace (or use admin tools to purge vectors).
+2. Re-upload or trigger re-embedding from the document manager.
+
+Cached vectors in `vector-cache/` may also need clearing if embeddings are stale.
+
+## API & automation
+
+Documents can be managed via the Developer API (`/api/v1/document/*`, `/api/v1/workspace/*`). See [docs.anythingllm.com/api](https://docs.anythingllm.com/api) for request schemas.
+
+## Related guides
+
+- [Storage & permissions](../README.md)
+- [Native models (embedding, transcription, local LLM)](../models/README.md)
+- [Ollama connection troubleshooting](../../utils/AiProviders/ollama/README.md)
+- [Docker deployment](../../../docker/HOW_TO_USE_DOCKER.md)
+- [Workspace memories](../MEMORY.md)

--- a/server/storage/models/README.md
+++ b/server/storage/models/README.md
@@ -36,7 +36,7 @@ If you would like to use a local Llama compatible LLM model for chatting you can
 ### Where do I put my GGUF model?
 > [!IMPORTANT]
 > If running in Docker you should be running the container to a mounted storage location on the host machine so you
-> can update the storage files directly without having to re-download or re-build your docker container. [See suggested Docker config](../../../README.md#recommended-usage-with-docker-easy)
+> can update the storage files directly without having to re-download or re-build your docker container. [See suggested Docker config](../../../docker/HOW_TO_USE_DOCKER.md)
 
 > [!NOTE]
 > `/server/storage/models/downloaded` is the default location that your model files should be at. 

--- a/server/utils/AiProviders/ollama/README.md
+++ b/server/utils/AiProviders/ollama/README.md
@@ -1,0 +1,136 @@
+# Ollama with AnythingLLM
+
+AnythingLLM connects to [Ollama](https://ollama.com) for local LLM inference and (optionally) embeddings. This guide covers configuration, Docker networking, and fixes for the most common connection errors.
+
+> Official Ollama API reference: [github.com/ollama/ollama/blob/main/docs/api.md](https://github.com/ollama/ollama/blob/main/docs/api.md)
+
+## Quick setup (bare metal / desktop)
+
+1. Install and start Ollama on your host machine.
+2. Pull a chat model: `ollama pull llama3.2`
+3. In AnythingLLM **Settings → LLM Preference**, select **Ollama**.
+4. Set **Ollama Base URL** to `http://127.0.0.1:11434` (default).
+5. Select your model from the dropdown.
+
+For embeddings with Ollama, also set **Settings → Embedding Preference → Ollama**, pull an embedding model (`ollama pull nomic-embed-text`), and point the embedding base path to the same URL.
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LLM_PROVIDER` | Yes | Set to `ollama` |
+| `OLLAMA_BASE_PATH` | Yes | Ollama API URL (e.g. `http://127.0.0.1:11434`) |
+| `OLLAMA_MODEL_PREF` | Yes | Model tag (e.g. `llama3.2`) |
+| `OLLAMA_MODEL_TOKEN_LIMIT` | No | Fallback context window if auto-detection fails (default: 4096) |
+| `OLLAMA_AUTH_TOKEN` | No | Bearer token if Ollama runs behind auth |
+| `OLLAMA_RESPONSE_TIMEOUT` | No | Max response time in ms (default: 5 min). Set higher for slow CPUs, e.g. `7200000` (2 hr) |
+| `OLLAMA_KEEP_ALIVE_TIMEOUT` | No | Seconds to keep model loaded in Ollama (default: 300) |
+| `EMBEDDING_ENGINE` | For RAG | Set to `ollama` when using Ollama embeddings |
+| `EMBEDDING_BASE_PATH` | For RAG | Same host URL as `OLLAMA_BASE_PATH` |
+| `EMBEDDING_MODEL_PREF` | For RAG | Embedding model tag (e.g. `nomic-embed-text:latest`) |
+| `OLLAMA_EMBEDDING_BATCH_SIZE` | No | Concurrent embedding chunks (default: 1) |
+
+See `server/.env.example` and `docker/.env.example` for copy-paste templates.
+
+## Docker networking (most common issue)
+
+When AnythingLLM runs **inside Docker** and Ollama runs on the **host**, `localhost` and `127.0.0.1` inside the container refer to the container itself — not your machine.
+
+| Host OS | Use this URL in AnythingLLM |
+|---------|----------------------------|
+| Windows / macOS | `http://host.docker.internal:11434` |
+| Linux (Docker 20.10+) | `http://host.docker.internal:11434` with `--add-host=host.docker.internal:host-gateway` |
+| Linux (fallback) | `http://172.17.0.1:11434` (default bridge gateway) |
+
+The project's `docker/docker-compose.yml` already includes:
+
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+### Ollama listening address
+
+Ollama must accept connections from Docker, not only loopback. If connections still fail:
+
+```bash
+# Linux example — bind to all interfaces
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
+
+On Windows/macOS the desktop Ollama app typically listens on all interfaces by default.
+
+## Error: `connect ECONNREFUSED 172.17.0.1:11434`
+
+This means AnythingLLM reached the Docker bridge gateway but **nothing is listening** on port 11434.
+
+**Checklist:**
+
+1. Confirm Ollama is running on the host: `curl http://127.0.0.1:11434` should return `Ollama is running`.
+2. Verify the URL in AnythingLLM matches your setup (see table above).
+3. Ensure the model is pulled: `ollama list` should show your chat model.
+4. On Linux, add `--add-host=host.docker.internal:host-gateway` to `docker run`, or use `172.17.0.1` explicitly.
+5. Check firewall rules blocking Docker bridge traffic to port 11434.
+
+## Error: `could not stream chat` / timeout
+
+Local models on CPU can exceed the default 5-minute fetch timeout.
+
+```env
+OLLAMA_RESPONSE_TIMEOUT=7200000
+```
+
+Restart the server after changing `.env`. Values ≤ 300000 (5 min) are ignored and fall back to default.
+
+## Error: model not found / empty model list
+
+- Pull the model on the host: `ollama pull <model-name>`
+- Ensure `OLLAMA_MODEL_PREF` exactly matches `ollama list` output (including tags like `:latest`).
+- AnythingLLM caches Ollama context windows on startup — if the model was just pulled, restart AnythingLLM to refresh.
+
+## Embeddings with Ollama
+
+For document RAG with Ollama embeddings:
+
+```env
+EMBEDDING_ENGINE=ollama
+EMBEDDING_BASE_PATH=http://host.docker.internal:11434
+EMBEDDING_MODEL_PREF=nomic-embed-text:latest
+```
+
+Pull the embedding model first: `ollama pull nomic-embed-text`.
+
+If document embedding fails but chat works, verify:
+
+- The model supports the `/api/embeddings` endpoint.
+- `EMBEDDING_MODEL_MAX_CHUNK_LENGTH` is not larger than the model's context window.
+
+## Agent & tool use with Ollama
+
+Agent mode requires models that support reliable tool/function calling. Smaller or older models may hallucinate tool calls or ignore instructions.
+
+Recommendations:
+
+- Use recent instruction-tuned models (Llama 3+, Qwen 2.5+, Mistral variants).
+- Enable **Intelligent Skill Selection** in settings to reduce token usage with many tools.
+- See [docs.anythingllm.com/agent](https://docs.anythingllm.com/agent/introduction) for agent configuration.
+
+## Ollama running in another Docker container
+
+If Ollama is a sibling container on the same Docker network, use the **service name** as hostname:
+
+```env
+OLLAMA_BASE_PATH=http://ollama:11434
+```
+
+Do not use `host.docker.internal` in this case.
+
+## Still stuck?
+
+1. Check AnythingLLM server logs for `[Ollama]` lines.
+2. Test from inside the AnythingLLM container:
+   ```bash
+   docker exec -it <container_id> curl http://host.docker.internal:11434
+   ```
+3. Review [Docker deployment guide](../../../../docker/HOW_TO_USE_DOCKER.md#common-questions-and-fixes).
+4. Ask on [Discord](https://discord.gg/6UyHPeGZAC).


### PR DESCRIPTION
## Summary

Adds in-repo local deployment and troubleshooting documentation.

## Changes

* Expand DOCUMENTS.md with RAG pipeline and troubleshooting
* Add Ollama provider README with Docker networking guidance
* Add MEMORY.md for workspace memory self-host configuration
* Fix broken Docker anchor and compose Ollama URLs

## Validation

* Referenced paths verified against source code
* Documentation-only changes

## Notes

Kept intentionally small and aligned with existing project patterns.