### PR TITLE
fix: accumulate token usage across all completion calls in agent runs

### DIFF
--- a/server/__tests__/utils/agents/aibitat/providers/ai-provider.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/ai-provider.test.js
@@ -1,0 +1,149 @@
+const Provider = require("../../../../../utils/agents/aibitat/providers/ai-provider.js");
+const UnTooled = require("../../../../../utils/agents/aibitat/providers/helpers/untooled.js");
+const InheritMultiple = require("../../../../../utils/agents/aibitat/providers/helpers/classes.js");
+
+class TestProvider extends Provider {
+  model = "test-model";
+
+  constructor() {
+    super(null);
+  }
+}
+
+// Mirrors how the UnTooled providers (LM Studio, LocalAI, Cerebras, etc.) are
+// declared - Provider's fields and methods arrive via the InheritMultiple mixin
+// rather than a direct prototype chain.
+class MixinProvider extends InheritMultiple([Provider, UnTooled]) {
+  model = "mixin-model";
+}
+
+describe("Provider usage tracking", () => {
+  test("recordUsage accumulates tokens across multiple completions", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 250,
+      completion_tokens: 40,
+      total_tokens: 290,
+    });
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 400,
+      completion_tokens: 60,
+      total_tokens: 460,
+    });
+
+    // getUsage only reflects the most recent completion
+    const last = provider.getUsage();
+    expect(last.prompt_tokens).toBe(400);
+    expect(last.completion_tokens).toBe(60);
+    expect(last.total_tokens).toBe(460);
+
+    // getCumulativeUsage reflects the sum of all completions
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(750);
+    expect(totals.completion_tokens).toBe(120);
+    expect(totals.total_tokens).toBe(870);
+    expect(totals.model).toBe("test-model");
+    expect(totals.provider).toBe("TestProvider");
+  });
+
+  test("resetUsage does not clear the accumulated totals", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+
+    provider.resetUsage();
+    expect(provider.getUsage().total_tokens).toBe(0);
+    expect(provider.getCumulativeUsage().total_tokens).toBe(120);
+  });
+
+  test("resetCumulativeUsage zeroes the accumulated totals", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+
+    provider.resetCumulativeUsage();
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(0);
+    expect(totals.completion_tokens).toBe(0);
+    expect(totals.total_tokens).toBe(0);
+    expect(totals.model).toBe(null);
+    expect(totals.provider).toBe(null);
+  });
+
+  test("recordUsage normalizes Anthropic-style input/output token keys", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({ input_tokens: 30, output_tokens: 10 });
+
+    provider.resetUsage();
+    provider.recordUsage({ input_tokens: 50, output_tokens: 15 });
+
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(80);
+    expect(totals.completion_tokens).toBe(25);
+    expect(totals.total_tokens).toBe(105);
+  });
+
+  test("instances do not share an accumulator", () => {
+    const providerA = new TestProvider();
+    const providerB = new TestProvider();
+
+    providerA.resetUsage();
+    providerA.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+
+    expect(providerA.getCumulativeUsage().total_tokens).toBe(120);
+    expect(providerB.getCumulativeUsage().total_tokens).toBe(0);
+  });
+
+  test("accumulation works through InheritMultiple mixin providers", () => {
+    const providerA = new MixinProvider();
+    const providerB = new MixinProvider();
+
+    providerA.resetUsage();
+    providerA.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      total_tokens: 110,
+    });
+
+    providerA.resetUsage();
+    providerA.recordUsage({
+      prompt_tokens: 300,
+      completion_tokens: 30,
+      total_tokens: 330,
+    });
+
+    expect(providerA.getCumulativeUsage().total_tokens).toBe(440);
+    expect(providerA.getUsage().total_tokens).toBe(330);
+    expect(providerB.getCumulativeUsage().total_tokens).toBe(0);
+
+    providerA.resetCumulativeUsage();
+    expect(providerA.getCumulativeUsage().total_tokens).toBe(0);
+  });
+});

--- a/server/__tests__/utils/agents/aibitat/providers/ai-provider.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/ai-provider.test.js
@@ -147,3 +147,138 @@ describe("Provider usage tracking", () => {
     expect(providerA.getCumulativeUsage().total_tokens).toBe(0);
   });
 });
