### PR TITLE
fix(model-router): renew cooldown TTL after inference completes

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -961,7 +961,7 @@ const TRANSLATIONS = {
         "Used when no routing rule matches. Also used to evaluate LLM-classified rules.",
       "cooldown-label": "Cache Cooldown (seconds)",
       "cooldown-help":
-        "How long a routing decision is cached before re-evaluating rules. Set to 0 to disable caching.",
+        "How long a routing decision sticks after the model finishes responding. The timer renews when inference completes (and on follow-up hits), so long reasoning/tool runs won't expire the route mid-reply. Set to 0 to disable caching.",
       "name-required": "Name is required.",
       "fallback-required": "Primary provider and model are required.",
       cancel: "Cancel",

--- a/server/__tests__/utils/router/index.test.js
+++ b/server/__tests__/utils/router/index.test.js
@@ -1,0 +1,91 @@
+/* eslint-env jest */
+
+describe("ModelRouterService sticky TTL after inference", () => {
+  let ModelRouterService;
+  let svc;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    ({ ModelRouterService } = require("../../../utils/router"));
+    // Reset singleton between tests
+    ModelRouterService.instance = null;
+    svc = ModelRouterService.getInstance();
+    // Silence logs
+    svc.log = jest.fn();
+    svc.logIndent = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    ModelRouterService.instance = null;
+  });
+
+  test("sticky route expires after cooldown without touch", () => {
+    const key = "1:ws:thread";
+    const route = {
+      provider: "openai",
+      model: "gpt-4o",
+      ruleTitle: "r1",
+      ruleType: "calculated",
+      isFallback: false,
+    };
+    svc.setStickyRoute(key, route);
+
+    jest.advanceTimersByTime(301_000);
+    expect(svc.getStickyRoute(key, 300_000)).toBeNull();
+  });
+
+  test("touchStickyRoute renews TTL so long inference does not expire route", () => {
+    const key = "1:ws:thread";
+    const route = {
+      provider: "openai",
+      model: "gpt-4o",
+      ruleTitle: "r1",
+      ruleType: "calculated",
+      isFallback: false,
+    };
+    svc.setStickyRoute(key, route);
+
+    // Simulate a 4-minute inference, then touch on completion
+    jest.advanceTimersByTime(240_000);
+    expect(svc.touchStickyRoute(key)).toBe(true);
+
+    // Another 4 minutes later — still within renewed 300s window
+    jest.advanceTimersByTime(240_000);
+    const sticky = svc.getStickyRoute(key, 300_000);
+    expect(sticky).toEqual(route);
+  });
+
+  test("markInferenceComplete refreshes sticky and LLM match cache by routeKey", () => {
+    const key = "0:demo:default";
+    const route = {
+      provider: "anthropic",
+      model: "claude",
+      ruleTitle: "code",
+      ruleType: "llm",
+      isFallback: false,
+    };
+    svc.setStickyRoute(key, route);
+    svc.setCachedLLMResult(key, {
+      title: "code",
+      route_provider: "anthropic",
+      route_model: "claude",
+      type: "llm",
+    });
+
+    jest.advanceTimersByTime(250_000);
+    ModelRouterService.markInferenceComplete({ routeKey: key });
+
+    jest.advanceTimersByTime(250_000);
+    expect(svc.getStickyRoute(key, 300_000)).toEqual(route);
+    expect(svc.getCachedLLMResult(key, 300_000)?.title).toBe("code");
+  });
+
+  test("touchCachedLLMResult does not refresh null/no-match entries", () => {
+    const key = "0:demo:default";
+    svc.setCachedLLMResult(key, null);
+    expect(svc.touchCachedLLMResult(key)).toBe(false);
+  });
+});

