### PR TITLE
fix(security): enforce workspace membership on suggested-messages and pfp GET routes

### DIFF
--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -546,7 +546,7 @@ function workspaceEndpoints(app) {
 
   app.get(
     "/workspace/:slug/suggested-messages",
-    [validatedRequest, flexUserRoleValid([ROLES.all])],
+    [validatedRequest, flexUserRoleValid([ROLES.all]), validWorkspaceSlug],
     async function (request, response) {
       try {
         const { slug } = request.params;
@@ -665,7 +665,7 @@ function workspaceEndpoints(app) {
 
   app.get(
     "/workspace/:slug/pfp",
-    [validatedRequest, flexUserRoleValid([ROLES.all])],
+    [validatedRequest, flexUserRoleValid([ROLES.all]), validWorkspaceSlug],
     async function (request, response) {
       try {
         const { slug } = request.params;


### PR DESCRIPTION
### What & why

In multi-user mode, `GET /api/workspace/:slug/suggested-messages` and `GET /api/workspace/:slug/pfp` were guarded only by `flexUserRoleValid([ROLES.all])` and resolved the workspace directly by slug, **without** the `validWorkspaceSlug` membership middleware that every other `/workspace/:slug/*` route uses.

This let any authenticated `default`-role user read the admin-configured **suggested messages** (and workspace profile image) of **any** workspace by slug — including workspaces they were never granted access to — breaking the workspace isolation boundary the rest of the API enforces. The `POST` counterpart already correctly requires admin/manager.

This is not an "unauthenticated" report: it requires multi-user mode enabled and a legitimately provisioned, authenticated user, and it violates the "explicit access granted by administrator" model that multi-user mode promises.

### Fix

Add `validWorkspaceSlug` to both middleware chains. It returns 404 for non-member `default` users while preserving admin/manager access (via `Workspace.getWithUser`), exactly matching the sibling routes. Two-line change.

### Verification (local, multi-user mode)

| request | before | after |
| --- | --- | --- |
| attacker (default, non-member) `GET /workspace/:slug/suggested-messages` | `200` + victim's messages | `404` |
| victim (member) same request | `200` + messages | `200` + messages |
| admin same request | `200` | `200` |
| attacker `GET /workspace/:slug/pfp` (non-member) | `204`/image | `404` |

No behavior change for members, admins, or managers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