+
+describe("Provider usage robustness against malformed payloads", () => {
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "not-a-usage-object"],
+    ["a number", 42],
+    ["a boolean", true],
+    ["an array", [100, 20, 120]],
+    ["an empty object", {}],
+  ])("recordUsage does not crash when the payload is %s", (_label, payload) => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    expect(() => provider.recordUsage(payload)).not.toThrow();
+
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(0);
+    expect(totals.completion_tokens).toBe(0);
+    expect(totals.total_tokens).toBe(0);
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "not-a-usage-object"],
+    ["an array", [100, 20, 120]],
+  ])("applyUsage does not crash when the payload is %s", (_label, payload) => {
+    const provider = new TestProvider();
+    expect(() => provider.applyUsage(payload)).not.toThrow();
+    expect(provider.getCumulativeUsage().total_tokens).toBe(0);
+  });
+
+  test("coerces numeric strings instead of concatenating them", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: "100",
+      completion_tokens: "20",
+      total_tokens: "120",
+    });
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: "50",
+      completion_tokens: "5",
+      total_tokens: "55",
+    });
+
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(150);
+    expect(totals.completion_tokens).toBe(25);
+    expect(totals.total_tokens).toBe(175);
+    expect(typeof totals.total_tokens).toBe("number");
+  });
+
+  test("treats negative, NaN, and non-finite token counts as zero", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: -100,
+      completion_tokens: NaN,
+      total_tokens: Infinity,
+    });
+
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(0);
+    expect(totals.completion_tokens).toBe(0);
+    expect(totals.total_tokens).toBe(0);
+  });
+
+  test("treats non-numeric token values as zero", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: { nested: 100 },
+      completion_tokens: "twenty",
+      total_tokens: () => 120,
+    });
+
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(0);
+    expect(totals.completion_tokens).toBe(0);
+    expect(totals.total_tokens).toBe(0);
+  });
+
+  test("garbage payloads between valid completions do not corrupt totals", () => {
+    const provider = new TestProvider();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+
+    provider.resetUsage();
+    provider.recordUsage(null);
+
+    provider.resetUsage();
+    provider.recordUsage({ prompt_tokens: "junk", completion_tokens: -5 });
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 50,
+      completion_tokens: 10,
+      total_tokens: 60,
+    });
+
+    const totals = provider.getCumulativeUsage();
+    expect(totals.prompt_tokens).toBe(150);
+    expect(totals.completion_tokens).toBe(30);
+    expect(totals.total_tokens).toBe(180);
+  });
+
+  test("mixin providers survive malformed payloads too", () => {
+    const provider = new MixinProvider();
+
+    provider.resetUsage();
+    expect(() => provider.recordUsage(null)).not.toThrow();
+    expect(() => provider.recordUsage([1, 2, 3])).not.toThrow();
+
+    provider.resetUsage();
+    provider.recordUsage({
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      total_tokens: 110,
+    });
+
+    expect(provider.getCumulativeUsage().total_tokens).toBe(110);
+  });
+});

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -1028,7 +1028,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     // and reset the usage accumulator so metrics only cover this run's completions.
     if (depth === 0) {
       this?.flushRoutingMetadata?.(v4());
-      this.providerInstance?.resetCumulativeUsage?.();
+      this.providerInstance.resetCumulativeUsage();
     }
 
     /** @type {{ functionCall: { name: string, arguments: string }, textResponse: string }} */
@@ -1194,7 +1194,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     // and reset the usage accumulator so metrics only cover this run's completions.
     if (depth === 0) {
       this?.flushRoutingMetadata?.(msgUUID);
-      this.providerInstance?.resetCumulativeUsage?.();
+      this.providerInstance.resetCumulativeUsage();
     }
 
     // get the chat completion

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -1025,7 +1025,11 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     };
 
     // Emit routing notification before the first completion so it appears above the response
-    if (depth === 0) this?.flushRoutingMetadata?.(v4());
+    // and reset the usage accumulator so metrics only cover this run's completions.
+    if (depth === 0) {
+      this?.flushRoutingMetadata?.(v4());
+      this.providerInstance?.resetCumulativeUsage?.();
+    }
 
     /** @type {{ functionCall: { name: string, arguments: string }, textResponse: string }} */
     const completionStream = await this.#safeProviderCall(() =>
