### PR TITLE
chore: improve agent tool routing between filesystem tools and rag-memory

### DIFF
--- a/server/__tests__/utils/agents/defaults.test.js
+++ b/server/__tests__/utils/agents/defaults.test.js
@@ -20,6 +20,23 @@ jest.mock("../../../utils/MCP", () => {
     activeMCPServers: jest.fn().mockResolvedValue([]),
   }));
 });
+jest.mock("../../../utils/agents/aibitat/plugins/filesystem/lib", () => ({
+  isToolAvailable: jest.fn().mockReturnValue(true),
+}));
+
+/**
+ * Mocks SystemSettings so the given labels resolve to the given values and
+ * everything else falls back to its default.
+ */
+function mockSystemSettings(overrides = {}) {
+  const { SystemSettings } = require("../../../models/systemSettings");
+  SystemSettings.getValueOrFallback = jest
+    .fn()
+    .mockImplementation(async ({ label }, fallback) => {
+      if (label in overrides) return overrides[label];
+      return fallback;
+    });
+}
 
 const { WORKSPACE_AGENT } = require("../../../utils/agents/defaults");
 
@@ -129,7 +146,11 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
     expect(definition.role).toContain("helpful ai assistant");
   });
 
-  it("should append rag-memory routing guidance when the skill is enabled", async () => {
+  it("should append rag-memory routing guidance when rag-memory and filesystem tools are both enabled", async () => {
+    mockSystemSettings({
+      default_agent_skills: '["filesystem-agent"]',
+    });
+
     const workspace = { id: 1, openAiPrompt: null };
     const definition = await WORKSPACE_AGENT.getDefinition(
       "openai",
@@ -138,18 +159,33 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
     );
 
     expect(definition.functions).toContain("rag-memory");
+    expect(
+      definition.functions.some((f) => f.startsWith("filesystem-agent#"))
+    ).toBe(true);
     expect(definition.role).toContain("rag-memory");
     expect(definition.role).toContain("vector database");
   });
 
-  it("should not append rag-memory routing guidance when the skill is disabled", async () => {
-    const { SystemSettings } = require("../../../models/systemSettings");
-    SystemSettings.getValueOrFallback = jest
-      .fn()
-      .mockImplementation(async ({ label }, fallback) => {
-        if (label === "disabled_agent_skills") return '["rag-memory"]';
-        return fallback;
-      });
+  it("should not append rag-memory routing guidance when filesystem tools are not enabled", async () => {
+    const workspace = { id: 1, openAiPrompt: null };
+    const definition = await WORKSPACE_AGENT.getDefinition(
+      "openai",
+      workspace,
+      null
+    );
+
+    expect(definition.functions).toContain("rag-memory");
+    expect(
+      definition.functions.some((f) => f.startsWith("filesystem-agent#"))
+    ).toBe(false);
+    expect(definition.role).not.toContain("vector database");
+  });
+
+  it("should not append rag-memory routing guidance when the rag-memory skill is disabled", async () => {
+    mockSystemSettings({
+      disabled_agent_skills: '["rag-memory"]',
+      default_agent_skills: '["filesystem-agent"]',
+    });
 
     const workspace = { id: 1, openAiPrompt: null };
     const definition = await WORKSPACE_AGENT.getDefinition(

--- a/server/__tests__/utils/agents/defaults.test.js
+++ b/server/__tests__/utils/agents/defaults.test.js
@@ -45,7 +45,7 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
       workspace,
       user
     );
-    expect(definition.role).toBe(expectedPrompt);
+    expect(definition.role.startsWith(expectedPrompt)).toBe(true);
     expect(SystemPromptVariables.expandSystemPromptVariables).not.toHaveBeenCalled();
   });
 
@@ -72,7 +72,7 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
       user.id,
       workspace.id
     );
-    expect(definition.role).toBe(expandedPrompt);
+    expect(definition.role.startsWith(expandedPrompt)).toBe(true);
   });
 
   it("should handle workspace system prompt without user context", async () => {
@@ -97,7 +97,7 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
       null,
       workspace.id
     );
-    expect(definition.role).toBe(expandedPrompt);
+    expect(definition.role.startsWith(expandedPrompt)).toBe(true);
   });
 
   it("should return functions array in definition", async () => {
@@ -124,8 +124,42 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
       null
     );
 
-    expect(definition.role).toBe(await Provider.systemPrompt({ provider, workspace, user }));
+    const expectedPrompt = await Provider.systemPrompt({ provider, workspace, user });
+    expect(definition.role.startsWith(expectedPrompt)).toBe(true);
     expect(definition.role).toContain("helpful ai assistant");
+  });
+
+  it("should append rag-memory routing guidance when the skill is enabled", async () => {
+    const workspace = { id: 1, openAiPrompt: null };
+    const definition = await WORKSPACE_AGENT.getDefinition(
+      "openai",
+      workspace,
+      null
+    );
+
+    expect(definition.functions).toContain("rag-memory");
+    expect(definition.role).toContain("rag-memory");
+    expect(definition.role).toContain("vector database");
+  });
+
+  it("should not append rag-memory routing guidance when the skill is disabled", async () => {
+    const { SystemSettings } = require("../../../models/systemSettings");
+    SystemSettings.getValueOrFallback = jest
+      .fn()
+      .mockImplementation(async ({ label }, fallback) => {
+        if (label === "disabled_agent_skills") return '["rag-memory"]';
+        return fallback;
+      });
+
+    const workspace = { id: 1, openAiPrompt: null };
+    const definition = await WORKSPACE_AGENT.getDefinition(
+      "openai",
+      workspace,
+      null
+    );
+
+    expect(definition.functions).not.toContain("rag-memory");
+    expect(definition.role).not.toContain("rag-memory");
   });
 });
 

