### PR TITLE
docs(bare-metal): fix env var name to match frontend/.env — VITE_API_BASE

### DIFF
--- a/BARE_METAL.md
+++ b/BARE_METAL.md
@@ -30,7 +30,7 @@ Here you can find the scripts and known working process to run AnythingLLM outsi
 STORAGE_DIR="/your/absolute/path/to/server/storage"
 ```
 
-5. Edit the `frontend/.env` file for the `VITE_BASE_API` to now be set to `/api`. This is documented in the .env for which one you should use.
+5. Edit the `frontend/.env` file for the `VITE_API_BASE` to now be set to `/api`. This is documented in the .env for which one you should use.
 ```
 # VITE_API_BASE='http://localhost:3001/api' # Use this URL when developing locally
 # VITE_API_BASE="https://$CODESPACE_NAME-3001.$GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN/api" # for GitHub Codespaces


### PR DESCRIPTION
## Summary

`BARE_METAL.md` step 5 tells the user to edit `VITE_BASE_API`, but the actual variable used by `frontend/.env` (shown in the code block immediately following, and in `frontend/.env.example`) is `VITE_API_BASE`:

```diff
- 5. Edit the `frontend/.env` file for the `VITE_BASE_API` to now be set to `/api`.
+ 5. Edit the `frontend/.env` file for the `VITE_API_BASE` to now be set to `/api`.
```

The following code block already uses `VITE_API_BASE` (three occurrences), so the prose was the outlier. Following the guide as-written leads a new operator to set an env var the app doesn't read, and the frontend can't reach the API.

## Verified

- [x] `frontend/.env.example` defines `VITE_API_BASE` (not `VITE_BASE_API`).
- [x] The code block on lines 34–37 immediately below the prose uses `VITE_API_BASE` three times.
- [x] One-line diff, `BARE_METAL.md` only.