### PR TITLE
fix: support reasoning field in Generic OpenAI provider

### DIFF
--- a/server/__tests__/utils/AiProviders/genericOpenAi/index.test.js
+++ b/server/__tests__/utils/AiProviders/genericOpenAi/index.test.js
@@ -116,6 +116,115 @@ describe("GenericOpenAiLLM attachment content", () => {
   });
 });
 
+describe("GenericOpenAiLLM reasoning content", () => {
+  /** @type {GenericOpenAiLLM} */
+  let provider;
+  beforeEach(() => (provider = new GenericOpenAiLLM()));
+
+  function completionResponse(message) {
+    return {
+      choices: [{ message }],
+      usage: {
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+        duration: 1,
+      },
+    };
+  }
+
+  function reasoningStream(delta) {
+    const chunks = [
+      { choices: [{ delta, finish_reason: null }] },
+      {
+        choices: [{ delta: { content: "Answer" }, finish_reason: null }],
+      },
+      { choices: [{ delta: {}, finish_reason: "stop" }] },
+    ];
+
+    return {
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of chunks) yield chunk;
+      },
+      endMeasurement: jest.fn(),
+    };
+  }
+
+  function mockWritableResponse() {
+    return {
+      writableEnded: false,
+      destroyed: false,
+      write: jest.fn(),
+      on: jest.fn(),
+      removeListener: jest.fn(),
+    };
+  }
+
+  it.each([
+    ["reasoning_content", "DeepSeek reasoning"],
+    ["reasoning", "vLLM reasoning"],
+  ])("parses non-streaming %s", async (field, reasoning) => {
+    provider.openai.chat.completions.create = jest
+      .fn()
+      .mockResolvedValue(
+        completionResponse({ content: "Answer", [field]: reasoning })
+      );
+
+    const result = await provider.getChatCompletion([], {});
+
+    expect(result.textResponse).toBe(`<think>${reasoning}</think>Answer`);
+  });
+
+  it("preserves reasoning_content precedence for non-streaming responses", async () => {
+    provider.openai.chat.completions.create = jest
+      .fn()
+      .mockResolvedValue(
+        completionResponse({
+          content: "Answer",
+          reasoning_content: "Preferred reasoning",
+          reasoning: "Fallback reasoning",
+        })
+      );
+
+    const result = await provider.getChatCompletion([], {});
+
+    expect(result.textResponse).toBe(
+      "<think>Preferred reasoning</think>Answer"
+    );
+  });
+
+  it.each([
+    ["reasoning_content", "DeepSeek reasoning"],
+    ["reasoning", "vLLM reasoning"],
+  ])("parses streaming delta.%s", async (field, reasoning) => {
+    const response = mockWritableResponse();
+    const result = await provider.handleStream(
+      response,
+      reasoningStream({ [field]: reasoning }),
+      { uuid: "test" }
+    );
+
+    expect(result).toBe(`<think>${reasoning}</think>Answer`);
+    expect(response.write).toHaveBeenCalledWith(
+      expect.stringContaining(`<think>${reasoning}`)
+    );
+  });
+
+  it("preserves reasoning_content precedence for streaming responses", async () => {
+    const response = mockWritableResponse();
+    const result = await provider.handleStream(
+      response,
+      reasoningStream({
+        reasoning_content: "Preferred reasoning",
+        reasoning: "Fallback reasoning",
+      }),
+      { uuid: "test" }
+    );
+
+    expect(result).toBe("<think>Preferred reasoning</think>Answer");
+  });
+});
+
 describe("GenericOpenAiProvider (agent) attachment content", () => {
   /** @type {GenericOpenAiProvider} */
   let provider;

--- a/server/utils/AiProviders/genericOpenAi/index.js
+++ b/server/utils/AiProviders/genericOpenAi/index.js
@@ -198,11 +198,9 @@ class GenericOpenAiLLM {
    */
   #parseReasoningFromResponse({ message }) {
     let textResponse = message?.content;
-    if (
-      !!message?.reasoning_content &&
-      message.reasoning_content.trim().length > 0
-    )
-      textResponse = `<think>${message.reasoning_content}</think>${textResponse}`;
+    const reasoning = message?.reasoning_content ?? message?.reasoning;
+    if (!!reasoning && reasoning.trim().length > 0)
+      textResponse = `<think>${reasoning}</think>${textResponse}`;
     return textResponse;
   }
 
@@ -308,7 +306,8 @@ class GenericOpenAiLLM {
         for await (const chunk of stream) {
           const message = chunk?.choices?.[0];
           const token = message?.delta?.content;
-          const reasoningToken = message?.delta?.reasoning_content;
+          const reasoningToken =
+            message?.delta?.reasoning_content ?? message?.delta?.reasoning;
 
           if (
             chunk.hasOwnProperty("usage") && // exists


### PR DESCRIPTION
### Pull Request Type
<!-- For change type, change [ ] to [x]. -->
- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues
<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->
resolves #6099

### Description
<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->
- Accept `reasoning` as a fallback when `reasoning_content` is absent from Generic OpenAI non-streaming responses.
- Apply the same fallback to streamed delta chunks.
- Preserve existing `reasoning_content` precedence.
- Add focused unit tests covering both response fields and precedence in streaming and non-streaming paths.

### Visuals (if applicable)
<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->
N/A — server response parsing only.

### Additional Information
<!-- Add any other context about the Pull Request here that was not captured above. -->
vLLM exposes reasoning under `reasoning`; existing DeepSeek-compatible `reasoning_content` behavior remains unchanged.

### Developer Validations
<!-- All of the applicable items should be checked. -->
- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally