### PR TITLE
chore: route agent chats with no tools through native tooled completions

### DIFF
--- a/server/utils/agents/aibitat/providers/apipie.js
+++ b/server/utils/agents/aibitat/providers/apipie.js
@@ -60,7 +60,7 @@ class ApiPieProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -100,7 +100,7 @@ class ApiPieProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/bedrock.js
+++ b/server/utils/agents/aibitat/providers/bedrock.js
@@ -68,8 +68,7 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -109,8 +108,7 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/cerebras.js
+++ b/server/utils/agents/aibitat/providers/cerebras.js
@@ -83,8 +83,7 @@ class CerebrasProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -129,8 +128,7 @@ class CerebrasProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/cohere.js
+++ b/server/utils/agents/aibitat/providers/cohere.js
@@ -80,8 +80,7 @@ class CohereProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -121,8 +120,7 @@ class CohereProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/cometapi.js
+++ b/server/utils/agents/aibitat/providers/cometapi.js
@@ -64,7 +64,7 @@ class CometApiProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -104,7 +104,7 @@ class CometApiProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/deepseek.js
+++ b/server/utils/agents/aibitat/providers/deepseek.js
@@ -119,7 +119,7 @@ class DeepSeekProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
     const cleanedMessages = this.#stripAttachments(messages);
 
     if (!useNative) {
@@ -160,7 +160,7 @@ class DeepSeekProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
     const cleanedMessages = this.#stripAttachments(messages);
 
     if (!useNative) {

--- a/server/utils/agents/aibitat/providers/dockerModelRunner.js
+++ b/server/utils/agents/aibitat/providers/dockerModelRunner.js
@@ -90,8 +90,7 @@ class DockerModelRunnerProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -135,8 +134,7 @@ class DockerModelRunnerProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/fireworksai.js
+++ b/server/utils/agents/aibitat/providers/fireworksai.js
@@ -61,7 +61,7 @@ class FireworksAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -101,7 +101,7 @@ class FireworksAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/genericOpenAi.js
+++ b/server/utils/agents/aibitat/providers/genericOpenAi.js
@@ -11,9 +11,9 @@ const { attachmentToContentBlock } = require("../../../helpers/attachments");
 
 /**
  * The agent provider for the Generic OpenAI provider.
- * Since we cannot promise the generic provider even supports tool calling
- * which is nearly 100% likely it does not, we can just wrap it in untooled
- * which often is far better anyway.
+ * Uses native OpenAI-compatible tool calling by default and falls back to
+ * the UnTooled prompt-based approach when native tool calling is disabled
+ * via PROVIDER_DISABLE_NATIVE_TOOL_CALLING.
  */
 class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
   model;
@@ -104,8 +104,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -149,8 +148,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/giteeai.js
+++ b/server/utils/agents/aibitat/providers/giteeai.js
@@ -55,7 +55,7 @@ class GiteeAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -95,7 +95,7 @@ class GiteeAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/groq.js
+++ b/server/utils/agents/aibitat/providers/groq.js
@@ -67,8 +67,7 @@ class GroqProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -112,8 +111,7 @@ class GroqProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -12,7 +12,7 @@ const { attachmentToContentBlock } = require("../../../../helpers/attachments");
  *   const { tooledStream, tooledComplete } = require("./helpers/tooled.js");
  *
  *   async stream(messages, functions, eventHandler) {
- *     if (functions.length > 0 && await this.supportsNativeToolCalling()) {
+ *     if (await this.supportsNativeToolCalling()) {
  *       return tooledStream(this.client, this.model, messages, functions, eventHandler);
  *     }
  *     // ... fallback to UnTooled ...

--- a/server/utils/agents/aibitat/providers/koboldcpp.js
+++ b/server/utils/agents/aibitat/providers/koboldcpp.js
@@ -63,7 +63,7 @@ class KoboldCPPProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -103,7 +103,7 @@ class KoboldCPPProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/lemonade.js
+++ b/server/utils/agents/aibitat/providers/lemonade.js
@@ -84,8 +84,7 @@ class LemonadeProvider extends InheritMultiple([Provider, UnTooled]) {
    */
   async stream(messages, functions = [], eventHandler = null) {
     await this.preloadModel();
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -130,8 +129,7 @@ class LemonadeProvider extends InheritMultiple([Provider, UnTooled]) {
    */
   async complete(messages, functions = []) {
     await this.preloadModel();
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/litellm.js
+++ b/server/utils/agents/aibitat/providers/litellm.js
@@ -67,8 +67,7 @@ class LiteLLMProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -112,8 +111,7 @@ class LiteLLMProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/lmstudio.js
+++ b/server/utils/agents/aibitat/providers/lmstudio.js
@@ -95,8 +95,7 @@ class LMStudioProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -141,8 +140,7 @@ class LMStudioProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/localai.js
+++ b/server/utils/agents/aibitat/providers/localai.js
@@ -69,8 +69,7 @@ class LocalAiProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -114,8 +113,7 @@ class LocalAiProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/minimax.js
+++ b/server/utils/agents/aibitat/providers/minimax.js
@@ -91,7 +91,7 @@ class MinimaxProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
     const cleanedMessages = this.#stripAttachments(messages);
 
     if (!useNative) {
@@ -132,7 +132,7 @@ class MinimaxProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
     const cleanedMessages = this.#stripAttachments(messages);
 
     if (!useNative) {

--- a/server/utils/agents/aibitat/providers/mistral.js
+++ b/server/utils/agents/aibitat/providers/mistral.js
@@ -60,7 +60,7 @@ class MistralProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -100,7 +100,7 @@ class MistralProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/moonshotAi.js
+++ b/server/utils/agents/aibitat/providers/moonshotAi.js
@@ -57,7 +57,7 @@ class MoonshotAiProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -97,7 +97,7 @@ class MoonshotAiProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/novita.js
+++ b/server/utils/agents/aibitat/providers/novita.js
@@ -90,8 +90,7 @@ class NovitaProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -135,8 +134,7 @@ class NovitaProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/ollama.js
+++ b/server/utils/agents/aibitat/providers/ollama.js
@@ -295,8 +295,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
    * @returns The completion.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (useNative) {
       this.providerLog(
@@ -311,7 +310,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       const stream = await this.client.chat({
         model: this.model,
         messages: formattedMessages,
-        tools,
+        ...(tools.length > 0 ? { tools } : {}),
         stream: true,
         options: this.queryOptions,
       });
@@ -495,8 +494,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
    * @returns The completion.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (useNative) {
       this.resetUsage();
@@ -507,7 +505,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       const response = await this.client.chat({
         model: this.model,
         messages: formattedMessages,
-        tools,
+        ...(tools.length > 0 ? { tools } : {}),
         options: this.queryOptions,
       });
 

--- a/server/utils/agents/aibitat/providers/omlx.js
+++ b/server/utils/agents/aibitat/providers/omlx.js
@@ -72,8 +72,7 @@ class OMLXProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -117,8 +116,7 @@ class OMLXProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when supported, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/openrouter.js
+++ b/server/utils/agents/aibitat/providers/openrouter.js
@@ -75,8 +75,7 @@ class OpenRouterProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -120,8 +119,7 @@ class OpenRouterProvider extends InheritMultiple([Provider, UnTooled]) {
    * Uses native tool calling when enabled via ENV, otherwise falls back to UnTooled.
    */
   async complete(messages, functions = []) {
-    const useNative =
-      functions.length > 0 && (await this.supportsNativeToolCalling());
+    const useNative = await this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/ppio.js
+++ b/server/utils/agents/aibitat/providers/ppio.js
@@ -64,7 +64,7 @@ class PPIOProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -104,7 +104,7 @@ class PPIOProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/privatemode.js
+++ b/server/utils/agents/aibitat/providers/privatemode.js
@@ -65,7 +65,7 @@ class PrivatemodelProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -105,7 +105,7 @@ class PrivatemodelProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/sambanova.js
+++ b/server/utils/agents/aibitat/providers/sambanova.js
@@ -54,7 +54,7 @@ class SambaNovaProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -94,7 +94,7 @@ class SambaNovaProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/textgenwebui.js
+++ b/server/utils/agents/aibitat/providers/textgenwebui.js
@@ -59,7 +59,7 @@ class TextWebGenUiProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -99,7 +99,7 @@ class TextWebGenUiProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/togetherai.js
+++ b/server/utils/agents/aibitat/providers/togetherai.js
@@ -60,7 +60,7 @@ class TogetherAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -100,7 +100,7 @@ class TogetherAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/xai.js
+++ b/server/utils/agents/aibitat/providers/xai.js
@@ -60,7 +60,7 @@ class XAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -100,7 +100,7 @@ class XAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(

--- a/server/utils/agents/aibitat/providers/zai.js
+++ b/server/utils/agents/aibitat/providers/zai.js
@@ -57,7 +57,7 @@ class ZAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async stream(messages, functions = [], eventHandler = null) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.stream.call(
@@ -97,7 +97,7 @@ class ZAIProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async complete(messages, functions = []) {
-    const useNative = functions.length > 0 && this.supportsNativeToolCalling();
+    const useNative = this.supportsNativeToolCalling();
 
     if (!useNative) {
       return await UnTooled.prototype.complete.call(


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [x] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #

### Description

Agent providers previously gated the native tool-calling path on `functions.length > 0`, so any agent chat with no tools attached was routed through the `UnTooled` prompt-based fallback — even on providers that fully support native tool calling.

This PR drops the `functions.length > 0` condition across all 30 providers that use the `useNative` routing pattern, so the native completion path is used whenever `supportsNativeToolCalling()` is true. `UnTooled` is now only used by providers without native support or when explicitly disabled via `PROVIDER_DISABLE_NATIVE_TOOL_CALLING`.

Because requests can now reach the native path with zero tools:

- The shared `helpers/tooled.js` request builders already omit the `tools` key when the list is empty, which covers all OpenAI-compatible providers.
- Ollama builds its own requests via the Ollama SDK, so it now conditionally spreads `tools` into the request only when tools exist.

Providers not touched are already consistent: `azure`, `openai`, `anthropic`, and `gemini` are always-native; `perplexity`, `foundry`, and `nvidiaNim` hard-code `supportsNativeToolCalling()` to `false` and always use `UnTooled`.

### Visuals (if applicable)

N/A

### Additional Information

All existing agent test suites pass (7 suites, 43 tests), including `helpers/tooled.test.js` which covers the shared native tool-calling path.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally

### Testing Checklist

Manual verification of each affected provider: run an agent chat with no tools mounted and confirm the request succeeds through the native path (no `tools` key sent).

| Provider | Model Used | Status |
| --- | --- | --- |
| APIpie | `gpt-4o` | ✅  |
| AWS Bedrock | `minimax` | ✅ |
| Cerebras | `gemma-27b` | ✅ |
| Cohere | `command-r` | ✅ |
| CometAPI | | ⬜ |
| DeepSeek | `deepseek-v4-pro` | ✅ |
| Docker Model Runner | `gemma4:latest`, `qwen3.6:latest` | ✅ |
| Fireworks AI | `glm-5.2` | ✅ |
| Generic OpenAI | `gemma4:e4b` (via Ollama) | ✅ |
| Gitee AI | | ⬜ |
| Groq | `gpt-oss-20b`| ✅ |
| KoboldCPP | | ⬜ |
| Lemonade | `gemma4-e2b` | ✅ |
| LiteLLM | | ⬜ |
| LM Studio | `gemma4-e4b` | ✅ |
| LocalAI | `gemma4-12b` | ✅ |
| MiniMax | | ⬜ |
| Mistral | | ⬜ |
| Moonshot AI | `kimi-k2.5` | ✅ |
| Novita | | ⬜ |
| Ollama | `gemma4:latest`, `qwen3.5:latest` | ✅ |
| oMLX | `gemma4-e4b` | ✅ |
| OpenRouter | `anthropic/claude-opus-5`, `qwen/qwen3.7-flash` | ✅ |
| PPIO | | ⬜ |
| PrivateMode | | ⬜ |
| SambaNova | | ⬜ |
| Text Gen Web UI | | ⬜ |
| Together AI | `gpt-oss-120b` | ✅ |
| xAI | `grok-4.3` | ✅ |
| Z.AI | | ⬜ |