@@ -1111,7 +1115,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
         eventHandler?.("reportStreamEvent", {
           type: "usageMetrics",
           uuid: directOutputUUID,
-          metrics: this.providerInstance.getUsage(),
+          metrics: this.providerInstance.getCumulativeUsage(),
         });
         this?.flushCitations?.(directOutputUUID);
         this?.emitChatId?.(directOutputUUID);
@@ -1152,7 +1156,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     eventHandler?.("reportStreamEvent", {
       type: "usageMetrics",
       uuid: responseUuid,
-      metrics: this.providerInstance.getUsage(),
+      metrics: this.providerInstance.getCumulativeUsage(),
     });
     this?.flushCitations?.(responseUuid);
     this?.emitChatId?.(responseUuid);
@@ -1187,7 +1191,11 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     };
 
     // Emit routing notification before the first completion so it appears above the response
-    if (depth === 0) this?.flushRoutingMetadata?.(msgUUID);
+    // and reset the usage accumulator so metrics only cover this run's completions.
+    if (depth === 0) {
+      this?.flushRoutingMetadata?.(msgUUID);
+      this.providerInstance?.resetCumulativeUsage?.();
+    }
 
     // get the chat completion
     const completion = await this.#safeProviderCall(() =>
@@ -1262,7 +1270,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
         eventHandler?.("reportStreamEvent", {
           type: "usageMetrics",
           uuid: msgUUID,
-          metrics: this.providerInstance.getUsage(),
+          metrics: this.providerInstance.getCumulativeUsage(),
         });
         this?.flushCitations?.(msgUUID);
         return result;
@@ -1302,7 +1310,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
     eventHandler?.("reportStreamEvent", {
       type: "usageMetrics",
       uuid: msgUUID,
-      metrics: this.providerInstance.getUsage(),
+      metrics: this.providerInstance.getCumulativeUsage(),
     });
     this?.flushCitations?.(msgUUID);
     this?.emitChatId?.(msgUUID);

