### PR TITLE
Redirect to neighboring thread on active thread delete

### DIFF
--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
@@ -24,7 +24,7 @@ export default function ThreadItem({
   hasNext,
   ctrlPressed = false,
 }) {
-  const { slug: urlSlug, threadSlug = null } = useParams();
+  const { slug: urlSlug } = useParams();
   const workspaceSlug = workspace?.slug ?? urlSlug;
   const optionsContainer = useRef(null);
   const [showOptions, setShowOptions] = useState(false);
@@ -153,7 +153,6 @@ export default function ThreadItem({
                 thread={thread}
                 onRemove={onRemove}
                 close={() => setShowOptions(false)}
-                currentThreadSlug={threadSlug}
               />
             )}
           </div>
@@ -163,14 +162,7 @@ export default function ThreadItem({
   );
 }
 
-function OptionsMenu({
-  containerRef,
-  workspace,
-  thread,
-  onRemove,
-  close,
-  currentThreadSlug,
-}) {
+function OptionsMenu({ containerRef, workspace, thread, onRemove, close }) {
   const menuRef = useRef(null);
 
   // Ref menu options
@@ -245,11 +237,9 @@ function OptionsMenu({
     }
     if (success) {
       showToast("Thread deleted successfully!", "success", { clear: true });
+      // onRemove handles redirecting to a neighboring thread when the active
+      // thread is deleted.
       onRemove(thread.id);
-      // Redirect if deleting the active thread
-      if (currentThreadSlug === thread.slug) {
-        window.location.href = paths.workspace.chat(workspace.slug);
-      }
       return;
     }
   };

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
@@ -72,6 +72,7 @@ export default function ThreadContainer({
   };
 
   function removeThread(threadId) {
+    const deletedThread = threads.find((t) => t.id === threadId);
     setThreads((prev) =>
       prev.map((_t) => {
         if (_t.id !== threadId) return _t;
@@ -84,6 +85,19 @@ export default function ThreadContainer({
     setTimeout(() => {
       setThreads((prev) => prev.filter((t) => !t.deleted));
     }, 500);
+
+    // If the active thread was deleted, redirect to the neighboring thread (the
+    // next one, or the previous if it was last) so the sidebar keeps a real
+    // active thread. Fall back to the workspace base chat when none remain.
+    if (deletedThread?.slug === threadSlug) {
+      const deletedIdx = threads.findIndex((t) => t.id === threadId);
+      const remaining = threads.filter((t) => t.id !== threadId);
+      const nextThread =
+        remaining[deletedIdx] ?? remaining[deletedIdx - 1] ?? null;
+      window.location.href = nextThread
+        ? paths.workspace.thread(workspace.slug, nextThread.slug)
+        : paths.workspace.chat(workspace.slug);
+    }
   }
 
   function getActiveThreadIdx() {


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #6056 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- on deleting the active thread, redirect to the neighboring thread (next, or previous if it was last) instead of the workspace base chat
- fall back to the base chat only when no threads remain
- keeps a real active thread selected so the phantom `*New Thread` placeholder no longer appears in the sidebar

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
