### PR TITLE
fix(generic-openai): send audio attachments as input_audio content

### DIFF
--- a/server/__tests__/utils/AiProviders/genericOpenAi.test.js
+++ b/server/__tests__/utils/AiProviders/genericOpenAi.test.js
@@ -1,0 +1,126 @@
+/* eslint-env jest, node */
+
+describe("GenericOpenAiLLM attachment content generation", () => {
+  let GenericOpenAiLLM;
+
+  beforeAll(() => {
+    process.env.GENERIC_OPEN_AI_BASE_PATH = "http://127.0.0.1:1234/v1";
+    process.env.GENERIC_OPEN_AI_MODEL_PREF = "test-model";
+    ({
+      GenericOpenAiLLM,
+    } = require("../../../utils/AiProviders/genericOpenAi"));
+  });
+
+  const lastMessage = (messages) => messages[messages.length - 1];
+  const newLLM = () => new GenericOpenAiLLM({}, "test-model");
+
+  it("returns the plain prompt string when there are no attachments", () => {
+    const messages = newLLM().constructPrompt({ userPrompt: "hello" });
+    expect(lastMessage(messages).content).toBe("hello");
+  });
+
+  it("sends image attachments as image_url content", () => {
+    const messages = newLLM().constructPrompt({
+      userPrompt: "describe this",
+      attachments: [
+        {
+          name: "photo.png",
+          mime: "image/png",
+          contentString: "data:image/png;base64,aW1hZ2U=",
+        },
+      ],
+    });
+    expect(lastMessage(messages).content).toEqual([
+      { type: "text", text: "describe this" },
+      {
+        type: "image_url",
+        image_url: { url: "data:image/png;base64,aW1hZ2U=", detail: "high" },
+      },
+    ]);
+  });
+
+  it("sends audio attachments as input_audio without the data uri prefix", () => {
+    const messages = newLLM().constructPrompt({
+      userPrompt: "transcribe this",
+      attachments: [
+        {
+          name: "clip.mp3",
+          mime: "audio/mpeg",
+          contentString: "data:audio/mpeg;base64,QUJDRA==",
+        },
+      ],
+    });
+    expect(lastMessage(messages).content).toEqual([
+      { type: "text", text: "transcribe this" },
+      { type: "input_audio", input_audio: { data: "QUJDRA==", format: "mp3" } },
+    ]);
+  });
+
+  it("maps wav mime variants to the wav format", () => {
+    for (const mime of ["audio/wav", "audio/x-wav", "audio/wave"]) {
+      const messages = newLLM().constructPrompt({
+        userPrompt: "listen",
+        attachments: [
+          { name: "clip.wav", mime, contentString: "data:" + mime + ";base64,UklGRg==" },
+        ],
+      });
+      expect(lastMessage(messages).content[1]).toEqual({
+        type: "input_audio",
+        input_audio: { data: "UklGRg==", format: "wav" },
+      });
+    }
+  });
+
+  it("passes through other audio subtypes as the format", () => {
+    const messages = newLLM().constructPrompt({
+      userPrompt: "listen",
+      attachments: [
+        {
+          name: "clip.ogg",
+          mime: "audio/ogg",
+          contentString: "data:audio/ogg;base64,T2dnUw==",
+        },
+      ],
+    });
+    expect(lastMessage(messages).content[1]).toEqual({
+      type: "input_audio",
+      input_audio: { data: "T2dnUw==", format: "ogg" },
+    });
+  });
+
+  it("keeps mixed image and audio attachments in order", () => {
+    const messages = newLLM().constructPrompt({
+      userPrompt: "both",
+      attachments: [
+        {
+          name: "photo.jpg",
+          mime: "image/jpeg",
+          contentString: "data:image/jpeg;base64,aW1n",
+        },
+        {
+          name: "clip.mp3",
+          mime: "audio/mp3",
+          contentString: "data:audio/mp3;base64,c25k",
+        },
+      ],
+    });
+    expect(lastMessage(messages).content).toEqual([
+      { type: "text", text: "both" },
+      {
+        type: "image_url",
+        image_url: { url: "data:image/jpeg;base64,aW1n", detail: "high" },
+      },
+      { type: "input_audio", input_audio: { data: "c25k", format: "mp3" } },
+    ]);
+  });
+
+  it("uses the raw content string when no data uri prefix is present", () => {
+    const messages = newLLM().constructPrompt({
+      userPrompt: "raw",
+      attachments: [
+        { name: "clip.mp3", mime: "audio/mpeg", contentString: "QUJDRA==" },
+      ],
+    });
+    expect(lastMessage(messages).content[1].input_audio.data).toBe("QUJDRA==");
+  });
+});

--- a/server/utils/AiProviders/genericOpenAi/index.js
+++ b/server/utils/AiProviders/genericOpenAi/index.js
@@ -122,6 +122,7 @@ class GenericOpenAiLLM {
    * This function assumes the generic OpenAI provider is _actually_ OpenAI compatible.
    * For example, Ollama is "OpenAI compatible" but does not support images as a content array.
    * The contentString also is the base64 string WITH `data:image/xxx;base64,` prefix, which may not be the case for all providers.
+   * Attachments with an `audio/*` mime are sent as `input_audio` content blocks with the raw base64 payload and a `format` key, per the OpenAI audio schema.
    * If your provider does not work exactly this way, then attachments will not function or potentially break vision requests.
    * If you encounter this issue, you are welcome to open an issue asking for your specific provider to be supported.
    *
@@ -139,6 +140,17 @@ class GenericOpenAiLLM {
 
     const content = [{ type: "text", text: userPrompt }];
     for (let attachment of attachments) {
+      if (attachment.mime?.startsWith("audio/")) {
+        content.push({
+          type: "input_audio",
+          input_audio: {
+            data: attachment.contentString.split("base64,").pop(),
+            format: this.#audioFormat(attachment.mime),
+          },
+        });
+        continue;
+      }
+
       content.push({
         type: "image_url",
         image_url: {
@@ -148,6 +160,26 @@ class GenericOpenAiLLM {
       });
     }
     return content.flat();
+  }
+
+  /**
+   * Maps an audio mime type to the `format` value expected by the OpenAI
+   * `input_audio` content schema (e.g. `audio/mpeg` -> `mp3`).
+   * @param {string} mime
+   * @returns {string}
+   */
+  #audioFormat(mime) {
+    const subtype = mime.split("/").pop().toLowerCase();
+    switch (subtype) {
+      case "mpeg":
+      case "mp3":
+        return "mp3";
+      case "x-wav":
+      case "wave":
+        return "wav";
+      default:
+        return subtype.replace(/^x-/, "");
+    }
   }
 
   /**


### PR DESCRIPTION
resolves #6025

### What kind of change does this PR introduce?

- [x] Bug fix

### Description

The GenericOpenAi provider wrapped every attachment in an `image_url` block, including audio files, so OpenAI compatible backends with audio support rejected the request with `Invalid uri format`.

Attachments with an `audio/*` mime are now sent as `input_audio` content blocks per the OpenAI audio schema: the data uri prefix is stripped and a `format` key is derived from the mime type (`audio/mpeg` and `audio/mp3` map to `mp3`, wav variants map to `wav`, other subtypes pass through for permissive backends such as llama.cpp). Image attachments keep the existing `image_url` behavior, including in chat history, since both flow through the same helper.

### Developer validations

- [x] I ran `yarn lint` from the root of the repo and committed changes
- [x] Relevant documentation has been updated (JSDoc note in the provider; no public API change)
- [x] I have tested my code functionality (new jest suite `server/__tests__/utils/AiProviders/genericOpenAi.test.js`, 7 tests with no mocks through the public `constructPrompt`; they fail without the fix and pass with it; full repo suite passes with 29 suites and 244 tests)
- [ ] Docker build succeeds locally (no Docker available on this machine)
