### PR TITLE
test: fix isoDeviceArgs unit test after usb-storage change

### DIFF
--- a/open-computer/cli/src/vm.test.ts
+++ b/open-computer/cli/src/vm.test.ts
@@ -45,14 +45,14 @@ test('gpuDeviceArgs: Windows uses standard VGA, other platforms use virtio-gpu',
   assert.deepEqual(gpuDeviceArgs('linux'), ['-device', 'virtio-gpu-pci']);
 });
 
-test('isoDeviceArgs: attaches a bootable CD-ROM only on Windows', () => {
+test('isoDeviceArgs: attaches a bootable USB CD-ROM only on Windows', () => {
   const win = isoDeviceArgs('/tmp/debian.iso', 'win32');
-  assert.ok(win.includes('ide-cd,bus=ide.0,drive=installcd,bootindex=0'));
+  assert.ok(win.includes('usb-storage,drive=install-cdrom'));
   assert.ok(win.some((s) => s.includes('media=cdrom')));
   assert.ok(win.some((s) => s.includes('/tmp/debian.iso')));
 });
 
-test('isoDeviceArgs: no CD-ROM on macOS/Linux (the virt machine has no ide.0 bus)', () => {
+test('isoDeviceArgs: no CD-ROM on macOS/Linux', () => {
   assert.deepEqual(isoDeviceArgs('/tmp/debian.iso', 'darwin'), []);
   assert.deepEqual(isoDeviceArgs('/tmp/debian.iso', 'linux'), []);
 });


### PR DESCRIPTION
## Summary

Follow up to #5982. That PR's merge changed the base install media in
`isoDeviceArgs` from an `ide-cd` device to `usb-storage`, but the corresponding
unit test still asserted the old `ide-cd` device, so `npm test` currently fails
on `master`.

This updates the test assertion to the `usb-storage` device id. Test only, no
production code changes.

## Testing

From `open-computer/cli`:

```
npm install
npm test
```

All 10 tests pass.
