### PR TITLE
feat: add BaseRT as first-class LLM, embedder, and agent provider

### DIFF
--- a/frontend/src/components/EmbeddingSelection/BaseRTOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/BaseRTOptions/index.jsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useState } from "react";
+import System from "@/models/system";
+import { BASERT_COMMON_URLS } from "@/utils/constants";
+import {
+  CaretDown,
+  CaretUp,
+  Info,
+  CircleNotch,
+  Warning,
+} from "@phosphor-icons/react";
+import { Tooltip } from "react-tooltip";
+import useProviderEndpointAutoDiscovery from "@/hooks/useProviderEndpointAutoDiscovery";
+
+export default function BaseRTEmbeddingOptions({ settings }) {
+  const {
+    autoDetecting: loading,
+    basePath,
+    basePathValue,
+    authToken,
+    authTokenValue,
+    showAdvancedControls,
+    setShowAdvancedControls,
+    handleAutoDetectClick,
+  } = useProviderEndpointAutoDiscovery({
+    provider: "basert",
+    initialBasePath: settings?.EmbeddingBasePath,
+    ENDPOINTS: BASERT_COMMON_URLS,
+  });
+
+  const [maxChunkLength, setMaxChunkLength] = useState(
+    settings?.EmbeddingModelMaxChunkLength || 8192
+  );
+
+  const handleMaxChunkLengthChange = (e) => {
+    setMaxChunkLength(Number(e.target.value));
+  };
+
+  return (
+    <div className="w-full flex flex-col gap-y-7">
+      <div className="w-full flex items-start gap-[36px] mt-1.5">
+        <BaseRTModelSelection
+          settings={settings}
+          basePath={basePath.value}
+          apiKey={authTokenValue.value}
+        />
+        <div className="flex flex-col w-60">
+          <div
+            data-tooltip-place="top"
+            data-tooltip-id="max-embedding-chunk-length-tooltip"
+            className="flex gap-x-1 items-center mb-3"
+          >
+            <label className="text-white text-sm font-semibold block">
+              Max embedding chunk length
+            </label>
+            <Info
+              size={16}
+              className="text-theme-text-secondary cursor-pointer"
+            />
+            <Tooltip id="max-embedding-chunk-length-tooltip">
+              Maximum length of text chunks, in characters, for embedding.
+            </Tooltip>
+          </div>
+          <input
+            type="number"
+            name="EmbeddingModelMaxChunkLength"
+            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            placeholder="8192"
+            min={1}
+            value={maxChunkLength}
+            onChange={handleMaxChunkLengthChange}
+            onScroll={(e) => e.target.blur()}
+            required={true}
+            autoComplete="off"
+          />
+        </div>
+      </div>
+      <div className="flex justify-start mt-4">
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            setShowAdvancedControls(!showAdvancedControls);
+          }}
+          className="border-none text-theme-text-primary hover:text-theme-text-secondary flex items-center text-sm"
+        >
+          {showAdvancedControls ? "Hide" : "Show"} Manual Endpoint Input
+          {showAdvancedControls ? (
+            <CaretUp size={14} className="ml-1" />
+          ) : (
+            <CaretDown size={14} className="ml-1" />
+          )}
+        </button>
+      </div>
+
+      <div hidden={!showAdvancedControls}>
+        <div className="w-full flex items-start gap-4">
+          <div className="flex flex-col w-[300px]">
+            <div className="flex justify-between items-center mb-2">
+              <div className="flex items-center gap-1">
+                <label className="text-white text-sm font-semibold">
+                  BaseRT Base URL
+                </label>
+                <Info
+                  size={18}
+                  className="text-theme-text-secondary cursor-pointer"
+                  data-tooltip-id="basert-embedding-base-url"
+                  data-tooltip-content="Enter the URL where the BaseRT server is running."
+                />
+                <Tooltip
+                  id="basert-embedding-base-url"
+                  place="top"
+                  delayShow={300}
+                  className="tooltip !text-xs !opacity-100"
+                  style={{
+                    maxWidth: "250px",
+                    whiteSpace: "normal",
+                    wordWrap: "break-word",
+                  }}
+                />
+              </div>
+              {loading ? (
+                <CircleNotch
+                  size={16}
+                  className="text-theme-text-secondary animate-spin"
+                />
+              ) : (
+                <>
+                  {!basePathValue.value && (
+                    <button
+                      onClick={handleAutoDetectClick}
+                      className="border-none bg-primary-button text-xs font-medium px-2 py-1 rounded-lg hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                    >
+                      Auto-Detect
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
+            <input
+              type="url"
+              name="EmbeddingBasePath"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder="http://127.0.0.1:8080"
+              value={basePathValue.value}
+              required={true}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={basePath.onChange}
+              onBlur={basePath.onBlur}
+            />
+          </div>
+          <div className="flex flex-col w-60">
+            <div className="flex items-center mb-2 gap-x-1">
+              <label className="text-white text-sm font-semibold">
+                API Key
+              </label>
+              <Info
+                size={18}
+                className="text-theme-text-secondary cursor-pointer"
+                data-tooltip-id="basert-embedding-api-key"
+              />
+              <Tooltip
+                id="basert-embedding-api-key"
+                place="top"
+                delayShow={300}
+                delayHide={400}
+                clickable={true}
+                className="tooltip !text-xs !opacity-100"
+                style={{
+                  maxWidth: "250px",
+                  whiteSpace: "normal",
+                  wordWrap: "break-word",
+                }}
+              >
+                <p className="text-xs leading-[18px] font-base">
+                  Enter the <code>Bearer</code> API key for your BaseRT server.
+                  Only required when serving with <code>--api-key</code>.
+                </p>
+              </Tooltip>
+            </div>
+            <input
+              type="password"
+              name="BaseRTLLMApiKey"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg outline-none block w-full p-2.5 focus:outline-primary-button active:outline-primary-button"
+              placeholder="BaseRT API Key"
+              defaultValue={settings?.BaseRTLLMApiKey ? "*".repeat(20) : ""}
+              value={authTokenValue.value}
+              onChange={authToken.onChange}
+              onBlur={authToken.onBlur}
+              required={false}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BaseRTModelSelection({ settings, basePath = null, apiKey = null }) {
+  const [customModels, setCustomModels] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function findCustomModels() {
+      if (!basePath) {
+        setCustomModels([]);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      try {
+        const { models } = await System.customModels(
+          "basert",
+          apiKey,
+          basePath
+        );
+        setCustomModels(models || []);
+      } catch (error) {
+        console.error("Failed to fetch custom models:", error);
+        setCustomModels([]);
+      }
+      setLoading(false);
+    }
+    findCustomModels();
+  }, [basePath, apiKey]);
+
+  if (loading || customModels.length == 0) {
+    return (
+      <div className="flex flex-col w-60">
+        <div className="flex items-center mb-2 gap-x-1">
+          <label className="text-white text-sm font-semibold">
+            Embedding Model
+          </label>
+          {!loading && !!basePath && (
+            <>
+              <Warning
+                size={18}
+                className="text-red-400 cursor-pointer"
+                data-tooltip-id="basert-embedding-model"
+              />
+              <Tooltip
+                id="basert-embedding-model"
+                place="top"
+                delayShow={300}
+                delayHide={400}
+                clickable={true}
+                className="tooltip !text-xs !opacity-100"
+                style={{
+                  maxWidth: "250px",
+                  whiteSpace: "normal",
+                  wordWrap: "break-word",
+                }}
+              >
+                <p className="text-xs leading-[18px] font-base">
+                  Could not reach BaseRT. Verify the URL is correct and the
+                  BaseRT server is running and accessible.
+                </p>
+              </Tooltip>
+            </>
+          )}
+        </div>
+        <select
+          name="EmbeddingModelPref"
+          disabled={true}
+          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+        >
+          <option disabled={true} selected={true}>
+            {loading
+              ? "--loading available models--"
+              : !!basePath
+                ? "No models found"
+                : "Enter BaseRT URL first"}
+          </option>
+        </select>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col w-60">
+      <label className="text-white text-sm font-semibold block mb-2">
+        BaseRT Embedding Model
+      </label>
+      <select
+        name="EmbeddingModelPref"
+        required={true}
+        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+      >
+        {customModels.length > 0 && (
+          <optgroup label="Your loaded models">
+            {customModels.map((model) => {
+              return (
+                <option
+                  key={model.id}
+                  value={model.id}
+                  selected={settings.EmbeddingModelPref === model.id}
+                >
+                  {model.id}
+                </option>
+              );
+            })}
+          </optgroup>
+        )}
+      </select>
+      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        Choose the BaseRT model you want to use for generating embeddings.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/LLMSelection/BaseRTOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/BaseRTOptions/index.jsx
@@ -1,0 +1,311 @@
+import useProviderEndpointAutoDiscovery from "@/hooks/useProviderEndpointAutoDiscovery";
+import System from "@/models/system";
+import { BASERT_COMMON_URLS } from "@/utils/constants";
+import { CaretDown, CaretUp, CircleNotch, Info } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { Tooltip } from "react-tooltip";
+
+export default function BaseRTOptions({ settings }) {
+  const {
+    autoDetecting: loading,
+    basePath,
+    basePathValue,
+    authToken,
+    authTokenValue,
+    showAdvancedControls,
+    setShowAdvancedControls,
+    handleAutoDetectClick,
+  } = useProviderEndpointAutoDiscovery({
+    provider: "basert",
+    initialBasePath: settings?.BaseRTLLMBasePath,
+    ENDPOINTS: BASERT_COMMON_URLS,
+  });
+
+  const [contextWindowLimit, setContextWindowLimit] = useState(
+    settings?.BaseRTLLMTokenLimit ?? ""
+  );
+  return (
+    <div className="w-full flex flex-col gap-y-7">
+      <div className="w-full flex items-start gap-[36px] mt-1.5">
+        <BaseRTModelSelection
+          settings={settings}
+          basePath={basePath.value}
+          authToken={authToken.value}
+        />
+      </div>
+      <div className="flex justify-start mt-4">
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            setShowAdvancedControls(!showAdvancedControls);
+          }}
+          className="border-none text-theme-text-primary hover:text-theme-text-secondary flex items-center text-sm"
+        >
+          {showAdvancedControls ? "Hide" : "Show"} advanced settings
+          {showAdvancedControls ? (
+            <CaretUp size={14} className="ml-1" />
+          ) : (
+            <CaretDown size={14} className="ml-1" />
+          )}
+        </button>
+      </div>
+
+      <div hidden={!showAdvancedControls}>
+        <div className="flex flex-col">
+          <div className="w-full flex items-start gap-4 mb-4">
+            <div className="flex flex-col w-60">
+              <div className="flex justify-between items-center mb-2">
+                <div className="flex items-center gap-1">
+                  <label className="text-white text-sm font-semibold">
+                    BaseRT Base URL
+                  </label>
+                  <Info
+                    size={18}
+                    className="text-theme-text-secondary cursor-pointer"
+                    data-tooltip-id="basert-base-url"
+                    data-tooltip-content="Enter the URL where the BaseRT server is running."
+                  />
+                  <Tooltip
+                    id="basert-base-url"
+                    place="top"
+                    delayShow={300}
+                    className="tooltip !text-xs !opacity-100"
+                    style={{
+                      maxWidth: "250px",
+                      whiteSpace: "normal",
+                      wordWrap: "break-word",
+                    }}
+                  />
+                </div>
+                {loading ? (
+                  <CircleNotch
+                    size={16}
+                    className="text-theme-text-secondary animate-spin"
+                  />
+                ) : (
+                  <>
+                    {!basePathValue.value && (
+                      <button
+                        onClick={handleAutoDetectClick}
+                        className="border-none bg-primary-button text-xs font-medium px-2 py-1 rounded-lg hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      >
+                        Auto-Detect
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+              <input
+                type="url"
+                name="BaseRTLLMBasePath"
+                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                placeholder="http://127.0.0.1:8080"
+                value={basePathValue.value}
+                required={true}
+                autoComplete="off"
+                spellCheck={false}
+                onChange={basePath.onChange}
+                onBlur={basePath.onBlur}
+              />
+            </div>
+          </div>
+          <div className="w-full flex items-start gap-4">
+            <div className="flex flex-col w-60">
+              <div className="flex items-center mb-2 gap-x-1">
+                <label className="text-white text-sm font-semibold block">
+                  Model context window
+                </label>
+                <Info
+                  size={18}
+                  className="text-theme-text-secondary cursor-pointer"
+                  data-tooltip-id="basert-model-context-window"
+                />
+                <Tooltip
+                  id="basert-model-context-window"
+                  place="top"
+                  delayShow={300}
+                  delayHide={400}
+                  clickable={true}
+                  className="tooltip !text-xs !opacity-100"
+                  style={{
+                    maxWidth: "250px",
+                    whiteSpace: "normal",
+                    wordWrap: "break-word",
+                  }}
+                >
+                  <p className="text-xs leading-[18px] font-base">
+                    Specify the maximum number of tokens that can be used for
+                    the model context window.
+                    <br /> <br />
+                    If you leave this field blank, the context window limit will
+                    be auto-detected from the model and applied to all chats. If
+                    auto-detection fails, a fallback context window limit of
+                    16000 will be used.
+                    <br /> <br />
+                    <b>Important:</b> Some models have very large context
+                    windows using the full context window limit can dramatically
+                    increase the memory usage of your system. For this reason,
+                    we will automatically cap the context window limit to 16,384
+                    tokens if the model supports more than that and no value is
+                    specified.
+                    <br /> <br />
+                    If an invalid value is entered, AnythingLLM will handle this
+                    for you so that chats do not fail.
+                  </p>
+                </Tooltip>
+              </div>
+              <input
+                type="number"
+                name="BaseRTLLMTokenLimit"
+                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                placeholder="Automatically managed"
+                min={1}
+                value={contextWindowLimit}
+                onChange={(e) =>
+                  setContextWindowLimit(
+                    e.target.value ? Number(e.target.value) : ""
+                  )
+                }
+                onScroll={(e) => e.target.blur()}
+                required={false}
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="flex flex-col w-60">
+              <div className="flex items-center mb-2 gap-x-1">
+                <label className="text-white text-sm font-semibold">
+                  API Key
+                </label>
+                <Info
+                  size={18}
+                  className="text-theme-text-secondary cursor-pointer"
+                  data-tooltip-id="basert-api-key"
+                />
+                <Tooltip
+                  id="basert-api-key"
+                  place="top"
+                  delayShow={300}
+                  delayHide={400}
+                  clickable={true}
+                  className="tooltip !text-xs !opacity-100"
+                  style={{
+                    maxWidth: "250px",
+                    whiteSpace: "normal",
+                    wordWrap: "break-word",
+                  }}
+                >
+                  <p className="text-xs leading-[18px] font-base">
+                    Enter the <code>Bearer</code> API key for your BaseRT
+                    server. Only required when serving with{" "}
+                    <code>--api-key</code>.
+                    <br /> <br />
+                  </p>
+                </Tooltip>
+              </div>
+              <input
+                type="password"
+                name="BaseRTLLMApiKey"
+                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg outline-none block w-full p-2.5 focus:outline-primary-button active:outline-primary-button"
+                placeholder="BaseRT API Key"
+                defaultValue={settings?.BaseRTLLMApiKey ? "*".repeat(20) : ""}
+                value={authTokenValue.value}
+                onChange={authToken.onChange}
+                onBlur={authToken.onBlur}
+                required={false}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BaseRTModelSelection({ settings, basePath = null, authToken = null }) {
+  const [customModels, setCustomModels] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function findCustomModels() {
+      if (!basePath) {
+        setCustomModels([]);
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      try {
+        const { models } = await System.customModels(
+          "basert",
+          authToken,
+          basePath
+        );
+        setCustomModels(models || []);
+      } catch (error) {
+        console.error("Failed to fetch custom models:", error);
+        setCustomModels([]);
+      }
+      setLoading(false);
+    }
+    findCustomModels();
+  }, [basePath, authToken]);
+
+  if (loading || customModels.length === 0) {
+    return (
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-2">
+          BaseRT Model
+        </label>
+        <select
+          name="BaseRTLLMModelPref"
+          disabled={true}
+          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+        >
+          <option disabled={true} selected={true}>
+            {!!basePath
+              ? "--loading available models--"
+              : "Enter BaseRT URL first"}
+          </option>
+        </select>
+        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          Select the BaseRT model you want to use. Models will load after
+          entering a valid BaseRT URL.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col w-60">
+      <label className="text-white text-sm font-semibold block mb-2">
+        BaseRT Model
+      </label>
+      <select
+        name="BaseRTLLMModelPref"
+        required={true}
+        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+      >
+        {customModels.length > 0 && (
+          <optgroup label="Your loaded models">
+            {customModels.map((model) => {
+              return (
+                <option
+                  key={model.id}
+                  value={model.id}
+                  selected={settings.BaseRTLLMModelPref === model.id}
+                >
+                  {model.id}
+                </option>
+              );
+            })}
+          </optgroup>
+        )}
+      </select>
+      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        Choose the BaseRT model you want to use for your conversations.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ProviderPrivacy/constants.js
+++ b/frontend/src/components/ProviderPrivacy/constants.js
@@ -44,6 +44,7 @@ import PrivateModeLogo from "@/media/llmprovider/privatemode.png";
 import SambaNovaLogo from "@/media/llmprovider/sambanova.png";
 import LemonadeLogo from "@/media/llmprovider/lemonade.png";
 import OMLXLogo from "@/media/llmprovider/omlx.png";
+import BaseRTLogo from "@/media/llmprovider/basert.svg";
 import MinimaxLogo from "@/media/llmprovider/minimax.png";
 import CerebrasLogo from "@/media/llmprovider/cerebras.png";
 
@@ -248,6 +249,13 @@ const LLM_PROVIDER_PRIVACY_MAP = {
     ],
     logo: OMLXLogo,
   },
+  basert: {
+    name: "BaseRT",
+    description: [
+      "Your model and chats are only accessible on the machine running the BaseRT server.",
+    ],
+    logo: BaseRTLogo,
+  },
   minimax: {
     name: "Minimax",
     policyUrl: "https://platform.minimax.io/protocol/privacy-policy",
@@ -361,6 +369,13 @@ const EMBEDDING_ENGINE_PROVIDER_PRIVACY_MAP = {
       "Your document text is embedded privately on the server running LMStudio.",
     ],
     logo: LMStudioLogo,
+  },
+  basert: {
+    name: "BaseRT",
+    description: [
+      "Your document text is embedded privately on the machine running the BaseRT server.",
+    ],
+    logo: BaseRTLogo,
   },
   openrouter: {
     name: "OpenRouter",

--- a/frontend/src/media/llmprovider/basert.svg
+++ b/frontend/src/media/llmprovider/basert.svg
@@ -1,0 +1,5 @@
+<svg width="376" height="376" viewBox="0 0 376 376" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="375.57" height="375.57" fill="#E8FFBD"/>
+<rect x="157.397" y="93.1294" width="62.0893" height="59.7897" fill="black"/>
+<rect x="157.397" y="221.621" width="62.0893" height="59.7897" fill="black"/>
+</svg>

--- a/frontend/src/pages/GeneralSettings/EmbeddingPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbeddingPreference/index.jsx
@@ -17,6 +17,7 @@ import GenericOpenAiLogo from "@/media/llmprovider/generic-openai.png";
 import MistralAiLogo from "@/media/llmprovider/mistral.jpeg";
 import OpenRouterLogo from "@/media/llmprovider/openrouter.jpeg";
 import LemonadeLogo from "@/media/llmprovider/lemonade.png";
+import BaseRTLogo from "@/media/llmprovider/basert.svg";
 
 import PreLoader from "@/components/Preloader";
 import ChangeWarningModal from "@/components/ChangeWarning";
@@ -34,6 +35,7 @@ import GenericOpenAiEmbeddingOptions from "@/components/EmbeddingSelection/Gener
 import OpenRouterOptions from "@/components/EmbeddingSelection/OpenRouterOptions";
 import MistralAiOptions from "@/components/EmbeddingSelection/MistralAiOptions";
 import LemonadeOptions from "@/components/EmbeddingSelection/LemonadeOptions";
+import BaseRTEmbeddingOptions from "@/components/EmbeddingSelection/BaseRTOptions";
 
 import EmbedderItem from "@/components/EmbeddingSelection/EmbedderItem";
 import { CaretUpDown, MagnifyingGlass, X } from "@phosphor-icons/react";
@@ -101,6 +103,14 @@ const EMBEDDERS = [
     options: (settings) => <LemonadeOptions settings={settings} />,
     description:
       "Run embedding models locally on your own machine using Lemonade.",
+  },
+  {
+    name: "BaseRT",
+    value: "basert",
+    logo: BaseRTLogo,
+    options: (settings) => <BaseRTEmbeddingOptions settings={settings} />,
+    description:
+      "Run embedding models on Apple Silicon with the BaseRT runtime.",
   },
   {
     name: "OpenRouter",

--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -42,6 +42,7 @@ import LemonadeLogo from "@/media/llmprovider/lemonade.png";
 import MinimaxLogo from "@/media/llmprovider/minimax.png";
 import CerebrasLogo from "@/media/llmprovider/cerebras.png";
 import OMLXLogo from "@/media/llmprovider/omlx.png";
+import BaseRTLogo from "@/media/llmprovider/basert.svg";
 
 import PreLoader from "@/components/Preloader";
 import ModelRouterOptions from "@/components/LLMSelection/ModelRouterOptions";
@@ -86,6 +87,7 @@ import LLMItem from "@/components/LLMSelection/LLMItem";
 import { CaretUpDown, MagnifyingGlass, X } from "@phosphor-icons/react";
 import CTAButton from "@/components/lib/CTAButton";
 import OMLXOptions from "@/components/LLMSelection/OMLXOptions";
+import BaseRTOptions from "@/components/LLMSelection/BaseRTOptions";
 
 export const MODEL_ROUTER_PROVIDER = {
   name: "Model Router",
@@ -414,6 +416,14 @@ export const AVAILABLE_LLM_PROVIDERS = [
     options: (settings) => <OMLXOptions settings={settings} />,
     description: "Run MLX models on Apple Silicon with smart caching.",
     requiredConfig: ["OMLXLLMBasePath"],
+  },
+  {
+    name: "BaseRT",
+    value: "basert",
+    logo: BaseRTLogo,
+    options: (settings) => <BaseRTOptions settings={settings} />,
+    description: "Fastest LLM inference runtime for Apple Silicon.",
+    requiredConfig: ["BaseRTLLMBasePath"],
   },
   {
     name: "Generic OpenAI",

--- a/frontend/src/pages/OnboardingFlow/Steps/LLMPreference/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/LLMPreference/index.jsx
@@ -34,6 +34,7 @@ import PrivateModeLogo from "@/media/llmprovider/privatemode.png";
 import SambaNovaLogo from "@/media/llmprovider/sambanova.png";
 import LemonadeLogo from "@/media/llmprovider/lemonade.png";
 import OMLXLogo from "@/media/llmprovider/omlx.png";
+import BaseRTLogo from "@/media/llmprovider/basert.svg";
 import MinimaxLogo from "@/media/llmprovider/minimax.png";
 import CerebrasLogo from "@/media/llmprovider/cerebras.png";
 
@@ -71,6 +72,7 @@ import PrivateModeOptions from "@/components/LLMSelection/PrivateModeOptions";
 import SambaNovaOptions from "@/components/LLMSelection/SambaNovaOptions";
 import LemonadeOptions from "@/components/LLMSelection/LemonadeOptions";
 import OMLXOptions from "@/components/LLMSelection/OMLXOptions";
+import BaseRTOptions from "@/components/LLMSelection/BaseRTOptions";
 import MinimaxOptions from "@/components/LLMSelection/MinimaxOptions";
 import CerebrasLLMOptions from "@/components/LLMSelection/CerebrasLLMOptions";
 
@@ -154,6 +156,13 @@ const LLMS = [
     logo: OMLXLogo,
     options: (settings) => <OMLXOptions settings={settings} />,
     description: "Run MLX models on Apple Silicon with smart caching.",
+  },
+  {
+    name: "BaseRT",
+    value: "basert",
+    logo: BaseRTLogo,
+    options: (settings) => <BaseRTOptions settings={settings} />,
+    description: "Fastest LLM inference runtime for Apple Silicon.",
   },
   {
     name: "Local AI",

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentLLMSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentLLMSelection/index.jsx
@@ -42,6 +42,7 @@ const ENABLED_PROVIDERS = [
   "sambanova",
   "lemonade",
   "omlx",
+  "basert",
   "minimax",
   "cerebras",
 ];
@@ -52,6 +53,7 @@ const WARN_PERFORMANCE = [
   "localai",
   "textgenwebui",
   "docker-model-runner",
+  "basert",
 ];
 
 const LLM_DEFAULT = {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -74,6 +74,12 @@ export const OMLX_COMMON_URLS = [
   "http://host.docker.internal:8000",
 ];
 
+export const BASERT_COMMON_URLS = [
+  "http://127.0.0.1:8080",
+  "http://localhost:8080",
+  "http://host.docker.internal:8080",
+];
+
 export function fullApiUrl() {
   if (API_BASE !== "/api") return API_BASE;
   return `${window.location.origin}/api`;

--- a/server/.env.example
+++ b/server/.env.example
@@ -32,6 +32,12 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # LMSTUDIO_MODEL_TOKEN_LIMIT=4096
 # LMSTUDIO_AUTH_TOKEN='your-lmstudio-auth-token-here'
 
+# LLM_PROVIDER='basert'
+# BASERT_LLM_BASE_PATH='http://127.0.0.1:8080'
+# BASERT_LLM_MODEL_PREF='Qwen/Qwen3-4B'
+# BASERT_LLM_TOKEN_LIMIT=16384 # (optional, context window is auto-detected from the server when unset)
+# BASERT_LLM_API_KEY='your-basert-api-key-here (optional, only when serving with --api-key)'
+
 # LLM_PROVIDER='localai'
 # LOCAL_AI_BASE_PATH='http://localhost:8080/v1'
 # LOCAL_AI_MODEL_PREF='luna-ai-llama2'
@@ -217,6 +223,11 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # EMBEDDING_ENGINE='lmstudio'
 # EMBEDDING_BASE_PATH='https://localhost:1234/v1'
 # EMBEDDING_MODEL_PREF='nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_0.gguf'
+# EMBEDDING_MODEL_MAX_CHUNK_LENGTH=8192
+
+# EMBEDDING_ENGINE='basert'
+# EMBEDDING_BASE_PATH='http://127.0.0.1:8080'
+# EMBEDDING_MODEL_PREF='your-embedding-model'
 # EMBEDDING_MODEL_MAX_CHUNK_LENGTH=8192
 
 # EMBEDDING_ENGINE='cohere'

--- a/server/endpoints/utils.js
+++ b/server/endpoints/utils.js
@@ -243,6 +243,9 @@ function getModelTag() {
     case "omlx":
       model = process.env.OMLX_LLM_MODEL_PREF;
       break;
+    case "basert":
+      model = process.env.BASERT_LLM_MODEL_PREF;
+      break;
     default:
       model = "--";
       break;

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -1044,6 +1044,12 @@ const SystemSettings = {
       OMLXLLMApiKey: !!process.env.OMLX_LLM_API_KEY,
       OMLXLLMModelPref: process.env.OMLX_LLM_MODEL_PREF,
       OMLXLLMTokenLimit: process.env.OMLX_LLM_TOKEN_LIMIT,
+
+      // BaseRT Keys
+      BaseRTLLMBasePath: process.env.BASERT_LLM_BASE_PATH,
+      BaseRTLLMApiKey: !!process.env.BASERT_LLM_API_KEY,
+      BaseRTLLMModelPref: process.env.BASERT_LLM_MODEL_PREF,
+      BaseRTLLMTokenLimit: process.env.BASERT_LLM_TOKEN_LIMIT,
     };
   },
 

--- a/server/utils/AiProviders/baseRT/index.js
+++ b/server/utils/AiProviders/baseRT/index.js
@@ -1,0 +1,352 @@
+const { NativeEmbedder } = require("../../EmbeddingEngines/native");
+const {
+  handleDefaultStreamResponseV2,
+  formatChatHistory,
+} = require("../../helpers/chat/responses");
+const {
+  LLMPerformanceMonitor,
+} = require("../../helpers/chat/LLMPerformanceMonitor");
+const { OpenAI: OpenAIApi } = require("openai");
+
+/**
+ * BaseRT is an OpenAI-compatible LLM inference runtime for Apple Silicon.
+ * https://docs.basecompute.co
+ */
+class BaseRTLLM {
+  /** @see BaseRTLLM.cacheContextWindows */
+  static modelContextWindows = {};
+
+  constructor(embedder = null, modelPreference = null) {
+    if (!process.env.BASERT_LLM_BASE_PATH)
+      throw new Error("No BaseRT API Base Path was set.");
+
+    this.className = "BaseRTLLM";
+    this.basert = new OpenAIApi({
+      baseURL: parseBaseRTBasePath(process.env.BASERT_LLM_BASE_PATH),
+      apiKey: process.env.BASERT_LLM_API_KEY || null,
+    });
+
+    this.model = modelPreference || process.env.BASERT_LLM_MODEL_PREF;
+    if (!this.model) throw new Error("BaseRT must have a valid model set.");
+
+    this.embedder = embedder ?? new NativeEmbedder();
+    this.defaultTemp = 0.7;
+
+    // Lazy load the limits to avoid blocking the main thread on cacheContextWindows
+    this.limits = null;
+
+    BaseRTLLM.cacheContextWindows(true);
+    this.#log(`initialized with model: ${this.model}`);
+  }
+
+  #log(text, ...args) {
+    console.log(`\x1b[32m[BaseRT]\x1b[0m ${text}`, ...args);
+  }
+
+  static #slog(text, ...args) {
+    console.log(`\x1b[32m[BaseRT]\x1b[0m ${text}`, ...args);
+  }
+
+  async assertModelContextLimits() {
+    if (this.limits !== null) return;
+    await BaseRTLLM.cacheContextWindows();
+    this.limits = {
+      history: this.promptWindowLimit() * 0.15,
+      system: this.promptWindowLimit() * 0.15,
+      user: this.promptWindowLimit() * 0.7,
+    };
+    this.#log(
+      `${this.model} is using a max context window of ${this.promptWindowLimit()} tokens.`
+    );
+  }
+
+  /**
+   * Cache the context windows for the models available on the BaseRT server.
+   * BaseRT reports the effective context window of each model via the
+   * `meta.n_ctx` field on `/v1/models`, so we can discover limits without
+   * the user having to set them manually.
+   * @param {boolean} force - Force the cache to be refreshed.
+   * @returns {Promise<void>} - A promise that resolves when the cache is refreshed.
+   */
+  static async cacheContextWindows(force = false) {
+    try {
+      // Skip if we already have cached context windows and we're not forcing a refresh
+      if (Object.keys(BaseRTLLM.modelContextWindows).length > 0 && !force)
+        return;
+
+      const endpoint = new URL(
+        parseBaseRTBasePath(process.env.BASERT_LLM_BASE_PATH)
+      );
+      endpoint.pathname += "/models";
+      await fetch(endpoint.toString(), {
+        headers: {
+          "Content-Type": "application/json",
+          ...(process.env.BASERT_LLM_API_KEY
+            ? { Authorization: `Bearer ${process.env.BASERT_LLM_API_KEY}` }
+            : {}),
+        },
+      })
+        .then((res) => {
+          if (!res.ok)
+            throw new Error(`BaseRT:cacheContextWindows - ${res.statusText}`);
+          return res.json();
+        })
+        .then(({ data: models }) => {
+          models.forEach((model) => {
+            // A model can omit meta.n_ctx - cache the 16k fallback for it
+            // so it is not later mistaken for a large-context model.
+            if (!model?.meta?.n_ctx)
+              return (BaseRTLLM.modelContextWindows[model.id] = 16000);
+            BaseRTLLM.modelContextWindows[model.id] = Number(model.meta.n_ctx);
+          });
+        })
+        .catch((e) => {
+          BaseRTLLM.#slog(`Error caching context windows`, e);
+          return;
+        });
+
+      BaseRTLLM.#slog(`Context windows cached for all models!`);
+    } catch (e) {
+      BaseRTLLM.#slog(`Error caching context windows`, e);
+      return;
+    }
+  }
+
+  #appendContext(contextTexts = []) {
+    if (!contextTexts || !contextTexts.length) return "";
+    return (
+      "\nContext:\n" +
+      contextTexts
+        .map((text, i) => {
+          return `[CONTEXT ${i}]:\n${text}\n[END CONTEXT ${i}]\n\n`;
+        })
+        .join("")
+    );
+  }
+
+  streamingEnabled() {
+    return "streamGetChatCompletion" in this;
+  }
+
+  static promptWindowLimit(modelName) {
+    if (Object.keys(BaseRTLLM.modelContextWindows).length === 0) {
+      this.#slog(
+        "No context windows cached - Context window may be inaccurately reported."
+      );
+      return Number(process.env.BASERT_LLM_TOKEN_LIMIT) || 16000;
+    }
+
+    let userDefinedLimit = null;
+    const systemDefinedLimit = BaseRTLLM.maxContextWindow(modelName);
+
+    if (
+      process.env.BASERT_LLM_TOKEN_LIMIT &&
+      !isNaN(Number(process.env.BASERT_LLM_TOKEN_LIMIT)) &&
+      Number(process.env.BASERT_LLM_TOKEN_LIMIT) > 0
+    )
+      userDefinedLimit = Number(process.env.BASERT_LLM_TOKEN_LIMIT);
+
+    // The user defined limit is always higher priority than the context window limit, but it cannot be higher than the context window limit
+    // so we return the minimum of the two, if there is no user defined limit, we return the system defined limit as-is.
+    if (userDefinedLimit !== null)
+      return Math.min(userDefinedLimit, systemDefinedLimit);
+
+    // Cap the context window limit to 16,384 tokens if the model supports more than that and no value is specified by the user.
+    // This prevents super-large context windows from being used if the user does not specify a value
+    // as well as also having smaller context windows use the full context window limit.
+    return Math.min(systemDefinedLimit, 16384);
+  }
+
+  promptWindowLimit() {
+    return this.constructor.promptWindowLimit(this.model);
+  }
+
+  static maxContextWindow(modelName = null) {
+    if (Object.keys(BaseRTLLM.modelContextWindows).length === 0 || !modelName)
+      return 16384;
+    return Number(BaseRTLLM.modelContextWindows[modelName]) || 16384;
+  }
+
+  async isValidChatCompletionModel(_ = "") {
+    return true;
+  }
+
+  /**
+   * Generates appropriate content array for a message + attachments.
+   * @param {{userPrompt:string, attachments: import("../../helpers").Attachment[]}}
+   * @returns {string|object[]}
+   */
+  #generateContent({ userPrompt, attachments = [] }) {
+    if (!attachments.length) {
+      return userPrompt;
+    }
+
+    const content = [{ type: "text", text: userPrompt }];
+    for (let attachment of attachments) {
+      content.push({
+        type: "image_url",
+        image_url: {
+          url: attachment.contentString,
+          detail: "auto",
+        },
+      });
+    }
+    return content.flat();
+  }
+
+  /**
+   * Construct the user prompt for this model.
+   * @param {{attachments: import("../../helpers").Attachment[]}} param0
+   * @returns
+   */
+  constructPrompt({
+    systemPrompt = "",
+    contextTexts = [],
+    chatHistory = [],
+    userPrompt = "",
+    attachments = [],
+  }) {
+    const prompt = {
+      role: "system",
+      content: `${systemPrompt}${this.#appendContext(contextTexts)}`,
+    };
+    return [
+      prompt,
+      ...formatChatHistory(chatHistory, this.#generateContent),
+      {
+        role: "user",
+        content: this.#generateContent({ userPrompt, attachments }),
+      },
+    ];
+  }
+
+  /**
+   * Parses and prepends reasoning from the response and returns the full text response.
+   * Used for getChatCompletions to render thinking text if present in full response.
+   * @param {Object} message - The message object from the BaseRT response.
+   * @returns {string}
+   */
+  #parseReasoningFromResponse({ message }) {
+    let textResponse = message?.content ?? "";
+    if (
+      !!message?.reasoning_content &&
+      message.reasoning_content.trim().length > 0
+    )
+      textResponse = `<think>${message.reasoning_content}</think>${textResponse}`;
+    return textResponse;
+  }
+
+  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+    const result = await LLMPerformanceMonitor.measureAsyncFunction(
+      this.basert.chat.completions.create({
+        model: this.model,
+        messages,
+        temperature,
+      })
+    );
+
+    if (
+      !result.output.hasOwnProperty("choices") ||
+      result.output.choices.length === 0
+    )
+      return null;
+
+    return {
+      textResponse: this.#parseReasoningFromResponse(result.output.choices[0]),
+      metrics: {
+        prompt_tokens: result.output.usage?.prompt_tokens || 0,
+        completion_tokens: result.output.usage?.completion_tokens || 0,
+        total_tokens: result.output.usage?.total_tokens || 0,
+        outputTps: result.output.usage?.completion_tokens / result.duration,
+        duration: result.duration,
+        model: this.model,
+        provider: this.className,
+        timestamp: new Date(),
+      },
+    };
+  }
+
+  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+    const measuredStreamRequest = await LLMPerformanceMonitor.measureStream({
+      func: this.basert.chat.completions.create({
+        model: this.model,
+        stream: true,
+        stream_options: { include_usage: true },
+        messages,
+        temperature,
+      }),
+      messages,
+      runPromptTokenCalculation: false,
+      modelTag: this.model,
+      provider: this.className,
+    });
+    return measuredStreamRequest;
+  }
+
+  handleStream(response, stream, responseProps) {
+    return handleDefaultStreamResponseV2(response, stream, responseProps);
+  }
+
+  // Simple wrapper for dynamic embedder & normalize interface for all LLM implementations
+  async embedTextInput(textInput) {
+    return await this.embedder.embedTextInput(textInput);
+  }
+  async embedChunks(textChunks = []) {
+    return await this.embedder.embedChunks(textChunks);
+  }
+
+  async compressMessages(promptArgs = {}, rawHistory = []) {
+    await this.assertModelContextLimits();
+    const { messageArrayCompressor } = require("../../helpers/chat");
+    const messageArray = this.constructPrompt(promptArgs);
+    return await messageArrayCompressor(this, messageArray, rawHistory);
+  }
+
+  async getModelCapabilities() {
+    const capabilities = {
+      reasoning: "unknown",
+      tools: true,
+      vision: false,
+      imageGeneration: false,
+    };
+    try {
+      const { data: models = [] } = await this.basert.models.list();
+      const modelData = models.find((model) => model.id === this.model);
+      if (!modelData) {
+        throw new Error(
+          `Model capabilities for ${this.model} could not be retrieved`
+        );
+      }
+
+      // BaseRT reports the input modalities of a model via the
+      // `architecture.input_modalities` field on `/v1/models`.
+      const inputModalities = modelData?.architecture?.input_modalities || [];
+      capabilities.vision = inputModalities.includes("image");
+    } catch (e) {
+      this.#log(e.message);
+    }
+
+    return capabilities;
+  }
+}
+
+/**
+ * Parse the base path for the BaseRT server. The OpenAI-compatible API is
+ * served under /v1 and the user may paste the URL with or without the /v1
+ * suffix or a trailing slash, so we normalize it here.
+ * @param {string} providedBasePath
+ * @returns {string}
+ */
+function parseBaseRTBasePath(providedBasePath = "") {
+  try {
+    const baseURL = new URL(providedBasePath);
+    return `${baseURL.origin}/v1`;
+  } catch {
+    return providedBasePath;
+  }
+}
+
+module.exports = {
+  BaseRTLLM,
+  parseBaseRTBasePath,
+};

--- a/server/utils/EmbeddingEngines/baseRT/index.js
+++ b/server/utils/EmbeddingEngines/baseRT/index.js
@@ -1,0 +1,119 @@
+const { parseBaseRTBasePath } = require("../../AiProviders/baseRT");
+const {
+  maximumChunkLength,
+  reportEmbeddingProgress,
+} = require("../../helpers");
+
+class BaseRTEmbedder {
+  constructor() {
+    if (!process.env.EMBEDDING_BASE_PATH)
+      throw new Error("No embedding base path was set.");
+    if (!process.env.EMBEDDING_MODEL_PREF)
+      throw new Error("No embedding model was set.");
+
+    this.className = "BaseRTEmbedder";
+    const { OpenAI: OpenAIApi } = require("openai");
+    this.basert = new OpenAIApi({
+      baseURL: parseBaseRTBasePath(process.env.EMBEDDING_BASE_PATH),
+      apiKey: process.env.BASERT_LLM_API_KEY || null,
+    });
+    this.model = process.env.EMBEDDING_MODEL_PREF;
+
+    // Limit of how many strings we can process in a single pass to stay with resource or network limits
+    this.maxConcurrentChunks = 1;
+    this.embeddingMaxChunkLength = maximumChunkLength();
+  }
+
+  log(text, ...args) {
+    console.log(`\x1b[36m[${this.className}]\x1b[0m ${text}`, ...args);
+  }
+
+  async #isAlive() {
+    return await this.basert.models
+      .list()
+      .then((res) => res?.data?.length > 0)
+      .catch((e) => {
+        this.log(e.message);
+        return false;
+      });
+  }
+
+  async embedTextInput(textInput) {
+    const result = await this.embedChunks(
+      Array.isArray(textInput) ? textInput : [textInput]
+    );
+    return result?.[0] || [];
+  }
+
+  async embedChunks(textChunks = []) {
+    if (!(await this.#isAlive()))
+      throw new Error(
+        `BaseRT service could not be reached. Is the BaseRT server running?`
+      );
+
+    this.log(
+      `Embedding ${textChunks.length} chunks of text with ${this.model}.`
+    );
+
+    let results = [];
+    let hasError = false;
+    for (const [idx, chunk] of textChunks.entries()) {
+      if (hasError) break;
+      results.push(
+        await this.basert.embeddings
+          .create({
+            model: this.model,
+            input: chunk,
+            // BaseRT only supports float encoding - the SDK defaults to base64.
+            encoding_format: "float",
+          })
+          .then((result) => {
+            const embedding = result.data?.[0]?.embedding;
+            if (!Array.isArray(embedding) || !embedding.length)
+              throw {
+                type: "EMPTY_ARR",
+                message: "The embedding was empty from BaseRT",
+              };
+            reportEmbeddingProgress(idx + 1, textChunks.length);
+            return { data: embedding, error: null };
+          })
+          .catch((e) => {
+            e.type =
+              e?.response?.data?.error?.code ||
+              e?.response?.status ||
+              "failed_to_embed";
+            e.message = e?.response?.data?.error?.message || e.message;
+            hasError = true;
+            return { data: [], error: e };
+          })
+      );
+    }
+
+    // Accumulate errors from embedding.
+    // If any are present throw an abort error.
+    const errors = results
+      .filter((res) => !!res.error)
+      .map((res) => res.error)
+      .flat();
+
+    if (errors.length > 0) {
+      let uniqueErrors = new Set();
+      console.log(errors);
+      errors.map((error) =>
+        uniqueErrors.add(`[${error.type}]: ${error.message}`)
+      );
+
+      if (errors.length > 0)
+        throw new Error(
+          `BaseRT Failed to embed: ${Array.from(uniqueErrors).join(", ")}`
+        );
+    }
+
+    const data = results.map((res) => res?.data || []);
+    return data.length > 0 ? data : null;
+  }
+}
+
+module.exports = {
+  BaseRTEmbedder,
+};

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -1436,6 +1436,8 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
         return new Providers.LemonadeProvider({ model: config.model });
       case "omlx":
         return new Providers.OMLXProvider({ model: config.model });
+      case "basert":
+        return new Providers.BaseRTProvider({ model: config.model });
       case "minimax":
         return new Providers.MinimaxProvider({ model: config.model });
       case "cerebras":

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -22,6 +22,7 @@ const {
 } = require("../../../AiProviders/dockerModelRunner");
 const { parseFoundryBasePath } = require("../../../AiProviders/foundry");
 const { parseOMLXBasePath } = require("../../../AiProviders/omlx");
+const { parseBaseRTBasePath } = require("../../../AiProviders/baseRT");
 const { AzureOpenAiLLM } = require("../../../AiProviders/azureOpenAi");
 const {
   SystemPromptVariables,
@@ -464,6 +465,14 @@ class Provider {
             baseURL: parseOMLXBasePath(process.env.OMLX_LLM_BASE_PATH),
           },
           apiKey: process.env.OMLX_LLM_API_KEY || null,
+          ...config,
+        });
+      case "basert":
+        return new ChatOpenAI({
+          configuration: {
+            baseURL: parseBaseRTBasePath(process.env.BASERT_LLM_BASE_PATH),
+          },
+          apiKey: process.env.BASERT_LLM_API_KEY || null,
           ...config,
         });
       default:

--- a/server/utils/agents/aibitat/providers/basert.js
+++ b/server/utils/agents/aibitat/providers/basert.js
@@ -1,0 +1,171 @@
+const OpenAI = require("openai");
+const Provider = require("./ai-provider.js");
+const InheritMultiple = require("./helpers/classes.js");
+const UnTooled = require("./helpers/untooled.js");
+const { tooledStream, tooledComplete } = require("./helpers/tooled.js");
+const { RetryError } = require("../error.js");
+const { parseBaseRTBasePath } = require("../../../AiProviders/baseRT/index.js");
+
+/**
+ * The agent provider for BaseRT.
+ * BaseRT is OpenAI-compatible and supports native tool calling, falling back
+ * to the UnTooled prompt-based approach when disabled via env.
+ */
+class BaseRTProvider extends InheritMultiple([Provider, UnTooled]) {
+  model;
+
+  /**
+   * @param {{model?: string}} config
+   */
+  constructor(config = {}) {
+    super();
+    this.providerTag = "basert";
+    const model = config?.model || process.env.BASERT_LLM_MODEL_PREF;
+    if (!model) throw new Error("BaseRT must have a valid model set.");
+
+    const client = new OpenAI({
+      baseURL: parseBaseRTBasePath(process.env.BASERT_LLM_BASE_PATH),
+      apiKey: process.env.BASERT_LLM_API_KEY || null,
+    });
+
+    this._client = client;
+    this.model = model;
+    this.verbose = true;
+  }
+
+  get client() {
+    return this._client;
+  }
+
+  get supportsAgentStreaming() {
+    return true;
+  }
+
+  async #handleFunctionCallChat({ messages = [] }) {
+    return await this.client.chat.completions
+      .create({
+        model: this.model,
+        messages,
+      })
+      .then((result) => {
+        if (!result.hasOwnProperty("choices"))
+          throw new Error("BaseRT chat: No results!");
+        if (result.choices.length === 0)
+          throw new Error("BaseRT chat: No results length!");
+        return result.choices[0].message.content;
+      })
+      .catch((_) => {
+        return null;
+      });
+  }
+
+  async #handleFunctionCallStream({ messages = [] }) {
+    return await this.client.chat.completions.create({
+      model: this.model,
+      stream: true,
+      messages,
+    });
+  }
+
+  /**
+   * Stream a chat completion with tool calling support.
+   * Uses native tool calling when supported, otherwise falls back to UnTooled.
+   */
+  async stream(messages, functions = [], eventHandler = null) {
+    const useNative =
+      functions.length > 0 && (await this.supportsNativeToolCalling());
+
+    if (!useNative) {
+      return await UnTooled.prototype.stream.call(
+        this,
+        messages,
+        functions,
+        this.#handleFunctionCallStream.bind(this),
+        eventHandler
+      );
+    }
+
+    this.providerLog(
+      "Provider.stream (tooled) - will process this chat completion."
+    );
+
+    try {
+      return await tooledStream(
+        this.client,
+        this.model,
+        messages,
+        functions,
+        eventHandler,
+        { provider: this }
+      );
+    } catch (error) {
+      console.error(error.message, error);
+      if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (
+        error instanceof OpenAI.RateLimitError ||
+        error instanceof OpenAI.InternalServerError ||
+        error instanceof OpenAI.APIError
+      ) {
+        throw new RetryError(error.message);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Create a non-streaming completion with tool calling support.
+   * Uses native tool calling when supported, otherwise falls back to UnTooled.
+   */
+  async complete(messages, functions = []) {
+    const useNative =
+      functions.length > 0 && (await this.supportsNativeToolCalling());
+
+    if (!useNative) {
+      return await UnTooled.prototype.complete.call(
+        this,
+        messages,
+        functions,
+        this.#handleFunctionCallChat.bind(this)
+      );
+    }
+
+    try {
+      const result = await tooledComplete(
+        this.client,
+        this.model,
+        messages,
+        functions,
+        this.getCost.bind(this),
+        { provider: this }
+      );
+
+      if (result.retryWithError) {
+        return this.complete([...messages, result.retryWithError], functions);
+      }
+
+      return result;
+    } catch (error) {
+      if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (
+        error instanceof OpenAI.RateLimitError ||
+        error instanceof OpenAI.InternalServerError ||
+        error instanceof OpenAI.APIError
+      ) {
+        throw new RetryError(error.message);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get the cost of the completion.
+   * Stubbed since BaseRT has no cost basis.
+   * @param _usage The completion to get the cost for.
+   * @returns The cost of the completion.
+   */
+  getCost(_usage) {
+    return 0;
+  }
+}
+
+module.exports = BaseRTProvider;

--- a/server/utils/agents/aibitat/providers/index.js
+++ b/server/utils/agents/aibitat/providers/index.js
@@ -33,6 +33,7 @@ const PrivatemodeProvider = require("./privatemode.js");
 const SambaNovaProvider = require("./sambanova.js");
 const LemonadeProvider = require("./lemonade.js");
 const OMLXProvider = require("./omlx.js");
+const BaseRTProvider = require("./basert.js");
 const MinimaxProvider = require("./minimax.js");
 const CerebrasProvider = require("./cerebras.js");
 
@@ -72,6 +73,7 @@ module.exports = {
   SambaNovaProvider,
   LemonadeProvider,
   OMLXProvider,
+  BaseRTProvider,
   MinimaxProvider,
   CerebrasProvider,
 };

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -278,6 +278,10 @@ class AgentHandler {
         if (!process.env.OMLX_LLM_BASE_PATH)
           throw new Error("OMLX base path must be provided to use agents.");
         break;
+      case "basert":
+        if (!process.env.BASERT_LLM_BASE_PATH)
+          throw new Error("BaseRT base path must be provided to use agents.");
+        break;
       case "minimax":
         if (!process.env.MINIMAX_API_KEY)
           throw new Error("Minimax API key must be provided to use agents.");
@@ -376,6 +380,8 @@ class AgentHandler {
         return process.env.LEMONADE_LLM_MODEL_PREF ?? null;
       case "omlx":
         return process.env.OMLX_LLM_MODEL_PREF ?? null;
+      case "basert":
+        return process.env.BASERT_LLM_MODEL_PREF ?? null;
       case "minimax":
         return process.env.MINIMAX_MODEL_PREF ?? "MiniMax-M2.7";
       case "cerebras":

--- a/server/utils/boot/eagerLoadContextWindows.js
+++ b/server/utils/boot/eagerLoadContextWindows.js
@@ -39,6 +39,11 @@ async function eagerLoadContextWindows() {
       await OMLXLLM.cacheContextWindows(true);
       log("OMLX");
       break;
+    case "basert":
+      const { BaseRTLLM } = require("../AiProviders/baseRT");
+      await BaseRTLLM.cacheContextWindows(true);
+      log("BaseRT");
+      break;
   }
 }
 

--- a/server/utils/helpers/customModels.js
+++ b/server/utils/helpers/customModels.js
@@ -51,6 +51,7 @@ const SUPPORT_CUSTOM_MODELS = [
   "minimax",
   "cerebras",
   "omlx",
+  "basert",
   "bedrock",
   "generic-openai",
   // Embedding Engines
@@ -153,6 +154,8 @@ async function getCustomModels(
       return await getLemonadeModels(basePath, "embedding");
     case "omlx":
       return await getOMLXModels(basePath, apiKey);
+    case "basert":
+      return await getBaseRTModels(basePath, apiKey);
     case "minimax":
       return await getMinimaxModels(apiKey);
     case "cerebras":
@@ -1081,6 +1084,38 @@ async function getOMLXModels(basePath = null, _apiKey = null) {
   } catch (e) {
     console.error("OMLX:getOMLXModels", e.message);
     return { models: [], error: "Could not fetch OMLX models" };
+  }
+}
+
+async function getBaseRTModels(basePath = null, _apiKey = null) {
+  const { OpenAI } = require("openai");
+  const { parseBaseRTBasePath } = require("../AiProviders/baseRT");
+  try {
+    const apiKey =
+      _apiKey === true
+        ? process.env.BASERT_LLM_API_KEY
+        : _apiKey || process.env.BASERT_LLM_API_KEY || null;
+
+    const client = new OpenAI({
+      baseURL: parseBaseRTBasePath(
+        basePath ?? process.env.BASERT_LLM_BASE_PATH
+      ),
+      apiKey,
+    });
+
+    const models = (await client.models.list()).data.map((model) => ({
+      id: model.id,
+      name: model.id,
+      organization: model.owned_by,
+    }));
+
+    return {
+      models,
+      error: null,
+    };
+  } catch (e) {
+    console.error("BaseRT:getBaseRTModels", e.message);
+    return { models: [], error: "Could not fetch BaseRT models" };
   }
 }
 

--- a/server/utils/helpers/index.js
+++ b/server/utils/helpers/index.js
@@ -245,6 +245,9 @@ function getLLMProvider({ provider = null, model = null } = {}) {
     case "omlx":
       const { OMLXLLM } = require("../AiProviders/omlx");
       return new OMLXLLM(embedder, model);
+    case "basert":
+      const { BaseRTLLM } = require("../AiProviders/baseRT");
+      return new BaseRTLLM(embedder, model);
     case "minimax":
       const { MinimaxLLM } = require("../AiProviders/minimax");
       return new MinimaxLLM(embedder, model);
@@ -291,6 +294,9 @@ function getEmbeddingEngineSelection() {
     case "lmstudio":
       const { LMStudioEmbedder } = require("../EmbeddingEngines/lmstudio");
       return new LMStudioEmbedder();
+    case "basert":
+      const { BaseRTEmbedder } = require("../EmbeddingEngines/baseRT");
+      return new BaseRTEmbedder();
     case "cohere":
       const { CohereEmbedder } = require("../EmbeddingEngines/cohere");
       return new CohereEmbedder();
@@ -436,6 +442,9 @@ function getLLMProviderClass({ provider = null } = {}) {
     case "omlx":
       const { OMLXLLM } = require("../AiProviders/omlx");
       return OMLXLLM;
+    case "basert":
+      const { BaseRTLLM } = require("../AiProviders/baseRT");
+      return BaseRTLLM;
     case "minimax":
       const { MinimaxLLM } = require("../AiProviders/minimax");
       return MinimaxLLM;
@@ -527,6 +536,8 @@ function getBaseLLMProviderModel({ provider = null } = {}) {
       return process.env.LEMONADE_LLM_MODEL_PREF;
     case "omlx":
       return process.env.OMLX_LLM_MODEL_PREF;
+    case "basert":
+      return process.env.BASERT_LLM_MODEL_PREF;
     case "minimax":
       return process.env.MINIMAX_MODEL_PREF;
     case "cerebras":

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -940,6 +940,24 @@ const KEY_MAPPING = {
     checks: [],
   },
 
+  // BaseRT Options
+  BaseRTLLMBasePath: {
+    envKey: "BASERT_LLM_BASE_PATH",
+    checks: [isValidURL],
+  },
+  BaseRTLLMApiKey: {
+    envKey: "BASERT_LLM_API_KEY",
+    checks: [],
+  },
+  BaseRTLLMModelPref: {
+    envKey: "BASERT_LLM_MODEL_PREF",
+    checks: [isNotEmpty],
+  },
+  BaseRTLLMTokenLimit: {
+    envKey: "BASERT_LLM_TOKEN_LIMIT",
+    checks: [],
+  },
+
   // Agent Skill Settings
   AgentSkillMaxToolCalls: {
     envKey: "AGENT_MAX_TOOL_CALLS",
@@ -1084,6 +1102,7 @@ function supportedLLM(input = "") {
     "minimax",
     "cerebras",
     "omlx",
+    "basert",
     "anythingllm-router",
   ].includes(input);
   return validSelection ? null : `${input} is not a valid LLM provider.`;
@@ -1124,6 +1143,7 @@ function supportedEmbeddingModel(input = "") {
     "mistral",
     "openrouter",
     "lemonade",
+    "basert",
   ];
   return supported.includes(input)
     ? null


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

None

### Description

Adds [BaseRT](https://github.com/basecompute/baseRT), a local LLM inference
runtime for Apple Silicon as a first-class provider for LLM chat, embeddings,
and agents.

**Why BaseRT?**

BaseRT is an open (Apache-2.0 CLI, format, and bindings) inference runtime
built directly on Apple's Metal API with no intermediate framework, developed
by [Base Compute](https://basecompute.co) and described in a peer-reviewable
paper ([arXiv:2607.00501](https://arxiv.org/abs/2607.00501)). Its published
benchmarks report the highest LLM inference throughput measured on Apple
Silicon to date: up to 1.56x the decode throughput of llama.cpp and 1.35x of
MLX on M3/M4-class hardware, across Qwen3, Llama 3.2, and Gemma 4 families at
Q4/Q8 quantization.

On the new M5 generation the gap widens considerably. A follow-up technical
report ([BaseRT on M5](https://www.basecompute.co/BaseRT_M5.pdf)) shows BaseRT
driving the M5's per-core GPU Neural Accelerators through hand-written Metal 4
tensor kernels, reaching up to **6.4× the prompt-processing (prefill)
throughput of llama.cpp and 3.9x of MLX** on an M5 Pro across fifteen model
configurations (sub-1B to 35B, dense and MoE), while holding a smaller decode
lead (up to 1.75x / 1.33x) since decode is memory-bandwidth-bound for every
runtime.

The prefill numbers are what make this directly relevant to AnythingLLM:
RAG-style chats send long prompts (system prompt + retrieved context chunks +
history), so time-to-first-token is dominated by prompt processing, exactly
the phase where BaseRT's advantage is largest. For users running AnythingLLM
fully locally on a Mac, that translates into noticeably lower first-token
latency on document-heavy workspaces compared to the existing llama.cpp- and
MLX-based options. It also fits AnythingLLM's local-first lineup (Ollama,
LM Studio, oMLX, LocalAI) with the same privacy properties: models and chats
never leave the machine.

Practically, BaseRT ships a single CLI (`basert pull` / `serve`) that pulls
models from HuggingFace and serves an OpenAI-compatible API with native tool
calling, embeddings, and multi-model serving -- everything this integration
consumes.

**What this PR adds**

- **LLM provider** (`server/utils/AiProviders/baseRT`) - chat + SSE streaming
  with exact token metrics (BaseRT emits `usage` in the final stream chunk);
  per-model context windows auto-detected from `meta.n_ctx` on `GET /v1/models`
  and cached at boot (same pattern as oMLX/LM Studio), with optional user
  override and a 16,384-token default cap; vision capability read from the
  model's `architecture.input_modalities`.
- **Embedding engine** (`server/utils/EmbeddingEngines/baseRT`) - sequential
  chunk embedding via `/v1/embeddings`; explicitly requests
  `encoding_format: "float"` since BaseRT rejects the OpenAI SDK's base64
  default.
- **Agent provider** (`server/utils/agents/aibitat/providers/basert.js`) -
  native OpenAI tool calling by default (verified working), with the standard
  UnTooled fallback via `PROVIDER_DISABLE_NATIVE_TOOL_CALLING`.
- **Frontend** - provider entries in LLM Preference, Embedding Preference,
  onboarding, agent LLM selection, and the privacy table; endpoint
  auto-discovery on port 8080 (BaseRT's default); live model dropdown from
  `/v1/models`; optional Bearer API key for servers started with `--api-key`.

New ENV vars (documented in `server/.env.example`): `BASERT_LLM_BASE_PATH`,
`BASERT_LLM_MODEL_PREF`, `BASERT_LLM_TOKEN_LIMIT`, `BASERT_LLM_API_KEY`.

### Visuals (if applicable)

<img width="784" height="826" alt="Screenshot 2026-07-22 at 5 18 28 pm" src="https://github.com/user-attachments/assets/0f2b9a02-5a81-4575-bc50-2b61f2a059dc" />

### Additional Information

Tested end-to-end against a live `basert serve` instance (two models loaded):
model listing, context-window auto-detection (40960 reported, capped to 16384
by default), non-streaming and streaming chat with usage metrics, native tool
calling through the agent provider, embeddings, and the settings UI
(auto-detect + model dropdown) in the running app.

Implementation follows the existing oMLX provider pattern throughout, so all
touchpoints (env validation, custom model listing, eager context-window
caching, agent wiring) mirror established conventions.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally