### PR TITLE
fix: [BUG]: Workspace LLM Temperature is not applied to agent sessions, and no agent-level temperature setting exists

### DIFF
--- a/server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js
+++ b/server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js
@@ -1,5 +1,7 @@
 const {
   formatMessagesForTools,
+  tooledStream,
+  tooledComplete,
 } = require("../../../../../../utils/agents/aibitat/providers/helpers/tooled.js");
 
 describe("formatMessagesForTools attachment content (native tool path)", () => {
@@ -46,5 +48,73 @@ describe("formatMessagesForTools attachment content (native tool path)", () => {
       type: "input_audio",
       input_audio: { data: "DDDD", format: "wav" },
     });
+  });
+});
+
+function fakeStream(chunks = []) {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        next: async () =>
+          i < chunks.length
+            ? { value: chunks[i++], done: false }
+            : { value: undefined, done: true },
+      };
+    },
+  };
+}
+
+describe("tooledStream/tooledComplete forward provider.temperature", () => {
+  it("tooledStream includes temperature when provider.temperature is a number", async () => {
+    const create = jest.fn().mockResolvedValue(fakeStream([]));
+    const client = { chat: { completions: { create } } };
+
+    await tooledStream(client, "test-model", [], [], null, {
+      provider: { temperature: 0.3 },
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 0.3 })
+    );
+  });
+
+  it("tooledStream omits temperature when provider.temperature is not a number", async () => {
+    const create = jest.fn().mockResolvedValue(fakeStream([]));
+    const client = { chat: { completions: { create } } };
+
+    await tooledStream(client, "test-model", [], [], null, {});
+
+    expect(create).toHaveBeenCalled();
+    expect(create.mock.calls[0][0]).not.toHaveProperty("temperature");
+  });
+
+  it("tooledComplete includes temperature when provider.temperature is a number", async () => {
+    const create = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: "hello", tool_calls: [] } }],
+      usage: {},
+    });
+    const client = { chat: { completions: { create } } };
+
+    await tooledComplete(client, "test-model", [], [], () => 0, {
+      provider: { temperature: 0.1 },
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 0.1 })
+    );
+  });
+
+  it("tooledComplete omits temperature when provider.temperature is not a number", async () => {
+    const create = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: "hello", tool_calls: [] } }],
+      usage: {},
+    });
+    const client = { chat: { completions: { create } } };
+
+    await tooledComplete(client, "test-model", [], [], () => 0, {});
+
+    expect(create).toHaveBeenCalled();
+    expect(create.mock.calls[0][0]).not.toHaveProperty("temperature");
   });
 });

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -99,6 +99,7 @@ class AIbitat {
    * @param {number} props.maxRounds - [default: 100] The maximum number of rounds for the AIbitat instance.
    * @param {number} props.maxToolCalls - [default: AIbitat.defaultMaxToolCalls()] The maximum number of tools an agent can chain for a single response.
    * @param {string} props.provider - [default: "openai"] The provider for the AIbitat instance.
+   * @param {number|null} [props.temperature] - Sampling temperature (ex: workspace's LLM Temperature) applied to the provider's completions when supported.
    * @param {Object} props.handlerProps - The handler properties for the AIbitat instance.
    * @param {Object} rest - The rest of the properties for the AIbitat instance.
    */
@@ -1409,6 +1410,8 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
    */
   getProviderForConfig(config) {
     const provider = this.#buildProviderForConfig(config);
+    if (typeof config.temperature === "number")
+      provider.temperature = config.temperature;
     provider.attachAbortSignal?.(this.abortController.signal);
     return provider;
   }

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -107,6 +107,14 @@ class Provider {
    */
   abortSignal = null;
 
+  /**
+   * Sampling temperature to use for this provider's completions, set by AIbitat
+   * from the workspace's LLM Temperature setting (`getProviderForConfig`).
+   * Left null so providers fall back to their own default temperature.
+   * @type {number|null}
+   */
+  temperature = null;
+
   constructor(client) {
     if (this.constructor == Provider) {
       return;

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -191,6 +191,9 @@ async function tooledStream(
     stream_options: { include_usage: true },
     messages: formattedMessages,
     ...(tools.length > 0 ? { tools } : {}),
+    ...(typeof provider?.temperature === "number"
+      ? { temperature: provider.temperature }
+      : {}),
   });
 
   const result = {
@@ -318,6 +321,9 @@ async function tooledComplete(
     stream: false,
     messages: formattedMessages,
     ...(tools.length > 0 ? { tools } : {}),
+    ...(typeof provider?.temperature === "number"
+      ? { temperature: provider.temperature }
+      : {}),
   });
 
   const completion = response.choices[0].message;

--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -514,6 +514,7 @@ class EphemeralAgentHandler extends AgentHandler {
     this.aibitat = new AIbitat({
       provider: this.provider ?? "openai",
       model: this.model ?? "gpt-4.1-nano",
+      temperature: this.#workspace?.openAiTemp ?? null,
       chats: await this.#chatHistory(20),
       handlerProps: {
         invocation: {

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -840,6 +840,7 @@ class AgentHandler {
     this.aibitat = new AIbitat({
       provider: this.provider ?? "openai",
       model: this.model ?? "gpt-4.1-nano",
+      temperature: this.invocation.workspace.openAiTemp ?? null,
       chats: await this.#chatHistory(20),
       handlerProps: {
         invocation: this.invocation,


### PR DESCRIPTION
Fixes #6091.

## What changed
- `server/__tests__/utils/agents/aibitat/providers/helpers/tooled.test.js`
- `server/utils/agents/aibitat/index.js`
- `server/utils/agents/aibitat/providers/ai-provider.js`
- `server/utils/agents/aibitat/providers/helpers/tooled.js`
- `server/utils/agents/ephemeral.js`
- `server/utils/agents/index.js`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.