### PR TITLE
feat: expose configurable AI request/socket timeout

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -46,7 +46,15 @@ GID='1000'
 # OLLAMA_MODEL_PREF='llama2'
 # OLLAMA_MODEL_TOKEN_LIMIT=4096
 # OLLAMA_AUTH_TOKEN='your-ollama-auth-token-here (optional, only for ollama running behind auth - Bearer token)'
-# OLLAMA_RESPONSE_TIMEOUT=7200000 (optional, max timeout in milliseconds for ollama response to conclude. Default is 5min before aborting)
+# OLLAMA_RESPONSE_TIMEOUT=1800000
+# Optional. Max wait (ms) for Ollama responses. Must be > 300000 (5m) to take effect.
+# Falls back to ANYTHINGLLM_FETCH_TIMEOUT when unset. Default request timeout is 10 minutes.
+
+# Global AI request / socket timeout (ms) for OpenAI-compatible providers, Anthropic SDK,
+# and the undici HTTP transport. Raise this for slow local/CPU models, long RAG, or agents.
+# Default: 600000 (10 minutes). Example 30 minutes:
+# ANYTHINGLLM_FETCH_TIMEOUT=1800000
+# ANYTHINGLLM_MAX_RETRIES=0
 
 # LLM_PROVIDER='togetherai'
 # TOGETHER_AI_API_KEY='my-together-ai-key'

--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -652,6 +652,32 @@ export default function GeneralLLMPreference() {
                     (llm) => llm.value === selectedLLM
                   )?.options?.(settings)}
               </div>
+              <div
+                onChange={() => setHasChanges(true)}
+                className="mt-6 flex flex-col gap-y-1 max-w-[640px]"
+              >
+                <label className="text-white text-sm font-semibold block mb-1">
+                  AI request timeout (ms)
+                </label>
+                <p className="text-xs text-white/60 mb-2">
+                  Global socket / request timeout for LLM providers (OpenAI SDK,
+                  Anthropic, undici). Raise this for slow local or CPU models,
+                  long RAG, or agent skills. Default is 600000 (10 minutes).
+                  Requires a server restart to fully apply. Ollama can also use{" "}
+                  <code className="text-white/80">OLLAMA_RESPONSE_TIMEOUT</code>
+                  .
+                </p>
+                <input
+                  type="number"
+                  name="env::AnythingLLMFetchTimeout"
+                  min={1000}
+                  step={1000}
+                  defaultValue={settings?.AnythingLLMFetchTimeout ?? 600_000}
+                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  placeholder="600000"
+                  onChange={() => setHasChanges(true)}
+                />
+              </div>
             </div>
           </form>
         </div>

--- a/server/.env.example
+++ b/server/.env.example
@@ -43,7 +43,15 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # OLLAMA_MODEL_PREF='llama2'
 # OLLAMA_MODEL_TOKEN_LIMIT=4096
 # OLLAMA_AUTH_TOKEN='your-ollama-auth-token-here (optional, only for ollama running behind auth - Bearer token)'
-# OLLAMA_RESPONSE_TIMEOUT=7200000 (optional, max timeout in milliseconds for ollama response to conclude. Default is 5min before aborting)
+# OLLAMA_RESPONSE_TIMEOUT=1800000
+# Optional. Max wait (ms) for Ollama responses. Must be > 300000 (5m) to take effect.
+# Falls back to ANYTHINGLLM_FETCH_TIMEOUT when unset. Default request timeout is 10 minutes.
+
+# Global AI request / socket timeout (ms) for OpenAI-compatible providers, Anthropic SDK,
+# and the undici HTTP transport. Raise this for slow local/CPU models, long RAG, or agents.
+# Default: 600000 (10 minutes). Example 30 minutes:
+# ANYTHINGLLM_FETCH_TIMEOUT=1800000
+# ANYTHINGLLM_MAX_RETRIES=0
 
 # LLM_PROVIDER='togetherai'
 # TOGETHER_AI_API_KEY='my-together-ai-key'