--- a/server/utils/agents/aibitat/plugins/chat-history.js
+++ b/server/utils/agents/aibitat/plugins/chat-history.js
@@ -99,7 +99,7 @@ const chatHistory = {
         { prompt, response, attachments = [] } = {}
       ) {
         const invocation = aibitat.handlerProps.invocation;
-        const metrics = aibitat.providerInstance?.getUsage?.() ?? {};
+        const metrics = aibitat.providerInstance?.getCumulativeUsage?.() ?? {};
         const citations = aibitat._pendingCitations ?? [];
         const outputs = aibitat._pendingOutputs ?? [];
         const clarifyingQuestions =
@@ -134,7 +134,7 @@ const chatHistory = {
         { prompt, response, attachments = [], options = {} } = {}
       ) {
         const invocation = aibitat.handlerProps.invocation;
-        const metrics = aibitat.providerInstance?.getUsage?.() ?? {};
+        const metrics = aibitat.providerInstance?.getCumulativeUsage?.() ?? {};
         const citations = aibitat._pendingCitations ?? [];
         const outputs = aibitat._pendingOutputs ?? [];
         const clarifyingQuestions =

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -51,6 +51,8 @@ const { bindAbortSignal } = require("../../../helpers/abortSignals");
  * @property {(messages: Array, functions?: Array, eventHandler?: Function) => Promise<{functionCall: any, textResponse: string}>} stream - Stream a chat completion with tool calling.
  * @property {(messages: Array, functions?: Array) => Promise<{functionCall: any, textResponse: string, result?: string}>} complete - Non-streaming chat completion with tool calling.
  * @property {() => ProviderUsageMetrics} getUsage - Get usage metrics from the last completion.
+ * @property {() => ProviderUsageMetrics} getCumulativeUsage - Get usage metrics accumulated across all completions in the current run.
+ * @property {() => void} resetCumulativeUsage - Reset the accumulated usage metrics (call at the start of a run).
  */
 
 class Provider {
@@ -76,6 +78,24 @@ class Provider {
    * @type {ProviderUsageMetrics}
    */
   lastUsage = {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+    duration: 0,
+    outputTps: 0,
+    model: null,
+    provider: null,
+    timestamp: null,
+  };
+
+  /**
+   * Stores the usage metrics accumulated across every completion call in the
+   * current run. An agent loop makes one completion per tool call plus a final
+   * one for the response - this is the sum of all of them, whereas `lastUsage`
+   * only ever reflects the most recent call.
+   * @type {ProviderUsageMetrics}
+   */
+  cumulativeUsage = {
     prompt_tokens: 0,
     completion_tokens: 0,
     total_tokens: 0,
@@ -639,16 +659,68 @@ class Provider {
     const completionTokens =
       usage.completion_tokens || usage.output_tokens || 0;
 
-    this.lastUsage = {
+    this.applyUsage({
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
       total_tokens: usage.total_tokens || promptTokens + completionTokens,
+      duration,
+    });
+  }
+
+  /**
+   * Stores a normalized usage record for the completion that just finished and
+   * adds it to the run-level accumulated totals. Subclasses that override
+   * `recordUsage` should normalize their provider-specific usage format and
+   * call this so accumulation still happens in one place.
+   * @param {{prompt_tokens?: number, completion_tokens?: number, total_tokens?: number, duration?: number}} usage
+   */
+  applyUsage({
+    prompt_tokens = 0,
+    completion_tokens = 0,
+    total_tokens = 0,
+    duration = 0,
+  } = {}) {
+    const timestamp = new Date();
+    this.lastUsage = {
+      prompt_tokens,
+      completion_tokens,
+      total_tokens,
       outputTps:
-        completionTokens && duration > 0 ? completionTokens / duration : 0,
+        completion_tokens && duration > 0 ? completion_tokens / duration : 0,
       duration,
       model: this.model,
       provider: this.constructor.name,
-      timestamp: new Date(),
+      timestamp,
+    };
+
+    const totals = this.cumulativeUsage;
+    totals.prompt_tokens += prompt_tokens;
+    totals.completion_tokens += completion_tokens;
+    totals.total_tokens += total_tokens;
+    totals.duration += duration;
+    totals.outputTps =
+      totals.completion_tokens && totals.duration > 0
+        ? totals.completion_tokens / totals.duration
+        : 0;
+    totals.model = this.model;
+    totals.provider = this.constructor.name;
+    totals.timestamp = timestamp;
+  }
+
+  /**
+   * Resets the accumulated usage metrics. Call this at the start of an agent
+   * run so the totals only cover that run's completions.
+   */
+  resetCumulativeUsage() {
+    this.cumulativeUsage = {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+      duration: 0,
+      outputTps: 0,
+      model: null,
+      provider: null,
+      timestamp: null,
     };
   }
 
@@ -658,6 +730,15 @@ class Provider {
    */
   getUsage() {
     return { ...this.lastUsage };
+  }
+
+  /**
+   * Get the usage metrics accumulated across all completions in the current
+   * run - one completion per tool call plus the final response.
+   * @returns {ProviderUsageMetrics} The accumulated usage metrics
+   */
+  getCumulativeUsage() {
+    return { ...this.cumulativeUsage };
   }
 
   /**

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -106,6 +106,20 @@ class Provider {
   }
 
   /**
+   * Coerces a provider-reported metric into a safe, finite, non-negative
+   * number. Providers report usage in inconsistent shapes (missing keys,
+   * numeric strings, nulls, negative or non-finite values), so anything that
+   * does not resolve to a usable number becomes 0.
+   * @param {unknown} value
+   * @returns {number}
+   */
+  static #toSafeMetric(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number) || number < 0) return 0;
+    return number;
+  }
+
+  /**
    * Timestamp when the current request started (for duration calculation).
    * @type {number}
    */
@@ -654,14 +668,19 @@ class Provider {
       duration = (Date.now() - this._requestStartTime) / 1000;
     }
 
-    const promptTokens = usage.prompt_tokens || usage.input_tokens || 0;
-    const completionTokens =
-      usage.completion_tokens || usage.output_tokens || 0;
+    const safeUsage = usage && typeof usage === "object" ? usage : {};
+    const promptTokens = Provider.#toSafeMetric(
+      safeUsage.prompt_tokens || safeUsage.input_tokens
+    );
+    const completionTokens = Provider.#toSafeMetric(
+      safeUsage.completion_tokens || safeUsage.output_tokens
+    );
+    const totalTokens = Provider.#toSafeMetric(safeUsage.total_tokens);
 
     this.applyUsage({
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
-      total_tokens: usage.total_tokens || promptTokens + completionTokens,
+      total_tokens: totalTokens || promptTokens + completionTokens,
       duration,
     });
   }
@@ -671,21 +690,26 @@ class Provider {
    * adds it to the run-level accumulated totals. Subclasses that override
    * `recordUsage` should normalize their provider-specific usage format and
    * call this so accumulation still happens in one place.
+   * Every value is coerced to a safe number so a malformed payload from any
+   * provider cannot crash the run or corrupt the accumulated totals.
    * @param {{prompt_tokens?: number, completion_tokens?: number, total_tokens?: number, duration?: number}} usage
    */
-  applyUsage({
-    prompt_tokens = 0,
-    completion_tokens = 0,
-    total_tokens = 0,
-    duration = 0,
-  } = {}) {
+  applyUsage(usage = {}) {
+    const safeUsage = usage && typeof usage === "object" ? usage : {};
+    const promptTokens = Provider.#toSafeMetric(safeUsage.prompt_tokens);
+    const completionTokens = Provider.#toSafeMetric(
+      safeUsage.completion_tokens
+    );
+    const totalTokens = Provider.#toSafeMetric(safeUsage.total_tokens);
+    const duration = Provider.#toSafeMetric(safeUsage.duration);
+
     const timestamp = new Date();
     this.lastUsage = {
-      prompt_tokens,
-      completion_tokens,
-      total_tokens,
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: totalTokens,
       outputTps:
-        completion_tokens && duration > 0 ? completion_tokens / duration : 0,
+        completionTokens && duration > 0 ? completionTokens / duration : 0,
       duration,
       model: this.model,
       provider: this.constructor.name,
@@ -693,9 +717,9 @@ class Provider {
     };
 
     const totals = this.cumulativeUsage;
-    totals.prompt_tokens += prompt_tokens;
-    totals.completion_tokens += completion_tokens;
-    totals.total_tokens += total_tokens;
+    totals.prompt_tokens += promptTokens;
+    totals.completion_tokens += completionTokens;
+    totals.total_tokens += totalTokens;
     totals.duration += duration;
     totals.outputTps =
       totals.completion_tokens && totals.duration > 0

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -77,16 +77,7 @@ class Provider {
    * Stores the usage metrics from the last completion call.
    * @type {ProviderUsageMetrics}
    */
-  lastUsage = {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-    total_tokens: 0,
-    duration: 0,
-    outputTps: 0,
-    model: null,
-    provider: null,
-    timestamp: null,
-  };
+  lastUsage = Provider.#emptyUsage();
 
   /**
    * Stores the usage metrics accumulated across every completion call in the
@@ -95,16 +86,24 @@ class Provider {
    * only ever reflects the most recent call.
    * @type {ProviderUsageMetrics}
    */
-  cumulativeUsage = {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-    total_tokens: 0,
-    duration: 0,
-    outputTps: 0,
-    model: null,
-    provider: null,
-    timestamp: null,
-  };
+  cumulativeUsage = Provider.#emptyUsage();
+
+  /**
+   * Zeroed usage metrics for initializing/resetting an accumulator.
+   * @returns {ProviderUsageMetrics}
+   */
+  static #emptyUsage() {
+    return {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+      duration: 0,
+      outputTps: 0,
+      model: null,
+      provider: null,
+      timestamp: null,
+    };
+  }
 
   /**
    * Timestamp when the current request started (for duration calculation).
@@ -712,16 +711,7 @@ class Provider {
    * run so the totals only cover that run's completions.
    */
   resetCumulativeUsage() {
-    this.cumulativeUsage = {
-      prompt_tokens: 0,
-      completion_tokens: 0,
-      total_tokens: 0,
-      duration: 0,
-      outputTps: 0,
-      model: null,
-      provider: null,
-      timestamp: null,
-    };
+    this.cumulativeUsage = Provider.#emptyUsage();
   }
 
   /**

--- a/server/utils/agents/aibitat/providers/cerebras.js
+++ b/server/utils/agents/aibitat/providers/cerebras.js
@@ -181,17 +181,12 @@ class CerebrasProvider extends InheritMultiple([Provider, UnTooled]) {
     const completionTokens = usage.completion_tokens || 0;
     if (time_info?.completion_time) duration = time_info.completion_time;
 
-    this.lastUsage = {
+    this.applyUsage({
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
-      total_tokens: usage.total_tokens,
-      outputTps:
-        completionTokens && duration > 0 ? completionTokens / duration : 0,
+      total_tokens: usage.total_tokens || promptTokens + completionTokens,
       duration,
-      model: this.model,
-      provider: this.constructor.name,
-      timestamp: new Date(),
-    };
+    });
   }
 
   /**

--- a/server/utils/agents/aibitat/providers/cerebras.js
+++ b/server/utils/agents/aibitat/providers/cerebras.js
@@ -177,14 +177,15 @@ class CerebrasProvider extends InheritMultiple([Provider, UnTooled]) {
   recordUsage(usage = {}, time_info = {}) {
     // assume start time
     let duration = (Date.now() - this._requestStartTime) / 1000;
-    const promptTokens = usage.prompt_tokens || 0;
-    const completionTokens = usage.completion_tokens || 0;
+    const safeUsage = usage && typeof usage === "object" ? usage : {};
+    const promptTokens = safeUsage.prompt_tokens || 0;
+    const completionTokens = safeUsage.completion_tokens || 0;
     if (time_info?.completion_time) duration = time_info.completion_time;
 
     this.applyUsage({
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
-      total_tokens: usage.total_tokens || promptTokens + completionTokens,
+      total_tokens: safeUsage.total_tokens || promptTokens + completionTokens,
       duration,
     });
   }

--- a/server/utils/agents/aibitat/providers/gemini.js
+++ b/server/utils/agents/aibitat/providers/gemini.js
@@ -274,12 +274,17 @@ class GeminiProvider extends Provider {
         functionCall: null,
       };
 
+      // Gemini can attach usage to more than one chunk, so capture the latest
+      // and record exactly once after the stream ends - recordUsage accumulates
+      // into run totals, so calling it per-chunk would inflate them.
+      let usage = null;
+
       for await (const streamEvent of response) {
         /** @type {OpenAI.OpenAI.Chat.ChatCompletionChunk} */
         const chunk = streamEvent;
 
         // Capture usage from final chunk (when stream_options.include_usage is true)
-        if (chunk?.usage) this.recordUsage(chunk.usage);
+        if (chunk?.usage) usage = chunk.usage;
         const { content, tool_calls } = chunk?.choices?.[0]?.delta || {};
 
         if (content) {
@@ -315,6 +320,8 @@ class GeminiProvider extends Provider {
           });
         }
       }
+
+      if (usage) this.recordUsage(usage);
 
       if (completion.functionCall) {
         completion.functionCall.arguments = safeJsonParse(


### PR DESCRIPTION

### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #6084

### Description

Agent runs saved token usage from only the final completion call of the agent loop — every tool-call turn before it was overwritten, so `response.metrics` could undercount a run by an order of magnitude.

**Changes:**

- `ai-provider.js`: added a run-level `cumulativeUsage` record alongside the per-call `lastUsage`. Both are written through a new shared `applyUsage()` that `recordUsage()` feeds, so every completion adds to the run totals. New `getCumulativeUsage()`/`resetCumulativeUsage()` methods.
- `aibitat/index.js`: the loop resets the accumulator at depth 0 and all four `usageMetrics` emission sites now report `getCumulativeUsage()` instead of `getUsage()`.
- `chat-history.js`: persists the accumulated totals into `response.metrics`.
- `cerebras.js`: its `recordUsage` override wrote `lastUsage` directly and would have bypassed accumulation — now routes through `applyUsage()`. Also guards `total_tokens` against `undefined` (which would poison run totals as `NaN` under `+=`).
- `gemini.js`: stream handler called `recordUsage()` per chunk, which was harmless under overwrite semantics but would multi-count under accumulation (Gemini attaches `usage` to multiple chunks). Now captures the latest and records exactly once per stream — same pattern as `tooled.js`. All other providers were audited and record once per completion.

The metrics object shape is unchanged, so downstream consumers (ephemeral handler, scheduled jobs, frontend, Telegram bot) pick up correct totals with no changes. `duration` now sums LLM time across the run and `outputTps` is the run-wide average.

New tests cover accumulation, the reset lifecycle, Anthropic-style usage key normalization, per-instance isolation, and the `InheritMultiple` mixin providers.

**Known gap (pre-existing, out of scope):** providers running the UnTooled fallback path never call `recordUsage()`, so those runs still report zeros.

### Visuals (if applicable)

N/A — metrics are stored in `workspace_chats.response.metrics`; the chat UI renders the same string as before.

### Additional Information

Usage tracking was introduced in #5197 with per-call overwrite semantics; this PR makes the run-level consumers sum instead.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
