### PR TITLE
Fix typo in README regarding agent computer

### DIFF
--- a/open-computer/README.md
+++ b/open-computer/README.md
@@ -12,7 +12,7 @@
 <video src="https://github.com/user-attachments/assets/79334c87-c5ae-4c2c-8384-d7ef922e4184"></video>
 
 > [!IMPORTANT]
-> This project is a work in progress and is something we intend to bring fully into AnythingLLM — enabling custom, secure, and scalable agent compute for everyone.
+> This project is a work in progress and is something we intend to bring fully into AnythingLLM — enabling custom, secure, and scalable agent computer for everyone.
 >
 > ⭐ Star the repo to stay updated!
 


### PR DESCRIPTION
Corrected 'compute' to 'computer' in README.


### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [*] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Description

This resolves a typo on the readme main page of opencomputer.


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
