### PR TITLE
Reset agent clarifying-questions counter per turn

### DIFF
--- a/server/utils/agents/aibitat/plugins/request-user-input.js
+++ b/server/utils/agents/aibitat/plugins/request-user-input.js
@@ -110,7 +110,7 @@ const AskUser = {
         // present, so API/ephemeral runs would otherwise crash on call.
         if (typeof aibitat.requestUserClarification !== "function") return;
 
-        // A websocket session reuses one aibitat instance for every turn, so the
+        // A websocket session reuses one aibitat instance for every session, so the
         // per-turn counter has to reset when the user sends a new message or the
         // cap would apply to the whole session instead of the turn.
         aibitat.onMessage((message) => {

--- a/server/utils/agents/aibitat/plugins/request-user-input.js
+++ b/server/utils/agents/aibitat/plugins/request-user-input.js
@@ -110,6 +110,14 @@ const AskUser = {
         // present, so API/ephemeral runs would otherwise crash on call.
         if (typeof aibitat.requestUserClarification !== "function") return;
 
+        // A websocket session reuses one aibitat instance for every turn, so the
+        // per-turn counter has to reset when the user sends a new message or the
+        // cap would apply to the whole session instead of the turn.
+        aibitat.onMessage((message) => {
+          if (message.from !== "USER" || !aibitat._clarifyState) return;
+          aibitat._clarifyState.asked = 0;
+        });
+
         aibitat.function({
           super: aibitat,
           name: "request-user-input",


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #6082 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- reset the clarifying-questions agent tool counter when the user sends a new message so the cap applies per turn instead of leaking to the whole agent session

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
