### PR TITLE
feat(generic-openai): saved endpoint connections dropdown

### DIFF
--- a/frontend/src/components/LLMSelection/GenericOpenAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GenericOpenAiOptions/index.jsx
@@ -1,7 +1,242 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import System from "@/models/system";
+import GenericOpenAiConnections from "@/models/genericOpenAiConnections";
+import showToast from "@/utils/toast";
+import { LLM_PREFERENCE_CHANGED_EVENT } from "@/pages/GeneralSettings/LLMPreference";
+
+const MANUAL_CONNECTION_VALUE = "__manual__";
 
 export default function GenericOpenAiOptions({ settings }) {
+  const { t } = useTranslation();
+  const [localSettings, setLocalSettings] = useState(settings);
+  const [connections, setConnections] = useState(
+    settings?.GenericOpenAiSavedConnections || []
+  );
+  const [selectedConnectionId, setSelectedConnectionId] = useState(
+    settings?.GenericOpenAiActiveConnectionId || MANUAL_CONNECTION_VALUE
+  );
+  const [formKey, setFormKey] = useState(0);
+  const [loadingConnections, setLoadingConnections] = useState(false);
+  const [applyingConnection, setApplyingConnection] = useState(false);
+  const formRef = useRef(null);
+
+  const refreshConnections = async () => {
+    setLoadingConnections(true);
+    const result = await GenericOpenAiConnections.list();
+    if (result.success) {
+      setConnections(result.connections || []);
+      setSelectedConnectionId(
+        result.activeConnectionId || MANUAL_CONNECTION_VALUE
+      );
+    }
+    setLoadingConnections(false);
+    return result;
+  };
+
+  useEffect(() => {
+    setLocalSettings(settings);
+  }, [settings]);
+
+  useEffect(() => {
+    refreshConnections();
+  }, []);
+
+  const reloadSettings = async () => {
+    const updatedSettings = await System.keys();
+    if (!updatedSettings) return null;
+    setLocalSettings(updatedSettings);
+    setConnections(updatedSettings.GenericOpenAiSavedConnections || []);
+    setSelectedConnectionId(
+      updatedSettings.GenericOpenAiActiveConnectionId || MANUAL_CONNECTION_VALUE
+    );
+    setFormKey((key) => key + 1);
+    window.dispatchEvent(new Event(LLM_PREFERENCE_CHANGED_EVENT));
+    return updatedSettings;
+  };
+
+  const readFormValues = () => {
+    const container = formRef.current;
+    if (!container) return null;
+    const getValue = (name) =>
+      container.querySelector(`[name="${name}"]`)?.value ?? "";
+    return {
+      basePath: String(getValue("GenericOpenAiBasePath")).trim(),
+      apiKey: String(getValue("GenericOpenAiKey")).trim(),
+      modelPref: String(getValue("GenericOpenAiModelPref")).trim(),
+      tokenLimit: Number(getValue("GenericOpenAiTokenLimit")),
+      maxTokens: Number(getValue("GenericOpenAiMaxTokens")),
+    };
+  };
+
+  const handleConnectionSelect = async (event) => {
+    const value = event.target.value;
+    setSelectedConnectionId(value);
+
+    if (value === MANUAL_CONNECTION_VALUE) return;
+
+    setApplyingConnection(true);
+    const result = await GenericOpenAiConnections.activate(value);
+    setApplyingConnection(false);
+
+    if (!result.success) {
+      showToast(
+        t("llm.providers.generic_openai.saved_connection_apply_failed", {
+          error: result.error || "Unknown error",
+        }),
+        "error"
+      );
+      return;
+    }
+
+    await reloadSettings();
+    showToast(
+      t("llm.providers.generic_openai.saved_connection_applied"),
+      "success"
+    );
+  };
+
+  const handleSaveConnection = async () => {
+    const values = readFormValues();
+    if (!values) return;
+
+    const defaultName =
+      connections.find((c) => c.id === selectedConnectionId)?.name ||
+      values.modelPref ||
+      values.basePath;
+
+    const name = window.prompt(
+      t("llm.providers.generic_openai.saved_connection_name_prompt"),
+      defaultName
+    );
+    if (!name?.trim()) return;
+
+    const payload = {
+      ...values,
+      name: name.trim(),
+      id:
+        selectedConnectionId !== MANUAL_CONNECTION_VALUE
+          ? selectedConnectionId
+          : undefined,
+    };
+
+    if (
+      payload.apiKey &&
+      payload.apiKey.length > 0 &&
+      payload.apiKey === "*".repeat(20)
+    ) {
+      delete payload.apiKey;
+    }
+
+    const result = await GenericOpenAiConnections.save(payload);
+    if (!result.success) {
+      showToast(
+        t("llm.providers.generic_openai.saved_connection_save_failed", {
+          error: result.error || "Unknown error",
+        }),
+        "error"
+      );
+      return;
+    }
+
+    setConnections(result.connections || []);
+    setSelectedConnectionId(
+      result.activeConnectionId || MANUAL_CONNECTION_VALUE
+    );
+    await reloadSettings();
+    showToast(
+      t("llm.providers.generic_openai.saved_connection_saved"),
+      "success"
+    );
+  };
+
+  const handleDeleteConnection = async () => {
+    if (selectedConnectionId === MANUAL_CONNECTION_VALUE) return;
+    if (
+      !window.confirm(
+        t("llm.providers.generic_openai.saved_connection_delete_confirm")
+      )
+    ) {
+      return;
+    }
+
+    const result = await GenericOpenAiConnections.delete(selectedConnectionId);
+    if (!result.success) {
+      showToast(
+        t("llm.providers.generic_openai.saved_connection_delete_failed", {
+          error: result.error || "Unknown error",
+        }),
+        "error"
+      );
+      return;
+    }
+
+    setConnections(result.connections || []);
+    setSelectedConnectionId(MANUAL_CONNECTION_VALUE);
+    showToast(
+      t("llm.providers.generic_openai.saved_connection_deleted"),
+      "success"
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-y-7">
+      <div className="flex flex-col gap-y-3">
+        <p className="text-white text-sm font-semibold">
+          {t("llm.providers.generic_openai.saved_connections_label")}
+        </p>
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex flex-col w-60 min-w-[240px]">
+            <label className="text-white text-sm font-semibold block mb-3">
+              {t("llm.providers.generic_openai.saved_connection_select")}
+            </label>
+            <select
+              value={selectedConnectionId}
+              onChange={handleConnectionSelect}
+              disabled={loadingConnections || applyingConnection}
+              className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+            >
+              <option value={MANUAL_CONNECTION_VALUE}>
+                {t("llm.providers.generic_openai.saved_connection_manual")}
+              </option>
+              {connections.map((connection) => (
+                <option key={connection.id} value={connection.id}>
+                  {connection.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={handleSaveConnection}
+            className="text-sm font-semibold text-white bg-theme-settings-input-bg hover:bg-theme-bg-primary rounded-lg px-4 py-2.5 h-[42px]"
+          >
+            {t("llm.providers.generic_openai.saved_connection_save")}
+          </button>
+          <button
+            type="button"
+            onClick={handleDeleteConnection}
+            disabled={selectedConnectionId === MANUAL_CONNECTION_VALUE}
+            className="text-sm font-semibold text-white bg-theme-settings-input-bg hover:bg-theme-bg-primary disabled:opacity-40 rounded-lg px-4 py-2.5 h-[42px]"
+          >
+            {t("llm.providers.generic_openai.saved_connection_delete")}
+          </button>
+        </div>
+        <p className="text-xs text-white text-opacity-60 max-w-2xl">
+          {t("llm.providers.generic_openai.saved_connections_help")}
+        </p>
+      </div>
+
+      <GenericOpenAiForm
+        key={formKey}
+        settings={localSettings}
+        formRef={formRef}
+      />
+    </div>
+  );
+}
+
+function GenericOpenAiForm({ settings, formRef }) {
   const [genericOpenAiBasePath, setGenericOpenAiBasePath] = useState(
     settings?.GenericOpenAiBasePath
   );
@@ -13,7 +248,7 @@ export default function GenericOpenAiOptions({ settings }) {
   );
 
   return (
-    <div className="flex flex-col gap-y-7">
+    <div ref={formRef} className="flex flex-col gap-y-7">
       <div className="flex gap-[36px] mt-1.5 flex-wrap">
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
@@ -147,7 +382,6 @@ function GenericOpenAiModelSelection({
     );
   }
 
-  // If no models are found, just show a free-form input field for the model name
   if (customModels.length === 0) {
     return (
       <div className="flex flex-col w-60">
@@ -179,16 +413,13 @@ function GenericOpenAiModelSelection({
         name="GenericOpenAiModelPref"
         required={true}
         className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+        defaultValue={settings?.GenericOpenAiModelPref}
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">
             {customModels.map((model) => {
               return (
-                <option
-                  key={model.id}
-                  value={model.id}
-                  selected={settings.GenericOpenAiModelPref === model.id}
-                >
+                <option key={model.id} value={model.id}>
                   {model.id}
                 </option>
               );

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -930,6 +930,25 @@ const TRANSLATIONS = {
         default: "Default",
         reasoning: "Reasoning",
       },
+      generic_openai: {
+        saved_connections_label: "Saved endpoints",
+        saved_connection_select: "Saved connection",
+        saved_connection_manual: "Manual configuration",
+        saved_connection_save: "Save connection",
+        saved_connection_delete: "Delete",
+        saved_connections_help:
+          "Save multiple Generic OpenAI base URLs, API keys, and models so you can switch between RunPod workers, local servers, or LiteLLM routes without retyping settings.",
+        saved_connection_name_prompt: "Name for this connection",
+        saved_connection_saved: "Saved Generic OpenAI connection.",
+        saved_connection_deleted: "Deleted saved connection.",
+        saved_connection_applied: "Applied saved connection.",
+        saved_connection_save_failed: "Failed to save connection: {{error}}",
+        saved_connection_delete_failed:
+          "Failed to delete connection: {{error}}",
+        saved_connection_apply_failed: "Failed to apply connection: {{error}}",
+        saved_connection_delete_confirm:
+          "Delete this saved Generic OpenAI connection?",
+      },
     },
   },
   "model-router": {

--- a/frontend/src/models/genericOpenAiConnections.js
+++ b/frontend/src/models/genericOpenAiConnections.js
@@ -1,0 +1,59 @@
+import { API_BASE } from "@/utils/constants";
+import { baseHeaders } from "@/utils/request";
+
+const GenericOpenAiConnections = {
+  list: async () => {
+    return await fetch(`${API_BASE}/generic-openai/connections`, {
+      method: "GET",
+      headers: baseHeaders(),
+    })
+      .then((res) => res.json())
+      .catch((e) => ({
+        success: false,
+        connections: [],
+        activeConnectionId: null,
+        error: e.message,
+      }));
+  },
+
+  save: async (data) => {
+    return await fetch(`${API_BASE}/generic-openai/connections`, {
+      method: "POST",
+      headers: baseHeaders(),
+      body: JSON.stringify(data),
+    })
+      .then((res) => res.json())
+      .catch((e) => ({
+        success: false,
+        error: e.message,
+      }));
+  },
+
+  activate: async (id) => {
+    return await fetch(`${API_BASE}/generic-openai/connections/activate`, {
+      method: "POST",
+      headers: baseHeaders(),
+      body: JSON.stringify({ id }),
+    })
+      .then((res) => res.json())
+      .catch((e) => ({
+        success: false,
+        error: e.message,
+      }));
+  },
+
+  delete: async (id) => {
+    return await fetch(`${API_BASE}/generic-openai/connections/delete`, {
+      method: "POST",
+      headers: baseHeaders(),
+      body: JSON.stringify({ id }),
+    })
+      .then((res) => res.json())
+      .catch((e) => ({
+        success: false,
+        error: e.message,
+      }));
+  },
+};
+
+export default GenericOpenAiConnections;

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -17,6 +17,7 @@ storage/plugins/agent-skills/*
 storage/plugins/agent-flows/*
 storage/plugins/office-extensions/*
 storage/plugins/anythingllm_mcp_servers.json
+storage/config/generic-openai-connections.json
 !storage/documents/DOCUMENTS.md
 storage/push-notifications/*
 storage/direct-uploads

--- a/server/__tests__/utils/llm/genericOpenAiConnections.test.js
+++ b/server/__tests__/utils/llm/genericOpenAiConnections.test.js
@@ -1,0 +1,130 @@
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+jest.mock("../../../utils/helpers/updateENV", () => ({
+  updateENV: jest.fn(async () => ({ newValues: {}, error: null })),
+}));
+
+const { updateENV } = require("../../../utils/helpers/updateENV");
+const {
+  GenericOpenAiConnections,
+} = require("../../../utils/llm/genericOpenAiConnections");
+
+describe("GenericOpenAiConnections", () => {
+  let storageDir;
+
+  beforeEach(() => {
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), "generic-openai-conn-"));
+    process.env.STORAGE_DIR = storageDir;
+    process.env.NODE_ENV = "test";
+    GenericOpenAiConnections._instance = undefined;
+    updateENV.mockClear();
+  });
+
+  afterEach(() => {
+    GenericOpenAiConnections._instance = undefined;
+    delete process.env.STORAGE_DIR;
+    delete process.env.GENERIC_OPEN_AI_BASE_PATH;
+    delete process.env.GENERIC_OPEN_AI_MODEL_PREF;
+    fs.rmSync(storageDir, { recursive: true, force: true });
+  });
+
+  it("creates, lists, and summarizes saved connections without exposing API keys", () => {
+    const manager = new GenericOpenAiConnections();
+    const { connection, error } = manager.upsertConnection({
+      name: "RunPod Worker",
+      basePath: "https://api.runpod.example/v1",
+      apiKey: "secret-key",
+      modelPref: "llama-3",
+      tokenLimit: 8192,
+      maxTokens: 1024,
+    });
+
+    expect(error).toBeNull();
+    expect(connection?.name).toBe("RunPod Worker");
+
+    const summaries = manager.listSummaries();
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      name: "RunPod Worker",
+      basePath: "https://api.runpod.example/v1",
+      modelPref: "llama-3",
+      tokenLimit: 8192,
+      maxTokens: 1024,
+      hasApiKey: true,
+      isActive: true,
+    });
+    expect(summaries[0].apiKey).toBeUndefined();
+  });
+
+  it("updates an existing connection and preserves the API key when omitted", () => {
+    const manager = new GenericOpenAiConnections();
+    const first = manager.upsertConnection({
+      name: "Local",
+      basePath: "https://localhost:8000/v1",
+      apiKey: "keep-me",
+      modelPref: "qwen",
+      tokenLimit: 4096,
+      maxTokens: 512,
+    });
+    expect(first.error).toBeNull();
+
+    const updated = manager.upsertConnection({
+      id: first.connection.id,
+      name: "Local v2",
+      basePath: "https://localhost:8000/v1",
+      modelPref: "qwen-2",
+      tokenLimit: 8192,
+      maxTokens: 1024,
+    });
+    expect(updated.error).toBeNull();
+
+    const stored = manager.getConnection(first.connection.id);
+    expect(stored?.apiKey).toBe("keep-me");
+    expect(stored?.modelPref).toBe("qwen-2");
+  });
+
+  it("activates a saved connection through updateENV", async () => {
+    const manager = new GenericOpenAiConnections();
+    const { connection } = manager.upsertConnection({
+      name: "LiteLLM",
+      basePath: "https://litellm.example/v1",
+      apiKey: "sk-test",
+      modelPref: "gpt-4o-mini",
+      tokenLimit: 8192,
+      maxTokens: 2048,
+    });
+
+    const result = await manager.activateConnection(connection.id);
+    expect(result.success).toBe(true);
+    expect(updateENV).toHaveBeenCalledWith(
+      {
+        LLMProvider: "generic-openai",
+        GenericOpenAiBasePath: "https://litellm.example/v1",
+        GenericOpenAiModelPref: "gpt-4o-mini",
+        GenericOpenAiTokenLimit: "8192",
+        GenericOpenAiMaxTokens: "2048",
+        GenericOpenAiKey: "sk-test",
+      },
+      false
+    );
+    expect(manager.getActiveConnectionId()).toBe(connection.id);
+  });
+
+  it("deletes a saved connection", () => {
+    const manager = new GenericOpenAiConnections();
+    const { connection } = manager.upsertConnection({
+      name: "Temp",
+      basePath: "https://api.example/v1",
+      modelPref: "test-model",
+      tokenLimit: 4096,
+      maxTokens: 512,
+    });
+
+    const deleted = manager.deleteConnection(connection.id);
+    expect(deleted.success).toBe(true);
+    expect(manager.listConnections()).toHaveLength(0);
+    expect(manager.getActiveConnectionId()).toBeNull();
+  });
+});

--- a/server/endpoints/genericOpenAiConnections.js
+++ b/server/endpoints/genericOpenAiConnections.js
@@ -1,0 +1,136 @@
+const { reqBody } = require("../utils/http");
+const {
+  flexUserRoleValid,
+  ROLES,
+} = require("../utils/middleware/multiUserProtected");
+const { validatedRequest } = require("../utils/middleware/validatedRequest");
+const {
+  GenericOpenAiConnections,
+} = require("../utils/llm/genericOpenAiConnections");
+
+function genericOpenAiConnectionEndpoints(app) {
+  if (!app) return;
+
+  app.get(
+    "/generic-openai/connections",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (_request, response) => {
+      try {
+        const manager = new GenericOpenAiConnections();
+        return response.status(200).json({
+          success: true,
+          connections: manager.listSummaries(),
+          activeConnectionId: manager.getActiveConnectionId(),
+          error: null,
+        });
+      } catch (error) {
+        console.error("Error listing Generic OpenAI connections:", error);
+        return response.status(500).json({
+          success: false,
+          connections: [],
+          activeConnectionId: null,
+          error: error.message,
+        });
+      }
+    }
+  );
+
+  app.post(
+    "/generic-openai/connections",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      try {
+        const body = reqBody(request);
+        const manager = new GenericOpenAiConnections();
+        const { connection, error } = manager.upsertConnection(body);
+        if (error) {
+          return response.status(400).json({ success: false, error });
+        }
+
+        const { error: activateError } = await manager.activateConnection(
+          connection.id
+        );
+        if (activateError) {
+          return response.status(400).json({
+            success: false,
+            error: activateError,
+          });
+        }
+
+        return response.status(200).json({
+          success: true,
+          connection: manager
+            .listSummaries()
+            .find((c) => c.id === connection.id),
+          connections: manager.listSummaries(),
+          activeConnectionId: manager.getActiveConnectionId(),
+          error: null,
+        });
+      } catch (error) {
+        console.error("Error saving Generic OpenAI connection:", error);
+        return response.status(500).json({
+          success: false,
+          error: error.message,
+        });
+      }
+    }
+  );
+
+  app.post(
+    "/generic-openai/connections/activate",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      try {
+        const { id } = reqBody(request);
+        const manager = new GenericOpenAiConnections();
+        const { success, error } = await manager.activateConnection(id);
+        if (!success) {
+          return response.status(400).json({ success: false, error });
+        }
+
+        return response.status(200).json({
+          success: true,
+          connections: manager.listSummaries(),
+          activeConnectionId: manager.getActiveConnectionId(),
+          error: null,
+        });
+      } catch (error) {
+        console.error("Error activating Generic OpenAI connection:", error);
+        return response.status(500).json({
+          success: false,
+          error: error.message,
+        });
+      }
+    }
+  );
+
+  app.post(
+    "/generic-openai/connections/delete",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      try {
+        const { id } = reqBody(request);
+        const manager = new GenericOpenAiConnections();
+        const { success, error } = manager.deleteConnection(id);
+        if (!success) {
+          return response.status(400).json({ success: false, error });
+        }
+
+        return response.status(200).json({
+          success: true,
+          connections: manager.listSummaries(),
+          activeConnectionId: manager.getActiveConnectionId(),
+          error: null,
+        });
+      } catch (error) {
+        console.error("Error deleting Generic OpenAI connection:", error);
+        return response.status(500).json({
+          success: false,
+          error: error.message,
+        });
+      }
+    }
+  );
+}
+
+module.exports = { genericOpenAiConnectionEndpoints };

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,9 @@ const { browserExtensionEndpoints } = require("./endpoints/browserExtension");
 const { communityHubEndpoints } = require("./endpoints/communityHub");
 const { agentFlowEndpoints } = require("./endpoints/agentFlows");
 const { mcpServersEndpoints } = require("./endpoints/mcpServers");
+const {
+  genericOpenAiConnectionEndpoints,
+} = require("./endpoints/genericOpenAiConnections");
 const { mobileEndpoints } = require("./endpoints/mobile");
 const { webPushEndpoints } = require("./endpoints/webPush");
 const { telegramEndpoints } = require("./endpoints/telegram");
@@ -97,6 +100,7 @@ developerEndpoints(app, apiRouter);
 communityHubEndpoints(apiRouter);
 agentFlowEndpoints(apiRouter);
 mcpServersEndpoints(apiRouter);
+genericOpenAiConnectionEndpoints(apiRouter);
 mobileEndpoints(apiRouter);
 webPushEndpoints(apiRouter);
 telegramEndpoints(apiRouter);

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -958,6 +958,18 @@ const SystemSettings = {
       GenericOpenAiTokenLimit: process.env.GENERIC_OPEN_AI_MODEL_TOKEN_LIMIT,
       GenericOpenAiKey: !!process.env.GENERIC_OPEN_AI_API_KEY,
       GenericOpenAiMaxTokens: process.env.GENERIC_OPEN_AI_MAX_TOKENS,
+      GenericOpenAiSavedConnections: (() => {
+        const {
+          GenericOpenAiConnections,
+        } = require("../utils/llm/genericOpenAiConnections");
+        return new GenericOpenAiConnections().listSummaries();
+      })(),
+      GenericOpenAiActiveConnectionId: (() => {
+        const {
+          GenericOpenAiConnections,
+        } = require("../utils/llm/genericOpenAiConnections");
+        return new GenericOpenAiConnections().getActiveConnectionId();
+      })(),
 
       // Foundry Keys
       FoundryBasePath: process.env.FOUNDRY_BASE_PATH,

--- a/server/storage/config/generic-openai-connections.json.example
+++ b/server/storage/config/generic-openai-connections.json.example
@@ -1,0 +1,4 @@
+{
+  "connections": [],
+  "activeConnectionId": null
+}

--- a/server/utils/llm/genericOpenAiConnections.js
+++ b/server/utils/llm/genericOpenAiConnections.js
@@ -1,0 +1,216 @@
+const fs = require("fs");
+const path = require("path");
+const { v4: uuidv4 } = require("uuid");
+const { safeJsonParse } = require("../http");
+const { updateENV } = require("../helpers/updateENV");
+
+const CONFIG_FILENAME = "generic-openai-connections.json";
+
+/**
+ * @typedef {Object} GenericOpenAiConnection
+ * @property {string} id
+ * @property {string} name
+ * @property {string} basePath
+ * @property {string} [apiKey]
+ * @property {string} modelPref
+ * @property {number} tokenLimit
+ * @property {number} maxTokens
+ */
+
+/**
+ * Manages saved Generic OpenAI endpoint profiles in storage.
+ * Resolves #3871 — quick switching between multiple OpenAI-compatible endpoints.
+ */
+class GenericOpenAiConnections {
+  static _instance;
+
+  constructor() {
+    if (GenericOpenAiConnections._instance)
+      return GenericOpenAiConnections._instance;
+    GenericOpenAiConnections._instance = this;
+    this.configPath = this.#resolveConfigPath();
+    this.#ensureConfigFile();
+    return this;
+  }
+
+  #resolveConfigPath() {
+    if (process.env.NODE_ENV === "development") {
+      return path.resolve(__dirname, `../../storage/config/${CONFIG_FILENAME}`);
+    }
+    const storageDir =
+      process.env.STORAGE_DIR ?? path.resolve(__dirname, `../../storage`);
+    return path.resolve(storageDir, `config/${CONFIG_FILENAME}`);
+  }
+
+  #ensureConfigFile() {
+    if (!fs.existsSync(this.configPath)) {
+      fs.mkdirSync(path.dirname(this.configPath), { recursive: true });
+      fs.writeFileSync(
+        this.configPath,
+        JSON.stringify({ connections: [], activeConnectionId: null }, null, 2),
+        "utf8"
+      );
+    }
+  }
+
+  #readConfig() {
+    return safeJsonParse(fs.readFileSync(this.configPath, "utf8"), {
+      connections: [],
+      activeConnectionId: null,
+    });
+  }
+
+  #writeConfig(config) {
+    fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2), "utf8");
+  }
+
+  /**
+   * @returns {GenericOpenAiConnection[]}
+   */
+  listConnections() {
+    const config = this.#readConfig();
+    return Array.isArray(config.connections) ? config.connections : [];
+  }
+
+  /**
+   * Public summary for settings API — never exposes API keys.
+   */
+  listSummaries() {
+    const config = this.#readConfig();
+    const activeId = config.activeConnectionId ?? null;
+    return this.listConnections().map((connection) => ({
+      id: connection.id,
+      name: connection.name,
+      basePath: connection.basePath,
+      modelPref: connection.modelPref,
+      tokenLimit: connection.tokenLimit,
+      maxTokens: connection.maxTokens,
+      hasApiKey: !!connection.apiKey,
+      isActive: connection.id === activeId,
+    }));
+  }
+
+  getActiveConnectionId() {
+    return this.#readConfig().activeConnectionId ?? null;
+  }
+
+  /**
+   * @param {string} id
+   * @returns {GenericOpenAiConnection|null}
+   */
+  getConnection(id) {
+    return this.listConnections().find((c) => c.id === id) ?? null;
+  }
+
+  /**
+   * @param {Object} input
+   * @returns {{ connection: GenericOpenAiConnection|null, error: string|null }}
+   */
+  upsertConnection(input = {}) {
+    const name = String(input.name || "").trim();
+    const basePath = String(input.basePath || "").trim();
+    const modelPref = String(input.modelPref || "").trim();
+    const tokenLimit = Number(input.tokenLimit);
+    const maxTokens = Number(input.maxTokens);
+
+    if (!name)
+      return { connection: null, error: "Connection name is required." };
+    if (!basePath) return { connection: null, error: "Base URL is required." };
+    if (!modelPref) return { connection: null, error: "Model is required." };
+    if (!Number.isFinite(tokenLimit) || tokenLimit <= 0) {
+      return {
+        connection: null,
+        error: "Model context window must be greater than 0.",
+      };
+    }
+    if (!Number.isFinite(maxTokens) || maxTokens <= 0) {
+      return { connection: null, error: "Max tokens must be greater than 0." };
+    }
+
+    const config = this.#readConfig();
+    const connections = this.listConnections();
+    const id = input.id ? String(input.id) : uuidv4();
+    const existingIndex = connections.findIndex((c) => c.id === id);
+
+    let apiKey = "";
+    if (typeof input.apiKey === "string" && input.apiKey.trim().length > 0) {
+      apiKey = input.apiKey.trim();
+    } else if (existingIndex >= 0) {
+      apiKey = connections[existingIndex].apiKey || "";
+    }
+
+    const connection = {
+      id,
+      name,
+      basePath,
+      apiKey,
+      modelPref,
+      tokenLimit,
+      maxTokens,
+    };
+
+    if (existingIndex >= 0) {
+      connections[existingIndex] = connection;
+    } else {
+      connections.push(connection);
+    }
+
+    config.connections = connections;
+    config.activeConnectionId = id;
+    this.#writeConfig(config);
+
+    return { connection, error: null };
+  }
+
+  /**
+   * @param {string} id
+   * @returns {{ success: boolean, error: string|null }}
+   */
+  deleteConnection(id) {
+    const config = this.#readConfig();
+    const connections = this.listConnections();
+    const index = connections.findIndex((c) => c.id === id);
+    if (index < 0) return { success: false, error: "Connection not found." };
+
+    connections.splice(index, 1);
+    config.connections = connections;
+    if (config.activeConnectionId === id) {
+      config.activeConnectionId = null;
+    }
+    this.#writeConfig(config);
+    return { success: true, error: null };
+  }
+
+  /**
+   * Apply a saved connection to the active Generic OpenAI ENV settings.
+   * @param {string} id
+   * @returns {Promise<{ success: boolean, error: string|null }>}
+   */
+  async activateConnection(id) {
+    const connection = this.getConnection(id);
+    if (!connection) return { success: false, error: "Connection not found." };
+
+    const payload = {
+      LLMProvider: "generic-openai",
+      GenericOpenAiBasePath: connection.basePath,
+      GenericOpenAiModelPref: connection.modelPref,
+      GenericOpenAiTokenLimit: String(connection.tokenLimit),
+      GenericOpenAiMaxTokens: String(connection.maxTokens),
+    };
+
+    if (connection.apiKey) {
+      payload.GenericOpenAiKey = connection.apiKey;
+    }
+
+    const { error } = await updateENV(payload, false);
+    if (error) return { success: false, error };
+
+    const config = this.#readConfig();
+    config.activeConnectionId = id;
+    this.#writeConfig(config);
+
+    return { success: true, error: null };
+  }
+}
+
+module.exports = { GenericOpenAiConnections };


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #3871

### Description

Adds **saved Generic OpenAI endpoint profiles** so users can store multiple base URLs / API keys / models (e.g. RunPod workers, LAN servers, LiteLLM routes) and switch between them from a dropdown in LLM Preference — without retyping settings each time.

**Backend**
- Persists profiles in `storage/config/generic-openai-connections.json` (gitignored; example file included)
- Admin API: list, save, activate, delete
- Selecting or saving a profile applies settings via existing `updateENV` path
- API keys are stored server-side only; list/summary endpoints never return secrets

**Frontend**
- Saved connection dropdown + Save / Delete actions on Generic OpenAI settings
- Applying a saved profile reloads the form with the active ENV values

This is a scoped first step toward the broader “stored connections” direction noted on #3871 / #2002 / #1567 (Generic OpenAI only for now).

### Visuals (if applicable)

N/A — dropdown + buttons above existing Generic OpenAI fields in LLM Preference.

### Additional Information

**Local testing**

```sh
yarn lint:ci
yarn test server/__tests__/utils/llm/genericOpenAiConnections.test.js
cd frontend && yarn build
cd docker && export UID=0 GID=0 && docker compose up -d --build
```

Results:
- `yarn lint:ci` — pass
- Connection manager unit tests — **4/4 pass** (create/list summaries hide secrets, update preserves API key when omitted, activate via `updateENV`, delete)
- `yarn build` (frontend) — pass

**Live API smoke test** (`yarn dev` server + `curl`):
- List / save / activate / update / delete saved connections — pass
- `setup-complete` reflects applied Generic OpenAI fields after save/activate
- List API returns `hasApiKey` only (no raw `apiKey` field)
- Validation errors: missing name, unknown id, invalid URL — expected failures

**Docker build & runtime** (from `docker/` per HOW_TO_USE_DOCKER.md):
- `docker compose up -d --build` — **success** (`anythingllm-anything-llm:latest`, ~4.67GB)
- Container `anythingllm` — **healthy**, `http://localhost:3001/api/ping` → `{"online":true}`
- Saved-connections API exercised inside running container — save + `setup-complete` pass

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally