### PR TITLE
Fix slash command presets not expanding into prompt text

### DIFF
--- a/server/__tests__/utils/chats/index.test.js
+++ b/server/__tests__/utils/chats/index.test.js
@@ -1,0 +1,98 @@
+/* eslint-env jest, node */
+const { grepCommand, grepAllSlashCommands } = require("../../../utils/chats");
+const { SlashCommandPresets } = require("../../../models/slashCommandsPresets");
+
+jest.mock("../../../models/slashCommandsPresets");
+
+// Helper to shape preset rows the way the model returns them.
+const preset = (command, prompt) => ({ command, prompt });
+
+describe("grepCommand", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the built-in command when the message starts with it", async () => {
+    SlashCommandPresets.getUserPresets.mockResolvedValue([]);
+    expect(await grepCommand("/reset")).toBe("/reset");
+    expect(await grepCommand("/RESET now")).toBe("/reset"); // case-insensitive
+  });
+
+  it("returns the message unchanged when no command matches", async () => {
+    SlashCommandPresets.getUserPresets.mockResolvedValue([]);
+    expect(await grepCommand("hello there")).toBe("hello there");
+  });
+
+  describe("preset expansion", () => {
+    beforeEach(() => {
+      SlashCommandPresets.getUserPresets.mockResolvedValue([
+        preset("/weather", "what is the weather?"),
+      ]);
+    });
+
+    it("expands a command at the start of the message", async () => {
+      expect(await grepCommand("/weather")).toBe("what is the weather?");
+    });
+
+    it("expands a command that follows other text and a space", async () => {
+      expect(await grepCommand("ok, /weather")).toBe("ok, what is the weather?");
+    });
+
+    it("expands a command with trailing punctuation", async () => {
+      expect(await grepCommand("/weather?")).toBe("what is the weather??");
+    });
+
+    it("does not expand a command that is part of a longer word", async () => {
+      expect(await grepCommand("/weatherman")).toBe("/weatherman");
+    });
+
+    it("does not expand a command glued to the end of a word", async () => {
+      expect(await grepCommand("foo/weather")).toBe("foo/weather");
+    });
+  });
+
+  it("expands multiple presets in a single message", async () => {
+    SlashCommandPresets.getUserPresets.mockResolvedValue([
+      preset("/weather", "the weather"),
+      preset("/time", "the time"),
+    ]);
+    expect(await grepCommand("/weather and /time")).toBe(
+      "the weather and the time"
+    );
+  });
+
+  it("scopes preset lookup to the passed user", async () => {
+    SlashCommandPresets.getUserPresets.mockResolvedValue([]);
+    await grepCommand("hi", { id: 42 });
+    expect(SlashCommandPresets.getUserPresets).toHaveBeenCalledWith(42);
+  });
+});
+
+describe("grepAllSlashCommands", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("expands presets regardless of user (not scoped)", async () => {
+    SlashCommandPresets.where.mockResolvedValue([
+      preset("/weather", "what is the weather?"),
+    ]);
+    expect(await grepAllSlashCommands("ok, /weather?")).toBe(
+      "ok, what is the weather??"
+    );
+    expect(SlashCommandPresets.where).toHaveBeenCalledWith({});
+  });
+
+  it("does not expand a command that is part of a longer word", async () => {
+    SlashCommandPresets.where.mockResolvedValue([
+      preset("/weather", "what is the weather?"),
+    ]);
+    expect(await grepAllSlashCommands("/weatherman")).toBe("/weatherman");
+  });
+
+  it("expands multiple presets in a single message", async () => {
+    SlashCommandPresets.where.mockResolvedValue([
+      preset("/weather", "the weather"),
+      preset("/time", "the time"),
+    ]);
+    expect(await grepAllSlashCommands("/weather and /time")).toBe(
+      "the weather and the time"
+    );
+  });
+});

--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -26,11 +26,14 @@ async function grepCommand(message, user = null) {
   // Allows multiple commands in one message
   let updatedMessage = message;
   for (const preset of userPresets) {
-    const regex = new RegExp(
-      `(?:\\b\\s|^)(${preset.command})(?:\\b\\s|$)`,
-      "g"
+    // Match the command when it starts the message or follows a space (`lead`),
+    // and is not part of a longer command (e.g. don't match /weather in /weatherman).
+    // `lead` is captured so we can keep the space when swapping in the prompt.
+    const regex = new RegExp(`(^|\\s)(${preset.command})(?![a-z0-9_-])`, "g");
+    updatedMessage = updatedMessage.replace(
+      regex,
+      (_match, lead) => `${lead}${preset.prompt}`
     );
-    updatedMessage = updatedMessage.replace(regex, preset.prompt);
   }
 
   return updatedMessage;
@@ -48,11 +51,14 @@ async function grepAllSlashCommands(message) {
   // Allows multiple commands in one message
   let updatedMessage = message;
   for (const preset of allPresets) {
-    const regex = new RegExp(
-      `(?:\\b\\s|^)(${preset.command})(?:\\b\\s|$)`,
-      "g"
+    // Match the command when it starts the message or follows a space (`lead`),
+    // and is not part of a longer command (e.g. don't match /weather in /weatherman).
+    // `lead` is captured so we can keep the space when swapping in the prompt.
+    const regex = new RegExp(`(^|\\s)(${preset.command})(?![a-z0-9_-])`, "g");
+    updatedMessage = updatedMessage.replace(
+      regex,
+      (_match, lead) => `${lead}${preset.prompt}`
     );
-    updatedMessage = updatedMessage.replace(regex, preset.prompt);
   }
 
   return updatedMessage;


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #6036 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->
- Some users noticed their slash command (like `/weather`) would show up as-is in the chat instead of being replaced with its prompt
- This happened when the command wasn't at the very start of the message, or had punctuation around it (`ok, /weather`, `/weather?`)
- Fixed the matching so command expands in all cases, while still not matching inside a longer word (`/weather` in `/weatherman`)

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