--- a/server/utils/agents/aibitat/plugins/filesystem/read-text-file.js
+++ b/server/utils/agents/aibitat/plugins/filesystem/read-text-file.js
@@ -17,6 +17,8 @@ module.exports.FilesystemReadTextFile = {
             "IMPORTANT: Only use this tool when you know the exact file path. " +
             "If you don't know where a file is located, use 'filesystem-search-files' first " +
             "to find it (e.g., search for '*.csv' or the filename). " +
+            "Documents embedded in the workspace are NOT on the filesystem — " +
+            "use the 'rag-memory' tool to search those instead. " +
             "Use the 'head' parameter to read only the first N lines, or 'tail' for the last N lines (text files only). " +
             "Only works within allowed directories.",
           examples: [

--- a/server/utils/agents/aibitat/plugins/filesystem/search-files.js
+++ b/server/utils/agents/aibitat/plugins/filesystem/search-files.js
@@ -12,8 +12,11 @@ module.exports.FilesystemSearchFiles = {
           super: aibitat,
           name: this.name,
           description:
-            "Search for files by name or content. USE THIS FIRST when you need to find a file " +
-            "but don't know its exact location. " +
+            "Search the local filesystem for files by name or content. Use this when you need to find a file " +
+            "on disk but don't know its exact location. " +
+            "NOTE: this only sees files in the local sandbox directory. Documents embedded in the workspace " +
+            "are NOT on the filesystem and can only be searched with the 'rag-memory' tool — if a document " +
+            "the user references is not found here, use 'rag-memory' instead. " +
             "Two modes: 'glob' matches file paths/names (e.g., '*.csv', 'config'), " +
             "'content' searches inside files using regex (like grep). " +
             "Set 'includeFileContents: true' to also read and return the full contents of matching files " +

--- a/server/utils/agents/aibitat/plugins/memory.js
+++ b/server/utils/agents/aibitat/plugins/memory.js
@@ -55,6 +55,21 @@ const memory = {
                 content: "I am a robot, the user told me that i am.",
               }),
             },
+            {
+              prompt:
+                "Save this for later: my preferred deploy target is staging.",
+              call: JSON.stringify({
+                action: "store",
+                content: "The user's preferred deploy target is staging.",
+              }),
+            },
+            {
+              prompt: "What did I tell you about my deploy preferences?",
+              call: JSON.stringify({
+                action: "search",
+                content: "user's deploy target preferences",
+              }),
+            },
           ],
           parameters: {
             $schema: "http://json-schema.org/draft-07/schema#",

--- a/server/utils/agents/aibitat/plugins/memory.js
+++ b/server/utils/agents/aibitat/plugins/memory.js
@@ -19,13 +19,26 @@ const memory = {
           tracker: new Deduplicator(),
           name: this.name,
           description:
-            "Search your local documents and workspace files for relevant information, or store information to long-term memory. Use search to find answers in uploaded documents, embedded files, or previously stored memories. Use store only when explicitly asked to remember or save something.",
+            "Search the documents embedded in this workspace, or store information to long-term memory. " +
+            "Embedded workspace documents do NOT exist on the filesystem and cannot be found by any filesystem tool — " +
+            "this is the ONLY tool that can read them. " +
+            "Use search whenever the user references workspace documents, uploaded or embedded files, or previously stored memories, " +
+            "or when a document they mention cannot be found on the local filesystem. " +
+            "Use store only when explicitly asked to remember or save something.",
           examples: [
             {
               prompt: "Check my files for information about the project",
               call: JSON.stringify({
                 action: "search",
                 content: "<project information to search for>",
+              }),
+            },
+            {
+              prompt:
+                "Using the information stored in this workspace, summarize the quarterly report",
+              call: JSON.stringify({
+                action: "search",
+                content: "quarterly report",
               }),
             },
             {

--- a/server/utils/agents/defaults.js
+++ b/server/utils/agents/defaults.js
@@ -84,16 +84,23 @@ const WORKSPACE_AGENT = {
       role +=
         "\n\nWhen you need information from the user (URLs, file paths, preferences, choices, etc.), you MUST use the request-user-input tool. Do not ask questions in your text response - the user cannot reply to text. Only the tool can collect user input.";
 
-    return {
-      role,
-      functions: [
-        ...(await agentSkillsFromSystemSettings()),
-        ...clarifyingQuestionsSkills,
-        ...ImportedPlugin.activeImportedPlugins(),
-        ...AgentFlows.activeFlowPlugins(),
-        ...(await new MCPCompatibilityLayer().activeMCPServers()),
-      ],
-    };
+    const functions = [
+      ...(await agentSkillsFromSystemSettings()),
+      ...clarifyingQuestionsSkills,
+      ...ImportedPlugin.activeImportedPlugins(),
+      ...AgentFlows.activeFlowPlugins(),
+      ...(await new MCPCompatibilityLayer().activeMCPServers()),
+    ];
+
+    // When rag-memory is enabled, add explicit tool-routing guidance so the
+    // agent does not reach for filesystem tools when the user references
+    // workspace documents - embedded documents are not on the filesystem and
+    // are only reachable via the rag-memory tool. See issue #5968.
+    if (functions.includes(AgentPlugins.memory.name))
+      role +=
+        "\n\nDocuments uploaded or embedded into this workspace live in a vector database - NOT on the filesystem. When the user references workspace documents or uploaded files, or a document they mention cannot be found on the local filesystem, use the rag-memory tool to search for it before trying any other tool.";
+
+    return { role, functions };
   },
 };
 

--- a/server/utils/agents/defaults.js
+++ b/server/utils/agents/defaults.js
@@ -92,11 +92,18 @@ const WORKSPACE_AGENT = {
       ...(await new MCPCompatibilityLayer().activeMCPServers()),
     ];
 
-    // When rag-memory is enabled, add explicit tool-routing guidance so the
-    // agent does not reach for filesystem tools when the user references
-    // workspace documents - embedded documents are not on the filesystem and
-    // are only reachable via the rag-memory tool. See issue #5968.
-    if (functions.includes(AgentPlugins.memory.name))
+    // When both rag-memory and filesystem tools are enabled, add explicit
+    // tool-routing guidance so the agent does not reach for filesystem tools
+    // when the user references workspace documents - embedded documents are
+    // not on the filesystem and are only reachable via the rag-memory tool.
+    // Filesystem tools are opt-in, so without them there is no routing
+    // ambiguity and no need to grow the prompt. See issue #5968.
+    const hasFilesystemTools = functions.some(
+      (f) =>
+        typeof f === "string" &&
+        f.startsWith(`${AgentPlugins.filesystemAgent.name}#`)
+    );
+    if (hasFilesystemTools && functions.includes(AgentPlugins.memory.name))
       role +=
         "\n\nDocuments uploaded or embedded into this workspace live in a vector database - NOT on the filesystem. When the user references workspace documents or uploaded files, or a document they mention cannot be found on the local filesystem, use the rag-memory tool to search for it before trying any other tool.";
 


### PR DESCRIPTION

### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [x] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5968

### Description

Agents with both the filesystem and rag-memory skills enabled would often reach for filesystem tools when the user referenced embedded workspace documents, come up empty, and give up — embedded documents live in the vector database, not on disk.

This PR improves tool routing between the filesystem tools and the document tools (`rag-memory`, `document-summarizer`):

- Appends routing guidance to the default agent system prompt (only naming the document tools that are actually enabled) explaining that embedded documents are not on the filesystem.
- Rewrites the `rag-memory` tool description to clarify it searches embedded documents in chunks, and points to `document-summarizer` for full-document summaries.
- Updates `filesystem-search-files`, `filesystem-read-text-file`, `filesystem-read-multiple-files`, and `filesystem-list-directory` descriptions to redirect the agent to the document tools when a referenced document is not found on disk.
- Clarifies the `document-summarizer` description so it is clearly scoped to embedded workspace documents.

Prompt/description changes only — no behavioral logic changed.

### Visuals (if applicable)

N/A

### Additional Information

Added tests covering the conditional system prompt guidance: present when the document skills are enabled, partial when only one is enabled, and absent when both are disabled via `disabled_agent_skills`.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
