### PR TITLE
fix: abort agent inference on disconnect

### DIFF
--- a/server/__tests__/endpoints/agentWebsocket.test.js
+++ b/server/__tests__/endpoints/agentWebsocket.test.js
@@ -1,0 +1,57 @@
+process.env.STORAGE_DIR = __dirname;
+process.env.NODE_ENV = "test";
+
+const mockAgentHandler = {
+  invocation: { id: 1 },
+  aibitat: { abort: jest.fn() },
+  closeAlert: jest.fn(),
+  createAIbitat: jest.fn(),
+  startAgentCluster: jest.fn(),
+  init: jest.fn(),
+};
+
+jest.mock("../../models/telemetry", () => ({
+  Telemetry: { sendTelemetry: jest.fn() },
+}));
+jest.mock("../../models/workspaceAgentInvocation", () => ({
+  WorkspaceAgentInvocation: { close: jest.fn() },
+}));
+jest.mock("../../utils/agents", () => ({
+  AgentHandler: jest.fn(() => mockAgentHandler),
+}));
+
+const { WorkspaceAgentInvocation } = require("../../models/workspaceAgentInvocation");
+const { agentWebsocket } = require("../../endpoints/agentWebsocket");
+
+describe("agent websocket cancellation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAgentHandler.init.mockResolvedValue(mockAgentHandler);
+  });
+
+  it("aborts the active agent when the client disconnects", async () => {
+    const listeners = {};
+    const socket = {
+      on: jest.fn((event, listener) => {
+        listeners[event] = listener;
+      }),
+      close: jest.fn(),
+      send: jest.fn(),
+    };
+    let websocketHandler;
+    const app = {
+      ws: jest.fn((_path, handler) => {
+        websocketHandler = handler;
+      }),
+    };
+    agentWebsocket(app);
+
+    await websocketHandler(socket, { params: { uuid: "invocation-id" } });
+    listeners.close();
+
+    expect(mockAgentHandler.aibitat.abort).toHaveBeenCalledTimes(1);
+    expect(WorkspaceAgentInvocation.close).toHaveBeenCalledWith(
+      "invocation-id"
+    );
+  });
+});

--- a/server/__tests__/utils/agents/aibitat/emitter.test.js
+++ b/server/__tests__/utils/agents/aibitat/emitter.test.js
@@ -147,4 +147,14 @@ describe("AIbitat abort listener cleanup pattern", () => {
     await Promise.resolve().finally(cleanup);
     expect(instance.emitter.listenerCount("abort")).toBe(0);
   });
+
+  it("abort() should cancel the active provider request", () => {
+    const instance = createAibitat();
+    const provider = { abort: jest.fn() };
+    instance.providerInstance = provider;
+
+    instance.abort();
+
+    expect(provider.abort).toHaveBeenCalledTimes(1);
+  });
 });

--- a/server/__tests__/utils/agents/providers/lmstudio.test.js
+++ b/server/__tests__/utils/agents/providers/lmstudio.test.js
@@ -1,0 +1,47 @@
+process.env.STORAGE_DIR = __dirname;
+process.env.NODE_ENV = "test";
+process.env.LMSTUDIO_MODEL_PREF = "test-model";
+process.env.LMSTUDIO_BASE_PATH = "http://localhost:1234";
+
+const mockCreate = jest.fn();
+
+jest.mock("openai", () =>
+  jest.fn(() => ({
+    chat: { completions: { create: mockCreate } },
+  }))
+);
+jest.mock("../../../../utils/AiProviders/lmStudio", () => ({
+  LMStudioLLM: {
+    cacheContextWindows: jest.fn(),
+    promptWindowLimit: jest.fn(() => 4096),
+    maxContextWindow: jest.fn(() => 4096),
+  },
+  parseLMStudioBasePath: jest.fn((url) => url),
+}));
+
+const LMStudioProvider = require("../../../../utils/agents/aibitat/providers/lmstudio");
+
+describe("LMStudioProvider cancellation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreate.mockResolvedValue(
+      (async function* () {
+        yield { choices: [{ delta: { content: "partial" } }] };
+      })()
+    );
+  });
+
+  it("passes an abortable signal to streamed completion requests", async () => {
+    const provider = new LMStudioProvider({ model: "test-model" });
+
+    await provider.stream([{ role: "user", content: "hello" }]);
+
+    const requestOptions = mockCreate.mock.calls[0][1];
+    expect(requestOptions.signal).toBeInstanceOf(AbortSignal);
+    expect(requestOptions.signal.aborted).toBe(false);
+
+    provider.abort();
+
+    expect(requestOptions.signal.aborted).toBe(true);
+  });
+});