--- a/server/__tests__/utils/AiProviders/ollama/timeout.test.js
+++ b/server/__tests__/utils/AiProviders/ollama/timeout.test.js
@@ -1,0 +1,65 @@
+/* eslint-env jest */
+
+describe("OllamaAILLM.applyOllamaFetch timeout selection", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.OLLAMA_RESPONSE_TIMEOUT;
+    delete process.env.ANYTHINGLLM_FETCH_TIMEOUT;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test("returns default fetch when no timeout ENVs are set", () => {
+    const { OllamaAILLM } = require("../../../../utils/AiProviders/ollama");
+    expect(OllamaAILLM.applyOllamaFetch()).toBe(fetch);
+  });
+
+  test("ignores OLLAMA_RESPONSE_TIMEOUT when <= 5 minutes", () => {
+    process.env.OLLAMA_RESPONSE_TIMEOUT = "120000";
+    const { OllamaAILLM } = require("../../../../utils/AiProviders/ollama");
+    expect(OllamaAILLM.applyOllamaFetch()).toBe(fetch);
+  });
+
+  test("uses OLLAMA_RESPONSE_TIMEOUT when > 5 minutes", () => {
+    process.env.OLLAMA_RESPONSE_TIMEOUT = "1800000";
+    const { OllamaAILLM } = require("../../../../utils/AiProviders/ollama");
+    const customFetch = OllamaAILLM.applyOllamaFetch();
+    expect(customFetch).not.toBe(fetch);
+    expect(typeof customFetch).toBe("function");
+  });
+
+  test("falls back to ANYTHINGLLM_FETCH_TIMEOUT when Ollama-specific unset", () => {
+    process.env.ANYTHINGLLM_FETCH_TIMEOUT = "1800000";
+    const { OllamaAILLM } = require("../../../../utils/AiProviders/ollama");
+    const customFetch = OllamaAILLM.applyOllamaFetch();
+    expect(customFetch).not.toBe(fetch);
+  });
+});
+
+describe("ANYTHINGLLM_FETCH_TIMEOUT wiring", () => {
+  test("updateENV maps AnythingLLMFetchTimeout", () => {
+    const fs = require("fs");
+    const src = fs.readFileSync(
+      require.resolve("../../../../utils/helpers/updateENV"),
+      "utf8"
+    );
+    expect(src).toMatch(
+      /AnythingLLMFetchTimeout:\s*\{[\s\S]*?envKey:\s*"ANYTHINGLLM_FETCH_TIMEOUT"/
+    );
+  });
+
+  test("patchSdkTimeouts documents ANYTHINGLLM_FETCH_TIMEOUT", () => {
+    const fs = require("fs");
+    const src = fs.readFileSync(
+      require.resolve("../../../../utils/boot/patchSdkTimeouts"),
+      "utf8"
+    );
+    expect(src).toContain("ANYTHINGLLM_FETCH_TIMEOUT");
+    expect(src).toContain("600_000");
+  });
+});

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -510,6 +510,7 @@ const SystemSettings = {
       LLMProvider: llmProvider,
       LLMModel: getBaseLLMProviderModel({ provider: llmProvider }) || null,
       ModelRouterId: process.env.MODEL_ROUTER_ID || null,
+      AnythingLLMFetchTimeout: process.env.ANYTHINGLLM_FETCH_TIMEOUT || 600_000,
       ...this.llmPreferenceKeys(),
 
       // --------------------------------------------------------

--- a/server/utils/AiProviders/ollama/index.js
+++ b/server/utils/AiProviders/ollama/index.js
@@ -128,29 +128,46 @@ class OllamaAILLM {
 
   /**
    * Apply a custom fetch function to the Ollama client.
-   * This is useful when we want to bypass the default 5m timeout for global fetch
-   * for machines which run responses very slowly.
+   * Useful when we want to raise the default request timeout for machines
+   * which run responses very slowly (CPU / large models / cold start).
+   *
+   * Uses OLLAMA_RESPONSE_TIMEOUT when set and > 5 minutes, otherwise falls
+   * back to ANYTHINGLLM_FETCH_TIMEOUT when that is also > 5 minutes.
    * @returns {Function} The custom fetch function.
    */
   static applyOllamaFetch() {
     try {
-      if (!("OLLAMA_RESPONSE_TIMEOUT" in process.env)) return fetch;
       const { Agent } = require("undici");
       const moment = require("moment");
-      let timeout = process.env.OLLAMA_RESPONSE_TIMEOUT;
+      const MIN_CUSTOM_MS = 5 * 60_000;
+      const DEFAULT_MS = 600_000;
 
-      if (!timeout || isNaN(Number(timeout)) || Number(timeout) <= 5 * 60_000) {
-        OllamaAILLM.#slog(
-          "Timeout option was not set, is not a number, or is less than 5 minutes in ms - falling back to default",
-          { timeout }
-        );
-        return fetch;
-      } else timeout = Number(timeout);
+      let timeout = null;
+      if ("OLLAMA_RESPONSE_TIMEOUT" in process.env) {
+        const parsed = Number(process.env.OLLAMA_RESPONSE_TIMEOUT);
+        if (Number.isFinite(parsed) && parsed > MIN_CUSTOM_MS) timeout = parsed;
+        else
+          OllamaAILLM.#slog(
+            "OLLAMA_RESPONSE_TIMEOUT was not a number > 5 minutes — ignoring",
+            { timeout: process.env.OLLAMA_RESPONSE_TIMEOUT }
+          );
+      }
+
+      if (timeout == null && "ANYTHINGLLM_FETCH_TIMEOUT" in process.env) {
+        const parsed = Number(process.env.ANYTHINGLLM_FETCH_TIMEOUT);
+        if (Number.isFinite(parsed) && parsed > MIN_CUSTOM_MS) timeout = parsed;
+      }
+
+      if (timeout == null) return fetch;
+      if (!Number.isFinite(timeout) || timeout <= 0) timeout = DEFAULT_MS;
 
       const noTimeoutFetch = (input, init = {}) => {
         return fetch(input, {
           ...init,
-          dispatcher: new Agent({ headersTimeout: timeout }),
+          dispatcher: new Agent({
+            headersTimeout: timeout,
+            bodyTimeout: timeout,
+          }),
         });
       };
 

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -11,6 +11,11 @@ const KEY_MAPPING = {
     envKey: "MODEL_ROUTER_ID",
     checks: [],
   },
+  // Global AI request / socket timeout (ms) — covers OpenAI SDK, Anthropic SDK, undici
+  AnythingLLMFetchTimeout: {
+    envKey: "ANYTHINGLLM_FETCH_TIMEOUT",
+    checks: [nonZero],
+  },
   // OpenAI Settings
   OpenAiKey: {
     envKey: "OPEN_AI_KEY",


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #5823

### Description

Users with slow local/CPU models, long RAG, or agent skills still hit socket/request timeouts after the #5721 global patch (default 10 minutes). The knobs already existed as undocumented ENV vars.

This PR makes the timeout **discoverable and configurable**:

- Documents `ANYTHINGLLM_FETCH_TIMEOUT` / `ANYTHINGLLM_MAX_RETRIES` in `server/.env.example` + `docker/.env.example`
- Adds `AnythingLLMFetchTimeout` to `updateENV` + `systemSettings` so it can be saved from the UI
- Adds an **AI request timeout (ms)** field on LLM Preference (global; default `600000`)
- Fixes Ollama custom fetch to set both `headersTimeout` **and** `bodyTimeout`, and fall back to `ANYTHINGLLM_FETCH_TIMEOUT` when `OLLAMA_RESPONSE_TIMEOUT` is unset

This follows the intentional global-timeout design from #5721 (rather than reviving per-provider sprawl from #5637).

**Note:** Changing the timeout via UI/ENV requires a server restart for the boot-time SDK/undici patch to fully apply.

### Visuals (if applicable)

N/A (single timeout input under LLM Preference)

### Additional Information

**Local testing performed:**

```sh
yarn lint:ci
yarn test server/__tests__/utils/AiProviders/ollama/timeout.test.js
```

Results:
- `yarn lint:ci` — pass
- Timeout suite — 6/6 pass (default fetch, ignore short Ollama timeout, use Ollama >5m, fall back to global ENV, updateENV + patch wiring)

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally

**Docker build (local):**

```sh
docker buildx build --load -f docker/Dockerfile \
  --build-arg ARG_UID=1000 --build-arg ARG_GID=1000 \
  --platform linux/amd64 -t anythingllm-pr-6060-test .
```

Result: build succeeded (`EXIT_CODE=0`), image `anythingllm-pr-6060-test:latest` (4.67GB).