### PR TITLE
Add grounding instruction for reranked (Accuracy Optimized) mode to reduce confident hallucination

### DIFF
--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -262,9 +262,15 @@ async function streamChatWithWorkspace(
       prompt: updatedMessage,
       rawHistory,
     }));
+    const groundingInstruction =
+    workspace?.vectorSearchMode === "rerank"
+      ? "\n\nIMPORTANT: The context above was selected by a precision-focused retrieval process that returns a small, narrow set of passages. If the provided context does not clearly and directly support an answer, explicitly say you are not certain rather than guessing or stating an answer with unwarranted confidence."
+      : "";
+
+  const finalSystemPrompt = systemPrompt + groundingInstruction;
   const messages = await LLMConnector.compressMessages(
     {
-      systemPrompt,
+      systemPrompt: finalSystemPrompt,
       userPrompt: updatedMessage,
       contextTexts,
       chatHistory,


### PR DESCRIPTION
## What this does

Adds a conditional grounding instruction to the system prompt, active only when a workspace's Vector Search Mode is set to "rerank" (Accuracy Optimized).

## Why

While evaluating the existing reranking feature, I found that reranked mode can produce shorter, more confident answers than default mode — but not necessarily more accurate ones. In one test case, reranked mode confidently stated an incorrect fact that default mode correctly hedged on instead of guessing.

This suggests narrower, more precisely-retrieved context can make the model sound more certain without actually being more grounded, since there's less surrounding material to prompt hedging language.

## The fix

A small instruction is appended to the system prompt only in reranked mode, asking the model to explicitly flag uncertainty when the provided context doesn't clearly support an answer, rather than defaulting to a confident-sounding guess.

## Testing / limitations

I ran a 9-question before/after evaluation on a real document. The instruction successfully corrected the target hallucination case, but I also found a real tradeoff worth being upfront about: it caused some previously-accurate answers to become more hedged than necessary, and it did not catch a separate, unrelated hallucination in my test set. Full writeup with screenshots here: https://github.com/SAYALI287/anythingllm-rag-reranking-eval

This is a minimal, low-risk change — it only affects the system prompt text when reranking is explicitly enabled, and does not touch retrieval logic, the reranker itself, or default-mode behavior at all.

Happy to iterate on this — a more targeted follow-up could condition the instruction on the reranker's own relevance/confidence scores rather than applying it uniformly whenever reranking is on.