--- a/server/__tests__/utils/agents/providers/ollama.test.js
+++ b/server/__tests__/utils/agents/providers/ollama.test.js
@@ -1,0 +1,31 @@
+process.env.STORAGE_DIR = __dirname;
+process.env.NODE_ENV = "test";
+
+const mockAbort = jest.fn();
+
+jest.mock("ollama", () => ({
+  Ollama: jest.fn(() => ({ abort: mockAbort })),
+}));
+jest.mock("../../../../utils/AiProviders/ollama", () => ({
+  OllamaAILLM: {
+    applyOllamaFetch: jest.fn(),
+  },
+}));
+
+const OllamaProvider = require("../../../../utils/agents/aibitat/providers/ollama");
+
+describe("OllamaProvider cancellation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("aborts the active Ollama stream", () => {
+    const provider = new OllamaProvider({ model: "test-model" });
+    const signal = provider.requestOptions().signal;
+
+    provider.abort();
+
+    expect(mockAbort).toHaveBeenCalledTimes(1);
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/server/endpoints/agentWebsocket.js
+++ b/server/endpoints/agentWebsocket.js
@@ -33,6 +33,7 @@ function agentWebsocket(app) {
 
       socket.on("message", relayToSocket);
       socket.on("close", () => {
+        agentHandler.aibitat?.abort?.();
         agentHandler.closeAlert();
         WorkspaceAgentInvocation.close(String(request.params.uuid));
         return;

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -33,6 +33,8 @@ class AIbitat {
   /** @type {import("./providers/ai-provider").AgentProviderInstance|null} */
   _providerInstance = null;
 
+  _aborted = false;
+
   defaultProvider = null;
   defaultInterrupt;
   maxRounds;
@@ -408,7 +410,10 @@ class AIbitat {
    * Abort the running of any plugins that may still be pending (Langchain summarize)
    */
   abort() {
+    if (this._aborted) return;
+    this._aborted = true;
     this.emitter.emit("abort", null, this);
+    this.providerInstance?.abort?.();
   }
 
   /**

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -48,6 +48,7 @@ const DEFAULT_WORKSPACE_PROMPT =
  * @property {boolean} [verbose] - Whether to log verbose introspection messages.
  * @property {boolean} supportsAgentStreaming - Whether the provider supports streaming tool-call execution.
  * @property {(handlerProps: Object) => void} attachHandlerProps - Attach invocation/handler context to the provider.
+ * @property {() => void} abort - Abort the active provider request.
  * @property {(messages: Array, functions?: Array, eventHandler?: Function) => Promise<{functionCall: any, textResponse: string}>} stream - Stream a chat completion with tool calling.
  * @property {(messages: Array, functions?: Array) => Promise<{functionCall: any, textResponse: string, result?: string}>} complete - Non-streaming chat completion with tool calling.
  * @property {() => ProviderUsageMetrics} getUsage - Get usage metrics from the last completion.
@@ -55,6 +56,8 @@ const DEFAULT_WORKSPACE_PROMPT =
 
 class Provider {
   _client;
+
+  _abortController = new AbortController();
 
   /**
    * The invocation object containing the user ID and other invocation details.
@@ -128,6 +131,14 @@ class Provider {
 
   get client() {
     return this._client;
+  }
+
+  requestOptions() {
+    return { signal: this._abortController.signal };
+  }
+
+  abort() {
+    this._abortController.abort();
   }
 
   /**
@@ -648,14 +659,17 @@ class Provider {
     this.providerLog("Provider.stream - will process this chat completion.");
     const msgUUID = v4();
     const formattedMessages = this.formatMessagesWithAttachments(messages);
-    const stream = await this.client.chat.completions.create({
-      model: this.model,
-      stream: true,
-      messages: formattedMessages,
-      ...(Array.isArray(functions) && functions?.length > 0
-        ? { functions }
-        : {}),
-    });
+    const stream = await this.client.chat.completions.create(
+      {
+        model: this.model,
+        stream: true,
+        messages: formattedMessages,
+        ...(Array.isArray(functions) && functions?.length > 0
+          ? { functions }
+          : {}),
+      },
+      this.requestOptions()
+    );
 
     const result = {
       functionCall: null,

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -189,13 +189,16 @@ async function tooledStream(
   const formattedMessages = formatMessagesForTools(messages, formatOptions);
   const tools = formatFunctionsToTools(functions);
 
-  const stream = await client.chat.completions.create({
-    model,
-    stream: true,
-    stream_options: { include_usage: true },
-    messages: formattedMessages,
-    ...(tools.length > 0 ? { tools } : {}),
-  });
+  const stream = await client.chat.completions.create(
+    {
+      model,
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: formattedMessages,
+      ...(tools.length > 0 ? { tools } : {}),
+    },
+    provider?.requestOptions?.()
+  );
 
   const result = {
     functionCall: null,

--- a/server/utils/agents/aibitat/providers/lmstudio.js
+++ b/server/utils/agents/aibitat/providers/lmstudio.js
@@ -65,10 +65,13 @@ class LMStudioProvider extends InheritMultiple([Provider, UnTooled]) {
   async #handleFunctionCallChat({ messages = [] }) {
     await LMStudioLLM.cacheContextWindows();
     return await this.client.chat.completions
-      .create({
-        model: this.model,
-        messages,
-      })
+      .create(
+        {
+          model: this.model,
+          messages,
+        },
+        this.requestOptions()
+      )
       .then((result) => {
         if (!result.hasOwnProperty("choices"))
           throw new Error("LMStudio chat: No results!");
@@ -83,11 +86,14 @@ class LMStudioProvider extends InheritMultiple([Provider, UnTooled]) {
 
   async #handleFunctionCallStream({ messages = [] }) {
     await LMStudioLLM.cacheContextWindows();
-    return await this.client.chat.completions.create({
-      model: this.model,
-      stream: true,
-      messages,
-    });
+    return await this.client.chat.completions.create(
+      {
+        model: this.model,
+        stream: true,
+        messages,
+      },
+      this.requestOptions()
+    );
   }
 
   /**

--- a/server/utils/agents/aibitat/providers/ollama.js
+++ b/server/utils/agents/aibitat/providers/ollama.js
@@ -40,6 +40,11 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
     return this._client;
   }
 
+  abort() {
+    this.client.abort();
+    Provider.prototype.abort.call(this);
+  }
+
   get supportsAgentStreaming() {
     return true;
   }


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

Fixes #5905

### Problem

Closing an active agent chat—or pressing Stop Generation, which closes the same WebSocket—ended the client connection but did not cancel the in-flight provider request. LM Studio and Ollama could therefore continue generating after the user had left or stopped the session.

### Root Cause

The agent WebSocket close handler only closed the invocation record. It did not call AIbitat's abort path. AIbitat's existing `abort()` method notified plugins, but it did not propagate cancellation to the active provider request. The LM Studio OpenAI-compatible request also had no `AbortSignal`, and the Ollama client's stream abort method was not connected to the session lifecycle.

### Solution

- Abort the active AIbitat session when the agent WebSocket closes.
- Make AIbitat abort idempotent and delegate cancellation to the active provider.
- Add an `AbortController` to the shared agent provider base.
- Pass its signal to shared OpenAI-compatible streaming requests and LM Studio completion requests.
- Connect the Ollama provider to the Ollama client's native `abort()` method.

### Scope

This change is limited to agent-session cancellation. It does not change background chat persistence, navigation behavior, or provider selection.

### Tests

Added regression coverage for:

- WebSocket disconnects aborting the active agent.
- AIbitat delegating abort to its provider.
- LM Studio streamed requests receiving an abortable signal.
- Ollama streams using the client abort method.

### Validation

- `corepack yarn test --runInBand server/__tests__/endpoints/agentWebsocket.test.js server/__tests__/utils/agents/aibitat/emitter.test.js server/__tests__/utils/agents/providers/lmstudio.test.js server/__tests__/utils/agents/providers/ollama.test.js`
  - Passed: 4 suites, 11 tests.
- `cd server && corepack yarn lint:check`
  - Passed.
- `corepack yarn test --runInBand server`
  - Passed: 24 suites, 174 tests.
- `corepack yarn test --runInBand`
  - Partial environment result: 27 of 28 suites passed; 208 of 211 tests passed. The remaining three existing FFmpeg wrapper tests could not run because `ffmpeg` is not installed on the Windows test host.
- `git diff --check`
  - Passed.

Validation was run with Node.js v24.14.0 and Yarn v1.22.22 via Corepack. CI uses Node.js 18.

### Compatibility

The OpenAI SDK version already used by the repository accepts `AbortSignal` through request options. Ollama cancellation uses the existing client instance's public `abort()` method. Providers without a custom abort implementation continue to use the shared provider cancellation path.

### Developer Validations

- [x] Relevant server lint passes
- [x] Relevant automated tests pass
- [ ] Docker build succeeds locally
