### PR TITLE
fix: preserve TTS audio content type

### DIFF
--- a/server/__tests__/utils/TextToSpeech/audioFormat.test.js
+++ b/server/__tests__/utils/TextToSpeech/audioFormat.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+const { getAudioFileInfo } = require("../../../utils/TextToSpeech/audioFormat");
+
+describe("getAudioFileInfo", () => {
+  test.each([
+    [
+      "WAV",
+      Buffer.concat([
+        Buffer.from("RIFF"),
+        Buffer.alloc(4),
+        Buffer.from("WAVEfmt "),
+      ]),
+      { mime: "audio/wav", extension: ".wav" },
+    ],
+    ["Ogg", Buffer.from("OggS"), { mime: "audio/ogg", extension: ".ogg" }],
+    ["FLAC", Buffer.from("fLaC"), { mime: "audio/flac", extension: ".flac" }],
+    [
+      "M4A",
+      Buffer.concat([Buffer.alloc(4), Buffer.from("ftyp")]),
+      { mime: "audio/mp4", extension: ".m4a" },
+    ],
+    [
+      "WebM",
+      Buffer.from([0x1a, 0x45, 0xdf, 0xa3]),
+      { mime: "audio/webm", extension: ".webm" },
+    ],
+    ["ID3 MP3", Buffer.from("ID3"), { mime: "audio/mpeg", extension: ".mp3" }],
+    [
+      "frame-synced MP3",
+      Buffer.from([0xff, 0xfb]),
+      { mime: "audio/mpeg", extension: ".mp3" },
+    ],
+  ])("detects %s audio", (_name, buffer, expected) => {
+    expect(getAudioFileInfo(buffer)).toEqual(expected);
+  });
+
+  test.each([Buffer.from("unknown"), Buffer.alloc(0), null])(
+    "defaults unknown data to MP3",
+    (buffer) => {
+      expect(getAudioFileInfo(buffer)).toEqual({
+        mime: "audio/mpeg",
+        extension: ".mp3",
+      });
+    }
+  );
+});

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -31,6 +31,7 @@ const {
   fetchPfp,
 } = require("../utils/files/pfp");
 const { getTTSProvider } = require("../utils/TextToSpeech");
+const { getAudioFileInfo } = require("../utils/TextToSpeech/audioFormat");
 const { WorkspaceThread } = require("../models/workspaceThread");
 
 const truncate = require("truncate");
@@ -650,9 +651,10 @@ function workspaceEndpoints(app) {
         const buffer = await TTSProvider.ttsBuffer(text);
         if (buffer === null) return response.sendStatus(204).end();
 
-        responseCache.set(cacheKey, { buffer, mime: "audio/mpeg" });
+        const { mime } = getAudioFileInfo(buffer);
+        responseCache.set(cacheKey, { buffer, mime });
         response.writeHead(200, {
-          "Content-Type": "audio/mpeg",
+          "Content-Type": mime,
         });
         response.end(buffer);
         return;

--- a/server/utils/TextToSpeech/audioFormat.js
+++ b/server/utils/TextToSpeech/audioFormat.js
@@ -1,0 +1,50 @@
+const AUDIO_FORMATS = {
+  flac: { mime: "audio/flac", extension: ".flac" },
+  m4a: { mime: "audio/mp4", extension: ".m4a" },
+  mp3: { mime: "audio/mpeg", extension: ".mp3" },
+  ogg: { mime: "audio/ogg", extension: ".ogg" },
+  wav: { mime: "audio/wav", extension: ".wav" },
+  webm: { mime: "audio/webm", extension: ".webm" },
+};
+
+/**
+ * Detect the container of an audio buffer from its file signature.
+ * Defaults to MP3 to preserve the existing behavior for unknown data.
+ * @param {Buffer} buffer
+ * @returns {{mime: string, extension: string}}
+ */
+function getAudioFileInfo(buffer) {
+  if (!Buffer.isBuffer(buffer)) return AUDIO_FORMATS.mp3;
+
+  const signature = (start, end) => buffer.toString("ascii", start, end);
+
+  if (
+    buffer.length >= 12 &&
+    ["RIFF", "RF64"].includes(signature(0, 4)) &&
+    signature(8, 12) === "WAVE"
+  )
+    return AUDIO_FORMATS.wav;
+  if (buffer.length >= 4 && signature(0, 4) === "OggS")
+    return AUDIO_FORMATS.ogg;
+  if (buffer.length >= 4 && signature(0, 4) === "fLaC")
+    return AUDIO_FORMATS.flac;
+  if (buffer.length >= 8 && signature(4, 8) === "ftyp")
+    return AUDIO_FORMATS.m4a;
+  if (
+    buffer.length >= 4 &&
+    buffer[0] === 0x1a &&
+    buffer[1] === 0x45 &&
+    buffer[2] === 0xdf &&
+    buffer[3] === 0xa3
+  )
+    return AUDIO_FORMATS.webm;
+  if (
+    (buffer.length >= 3 && signature(0, 3) === "ID3") ||
+    (buffer.length >= 2 && buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0)
+  )
+    return AUDIO_FORMATS.mp3;
+
+  return AUDIO_FORMATS.mp3;
+}
+
+module.exports = { getAudioFileInfo };

--- a/server/utils/telegramBot/utils/media.js
+++ b/server/utils/telegramBot/utils/media.js
@@ -1,3 +1,5 @@
+const { getAudioFileInfo } = require("../../TextToSpeech/audioFormat");
+
 /**
  * Download a file from Telegram by file ID.
  * @param {TelegramBot} bot
@@ -133,13 +135,14 @@ async function sendVoiceResponse(bot, chatId, text) {
     const provider = getTTSProvider();
     const buffer = await provider.ttsBuffer(text);
     if (!buffer) return false;
+    const { mime, extension } = getAudioFileInfo(buffer);
     await bot.sendAudio(
       chatId,
       buffer,
       {},
       {
-        filename: `${chatId}-response.mp3`,
-        contentType: "audio/mpeg",
+        filename: `${chatId}-response${extension}`,
+        contentType: mime,
       }
     );
     return true;


### PR DESCRIPTION
## Summary

- detect WAV, Ogg, FLAC, M4A, WebM, and MP3 containers from TTS response bytes
- return the matching `Content-Type` from workspace TTS responses
- send Telegram audio with the matching MIME type and filename extension
- retain MP3 as the fallback for unknown data to preserve existing behavior

## Testing

- `npx --yes jest@29.7.0 server/__tests__/utils/TextToSpeech/audioFormat.test.js --runInBand`
- Prettier check for all changed files
- Node syntax checks for changed runtime files

Fixes #6011