--- a/server/models/modelRouter.js
+++ b/server/models/modelRouter.js
@@ -45,7 +45,7 @@ const ModelRouter = {
     const cooldown_seconds =
       data.cooldown_seconds != null
         ? this.validations.cooldown_seconds(data.cooldown_seconds)
-        : ModelRouterService.DEFAULT_STICKY_MS;
+        : ModelRouterService.DEFAULT_STICKY_MS / 1000;
 
     try {
       const router = await prisma.model_routers.create({

--- a/server/utils/AiProviders/modelRouter/index.js
+++ b/server/utils/AiProviders/modelRouter/index.js
@@ -109,6 +109,7 @@ class AnythingLLMModelRouter {
   get routingMetadata() {
     if (!this.resolvedRoute) return null;
     return {
+      routeKey: this._routeKey,
       routedTo: {
         provider: this.resolvedRoute.provider,
         model: this.resolvedRoute.model,

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -946,6 +946,23 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
       content = await this.handleExecution(messages, functions, route.from);
     }
 
+    // Renew model-router sticky TTL after each agent turn so long tool/CoT
+    // loops don't expire the route mid-session.
+    try {
+      const routeKey = this.handlerProps?.routingMetadata?.routeKey ?? null;
+      const workspace = this.handlerProps?.invocation?.workspace ?? null;
+      if (routeKey || workspace) {
+        const { ModelRouterService } = require("../../router");
+        ModelRouterService.markInferenceComplete({
+          workspace,
+          user: this.handlerProps?.invocation?.user_id
+            ? { id: this.handlerProps.invocation.user_id }
+            : null,
+          routeKey,
+        });
+      }
+    } catch {}
+
     this.newMessage({ ...route, content });
     return content;
   }

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -223,14 +223,15 @@ async function chatSync({
       });
   }
 
-  const { connector: LLMConnector } = await resolveProviderConnector({
-    workspace,
-    prompt: message,
-    user,
-    thread,
-    attachments,
-    apiSessionId: sessionId,
-  });
+  const { connector: LLMConnector, routingMetadata } =
+    await resolveProviderConnector({
+      workspace,
+      prompt: message,
+      user,
+      thread,
+      attachments,
+      apiSessionId: sessionId,
+    });
 
   const VectorDb = getVectorDbClass();
   const messageLimit = workspace?.openAiHistory || 20;
@@ -423,6 +424,16 @@ async function chatSync({
       user: user,
     });
 
+  try {
+    const { ModelRouterService } = require("../router");
+    ModelRouterService.markInferenceComplete({
+      workspace,
+      user,
+      thread,
+      routeKey: routingMetadata?.routeKey ?? null,
+    });
+  } catch {}
+
   if (!textResponse) {
     return {
       id: uuid,
@@ -590,14 +601,15 @@ async function streamChat({
       });
   }
 
-  const { connector: LLMConnector } = await resolveProviderConnector({
-    workspace,
-    prompt: message,
-    user,
-    thread,
-    attachments,
-    apiSessionId: sessionId,
-  });
+  const { connector: LLMConnector, routingMetadata } =
+    await resolveProviderConnector({
+      workspace,
+      prompt: message,
+      user,
+      thread,
+      attachments,
+      apiSessionId: sessionId,
+    });
 
   const VectorDb = getVectorDbClass();
   const messageLimit = workspace?.openAiHistory || 20;
@@ -824,6 +836,16 @@ async function streamChat({
     completeText = await LLMConnector.handleStream(response, stream, { uuid });
     metrics = stream.metrics;
   }
+
+  try {
+    const { ModelRouterService } = require("../router");
+    ModelRouterService.markInferenceComplete({
+      workspace,
+      user,
+      thread,
+      routeKey: routingMetadata?.routeKey ?? null,
+    });
+  } catch {}
 
   if (completeText?.length > 0) {
     const { chat } = await WorkspaceChats.new({

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -308,6 +308,18 @@ async function streamChatWithWorkspace(
     metrics = stream.metrics;
   }
 
+  // Renew model-router sticky TTL after inference finishes so long CoT/tool
+  // runs don't expire the cooldown before the user's next message.
+  try {
+    const { ModelRouterService } = require("../router");
+    ModelRouterService.markInferenceComplete({
+      workspace,
+      user,
+      thread,
+      routeKey: routingMetadata?.routeKey ?? null,
+    });
+  } catch {}
+
   if (completeText?.length > 0) {
     const { chat } = await WorkspaceChats.new({
       workspaceId: workspace.id,

--- a/server/utils/router/index.js
+++ b/server/utils/router/index.js
@@ -157,6 +157,77 @@ class ModelRouterService {
   }
 
   /**
+   * Refresh sticky TTL without changing the routed model.
+   * Used after inference completes so long CoT/tool runs don't burn the window
+   * before the user's follow-up message can renew it.
+   * @param {string} key
+   * @returns {boolean} true if an entry was refreshed
+   */
+  touchStickyRoute(key) {
+    const entry = this.stickyRoutes.get(key);
+    if (!entry) return false;
+    entry.stickyAt = Date.now();
+    this.log(
+      `Sticky route: TOUCH → ${entry.route.provider}/${entry.route.model} (ttl reset after inference)`
+    );
+    return true;
+  }
+
+  /**
+   * Refresh LLM classification cache timestamp (match entries only).
+   * @param {string} key
+   * @returns {boolean}
+   */
+  touchCachedLLMResult(key) {
+    const entry = this.llmCache.get(key);
+    if (!entry || !entry.result) return false;
+    entry.cachedAt = Date.now();
+    this.log(
+      `LLM cache: TOUCH → "${entry.result.title}" (ttl reset after inference)`
+    );
+    return true;
+  }
+
+  /**
+   * Mark that inference finished for a workspace chat/agent turn.
+   * Refreshes sticky + LLM-match caches so the cooldown window effectively
+   * starts (or renews) after the model stops, not only at rule-match time.
+   * @param {Object} opts
+   * @param {Object} [opts.workspace]
+   * @param {Object|null} [opts.user]
+   * @param {Object|null} [opts.thread]
+   * @param {string|null} [opts.routeKey] - Prefer explicit route key when available
+   */
+  static markInferenceComplete({
+    workspace = null,
+    user = null,
+    thread = null,
+    routeKey = null,
+  } = {}) {
+    const svc = ModelRouterService.getInstance();
+    const key =
+      routeKey ||
+      (workspace?.slug
+        ? svc.routeCacheKey(
+            user?.id ?? null,
+            workspace.slug,
+            thread?.slug ?? null
+          )
+        : null);
+    if (!key) return;
+
+    const stickyTouched = svc.touchStickyRoute(key);
+    const llmTouched = svc.touchCachedLLMResult(key);
+    if (stickyTouched || llmTouched) {
+      svc.log(
+        `Inference complete → refreshed routing TTL for key "${key}"${
+          workspace?.slug ? ` (workspace: ${workspace.slug})` : ""
+        }`
+      );
+    }
+  }
+
+  /**
    * Clear a sticky route (e.g., on new conversation).
    * @param {string} key
    */


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #6042

### Description

Model router sticky cooldown previously started at **rule-match time**. Long reasoning / multi-tool agent turns could exceed the default 300s window before the next resolve, so follow-ups fell back to the default model.

**Fix:** renew sticky + LLM-match cache TTL when inference finishes:

- Chat: `stream.js` + `apiChatHandler.js` after completion/stream end
- Agents: `aibitat.reply()` after each turn (covers tool loops mid-session)
- New helpers: `touchStickyRoute`, `touchCachedLLMResult`, `markInferenceComplete`
- Expose `routeKey` on `routingMetadata` for reliable cache keying
- UI help text updated to describe post-inference renewal
- Bonus: fix `ModelRouter.create` defaulting `cooldown_seconds` to `DEFAULT_STICKY_MS` (ms) instead of seconds

This makes the cooldown window effectively start/renew **after the model stops**, which is the behavior requested in #6042. A separate UI toggle for legacy “start at match only” was deferred — happy to add if maintainers want it.

### Visuals (if applicable)

N/A

### Additional Information

**Local testing performed:**

```sh
yarn lint:ci
yarn test
yarn test server/__tests__/utils/router/index.test.js
```

Results:
- `yarn lint:ci` — pass
- `yarn test` — pass
- Router suite — 4/4 pass (fake timers: expire without touch; survive long inference with touch; markInferenceComplete refreshes both caches)

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally

**Docker build (local):**

```sh
docker buildx build --load -f docker/Dockerfile \
  --build-arg ARG_UID=1000 --build-arg ARG_GID=1000 \
  --platform linux/amd64 -t anythingllm-pr-6059-test .
```

Result: build succeeded (`EXIT_CODE=0`), image `anythingllm-pr-6059-test:latest` (4.67GB).