### PR TITLE
feat: support GitHub Enterprise URLs in the GitHub data connector

### DIFF
--- a/collector/__tests__/utils/extensions/RepoLoader/GithubRepo.test.js
+++ b/collector/__tests__/utils/extensions/RepoLoader/GithubRepo.test.js
@@ -1,0 +1,545 @@
+/* eslint-env jest, node */
+process.env.STORAGE_DIR = "test-storage";
+
+// The resync module pulls in the generic link scraper at require-time.
+jest.mock("../../../../processLink", () => ({
+  getLinkText: jest.fn(),
+}));
+
+// Stubbed so the options the recursive loader is constructed with can be asserted.
+jest.mock("@langchain/community/document_loaders/web/github", () => ({
+  GithubRepoLoader: jest.fn().mockImplementation(() => ({
+    load: jest.fn().mockResolvedValue([]),
+  })),
+}));
+
+// Only `fetchGithubFile` is stubbed - `generateChunkSource` stays real for the round trip.
+jest.mock("../../../../utils/extensions/RepoLoader/GithubRepo", () => {
+  const actual = jest.requireActual(
+    "../../../../utils/extensions/RepoLoader/GithubRepo"
+  );
+  return { ...actual, fetchGithubFile: jest.fn() };
+});
+
+const GitHubRepoLoader = require("../../../../utils/extensions/RepoLoader/GithubRepo/RepoLoader");
+const {
+  GithubRepoLoader: LCGithubLoader,
+} = require("@langchain/community/document_loaders/web/github");
+const {
+  generateChunkSource,
+  fetchGithubFile,
+} = require("../../../../utils/extensions/RepoLoader/GithubRepo");
+const { EncryptionWorker } = require("../../../../utils/EncryptionWorker");
+const resyncHandlers = require("../../../../extensions/resync");
+
+const jsonResponse = (body) => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  headers: { get: () => null },
+  json: async () => body,
+});
+
+const errorResponse = (status, statusText = "Error") => ({
+  ok: false,
+  status,
+  statusText,
+  headers: { get: () => null },
+  json: async () => ({}),
+});
+
+/**
+ * Stands up a fake GitHub REST v3 API over `fetch` so no network access is required.
+ * The handlers key off the endpoint path only - never the host.
+ */
+function mockGithubApi({
+  branches = [{ name: "main" }],
+  branchStatus = 200,
+  files = {},
+  octocatStatus = 200,
+} = {}) {
+  return jest.spyOn(global, "fetch").mockImplementation(async (url) => {
+    const { pathname, searchParams } = new URL(url);
+    const endpoint = pathname.replace(/^\/api\/v3/, "");
+
+    if (endpoint === "/octocat")
+      return octocatStatus === 200
+        ? jsonResponse({})
+        : errorResponse(octocatStatus, "Unauthorized");
+
+    if (endpoint.endsWith("/branches")) {
+      if (branchStatus !== 200) return errorResponse(branchStatus);
+      return jsonResponse(
+        Number(searchParams.get("page")) === 0 ? branches : []
+      );
+    }
+
+    const contents = endpoint.match(/\/repos\/[^/]+\/[^/]+\/contents\/(.+)$/);
+    if (contents) {
+      const filePath = decodeURIComponent(contents[1]);
+      if (!(filePath in files)) return errorResponse(404, "Not Found");
+      return jsonResponse({
+        content: Buffer.from(files[filePath]).toString("base64"),
+      });
+    }
+
+    return errorResponse(404, "Not Found");
+  });
+}
+
+/** Every URL `fetch` was called with during a test. */
+const requestedUrls = (fetchMock) => fetchMock.mock.calls.map(([url]) => url);
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  LCGithubLoader.mockClear();
+  fetchGithubFile.mockReset();
+});
+
+describe("GitHubRepoLoader apiBase resolution", () => {
+  test("a public github.com url still resolves to the public api root", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.com/Mintplex-Labs/anything-llm",
+    });
+    await loader.init();
+
+    expect(loader.ready).toBe(true);
+    expect(loader.apiBase).toBe("https://api.github.com");
+    expect(loader.author).toBe("Mintplex-Labs");
+    expect(loader.project).toBe("anything-llm");
+  });
+
+  test("the www. alias of github.com is not mistaken for an enterprise host", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://www.github.com/org/repo",
+    });
+    await loader.init();
+
+    expect(loader.apiBase).toBe("https://api.github.com");
+  });
+
+  test("a GitHub Enterprise Server host resolves to the /api/v3 root", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+    });
+    await loader.init();
+
+    expect(loader.ready).toBe(true);
+    expect(loader.apiBase).toBe("https://github.mycompany.com/api/v3");
+    expect(loader.author).toBe("org");
+    expect(loader.project).toBe("repo");
+  });
+
+  test("an Enterprise Server host keeps its port and http scheme", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "http://github.mycompany.com:8443/org/repo",
+    });
+    await loader.init();
+
+    expect(loader.apiBase).toBe("http://github.mycompany.com:8443/api/v3");
+    expect(loader.author).toBe("org");
+    expect(loader.project).toBe("repo");
+  });
+
+  test("a GHE.com data residency url resolves to its dedicated api subdomain", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://octocorp.ghe.com/org/repo",
+    });
+    await loader.init();
+
+    expect(loader.apiBase).toBe("https://api.octocorp.ghe.com");
+    expect(loader.author).toBe("org");
+    expect(loader.project).toBe("repo");
+  });
+
+  test("an api.* host is already an api root and is never suffixed with /api/v3", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://api.octocorp.ghe.com/org/repo",
+    });
+    await loader.init();
+
+    expect(loader.apiBase).toBe("https://api.octocorp.ghe.com");
+  });
+
+  test("a trailing slash does not produce a doubled separator or an empty project", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo/",
+    });
+    await loader.init();
+
+    expect(loader.apiBase).toBe("https://github.mycompany.com/api/v3");
+    expect(loader.author).toBe("org");
+    expect(loader.project).toBe("repo");
+  });
+
+  test("extra path segments beyond {author}/{project} are ignored when parsing", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo/tree/main/src",
+    });
+    await loader.init();
+
+    expect(loader.apiBase).toBe("https://github.mycompany.com/api/v3");
+    expect(loader.author).toBe("org");
+    expect(loader.project).toBe("repo");
+  });
+
+  test("a .git suffix is stripped from an Enterprise Server url", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo.git",
+    });
+    await loader.init();
+
+    expect(loader.project).toBe("repo");
+    expect(loader.apiBase).toBe("https://github.mycompany.com/api/v3");
+  });
+});
+
+describe("GitHubRepoLoader url rejection", () => {
+  test("a url without a project segment leaves the loader un-ready", async () => {
+    const fetchMock = mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org",
+    });
+    await loader.init();
+
+    expect(loader.ready).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a non-http protocol leaves the loader un-ready", async () => {
+    const fetchMock = mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "ssh://github.mycompany.com/org/repo",
+    });
+    await loader.init();
+
+    expect(loader.ready).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a malformed url leaves the loader un-ready and makes no api calls", async () => {
+    const fetchMock = mockGithubApi();
+    const loader = new GitHubRepoLoader({ repo: "not-a-url" });
+    await loader.init();
+
+    expect(loader.ready).toBe(false);
+    expect(loader.apiBase).toBe("https://api.github.com");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHubRepoLoader request urls", () => {
+  test("github.com requests are byte for byte what they were before", async () => {
+    const fetchMock = mockGithubApi({ files: { "README.md": "# hello" } });
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.com/org/repo",
+      branch: "main",
+      accessToken: "ghp_token",
+    });
+    await loader.init();
+    await loader.fetchSingleFile("README.md");
+
+    expect(requestedUrls(fetchMock)).toContain("https://api.github.com/octocat");
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://api.github.com/repos/org/repo/branches?per_page=100&page=0"
+    );
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://api.github.com/repos/org/repo/contents/README.md?ref=main"
+    );
+  });
+
+  test("an Enterprise Server host uses the same endpoint paths under /api/v3", async () => {
+    const fetchMock = mockGithubApi({ files: { "README.md": "# hello" } });
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+      branch: "main",
+      accessToken: "ghp_token",
+    });
+    await loader.init();
+    await loader.fetchSingleFile("README.md");
+
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://github.mycompany.com/api/v3/octocat"
+    );
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://github.mycompany.com/api/v3/repos/org/repo/branches?per_page=100&page=0"
+    );
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://github.mycompany.com/api/v3/repos/org/repo/contents/README.md?ref=main"
+    );
+  });
+
+  test("a GHE.com host uses the same endpoint paths under its api subdomain", async () => {
+    const fetchMock = mockGithubApi({ files: { "README.md": "# hello" } });
+    const loader = new GitHubRepoLoader({
+      repo: "https://octocorp.ghe.com/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+    await loader.fetchSingleFile("README.md");
+
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://api.octocorp.ghe.com/repos/org/repo/branches?per_page=100&page=0"
+    );
+    expect(requestedUrls(fetchMock)).toContain(
+      "https://api.octocorp.ghe.com/repos/org/repo/contents/README.md?ref=main"
+    );
+  });
+
+  test("getRepoBranches targets the enterprise host without a prior init call", async () => {
+    const fetchMock = mockGithubApi({
+      branches: [{ name: "legacy" }, { name: "main" }],
+    });
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+    });
+    const branches = await loader.getRepoBranches();
+
+    expect(branches[0]).toBe("main");
+    expect(branches.sort()).toEqual(["legacy", "main"]);
+    requestedUrls(fetchMock).forEach((url) =>
+      expect(url.startsWith("https://github.mycompany.com/api/v3/")).toBe(true)
+    );
+  });
+
+  test("a file fetched from an enterprise host is decoded from the api response", async () => {
+    mockGithubApi({ files: { "src/index.js": "console.log('hi');" } });
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+
+    await expect(loader.fetchSingleFile("src/index.js")).resolves.toBe(
+      "console.log('hi');"
+    );
+  });
+});
+
+describe("GitHubRepoLoader recursive loader options", () => {
+  test("github.com keeps the upstream loader on its default hosts", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.com/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+    await loader.recursiveLoader();
+
+    const [repoUrl, options] = LCGithubLoader.mock.calls[0];
+    expect(repoUrl).toBe("https://github.com/org/repo");
+    expect(options.baseUrl).toBe("https://github.com");
+    expect(options.apiUrl).toBe("https://api.github.com");
+  });
+
+  test("an Enterprise Server repo points the upstream loader at its own hosts", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+    await loader.recursiveLoader();
+
+    const [repoUrl, options] = LCGithubLoader.mock.calls[0];
+    expect(repoUrl).toBe("https://github.mycompany.com/org/repo");
+    expect(options.baseUrl).toBe("https://github.mycompany.com");
+    expect(options.apiUrl).toBe("https://github.mycompany.com/api/v3");
+  });
+
+  test("a GHE.com repo separates its browse host from its api host", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://octocorp.ghe.com/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+    await loader.recursiveLoader();
+
+    const [, options] = LCGithubLoader.mock.calls[0];
+    expect(options.baseUrl).toBe("https://octocorp.ghe.com");
+    expect(options.apiUrl).toBe("https://api.octocorp.ghe.com");
+  });
+
+  test("recursiveLoader refuses to run before init", async () => {
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+    });
+
+    await expect(loader.recursiveLoader()).rejects.toThrow(
+      "[GitHub Loader]: not in ready state!"
+    );
+  });
+});
+
+describe("GitHubRepoLoader access token validation", () => {
+  test("a token rejected by an enterprise instance is dropped and the loader stays ready", async () => {
+    mockGithubApi({ octocatStatus: 401 });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+      accessToken: "ghp_expired",
+    });
+    await loader.init();
+
+    expect(loader.ready).toBe(true);
+    expect(loader.accessToken).toBeNull();
+  });
+
+  test("no token means no validation request is made at all", async () => {
+    const fetchMock = mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+    });
+    await loader.init();
+
+    expect(requestedUrls(fetchMock)).not.toContain(
+      "https://github.mycompany.com/api/v3/octocat"
+    );
+  });
+});
+
+describe("GitHub chunkSource round trip", () => {
+  const encryptionWorker = new EncryptionWorker(
+    Buffer.alloc(32, 7).toString("base64")
+  );
+
+  const mockResponse = () => {
+    const json = jest.fn();
+    return {
+      json,
+      response: {
+        locals: { encryptionWorker },
+        status: jest.fn(() => ({ json })),
+      },
+    };
+  };
+
+  test("an enterprise host survives encode then decode so resync stays on it", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.mycompany.com/org/repo",
+      branch: "main",
+      accessToken: "ghp_token",
+    });
+    await loader.init();
+
+    const chunkSource = generateChunkSource(
+      loader,
+      { metadata: { source: "src/index.js" } },
+      encryptionWorker
+    );
+    expect(chunkSource.startsWith("github://")).toBe(true);
+
+    fetchGithubFile.mockResolvedValue({
+      success: true,
+      reason: null,
+      content: "console.log('hi');",
+    });
+    const { response, json } = mockResponse();
+    await resyncHandlers.github({ chunkSource }, response);
+
+    expect(fetchGithubFile).toHaveBeenCalledWith({
+      repoUrl: "https://github.mycompany.com/org/repo",
+      branch: "main",
+      accessToken: "ghp_token",
+      sourceFilePath: "src/index.js",
+    });
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      content: "console.log('hi');",
+    });
+  });
+
+  test("an http enterprise host keeps its scheme and port through a resync", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "http://github.mycompany.com:8443/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+
+    const chunkSource = generateChunkSource(
+      loader,
+      { metadata: { source: "src/index.js" } },
+      encryptionWorker
+    );
+
+    fetchGithubFile.mockResolvedValue({
+      success: true,
+      reason: null,
+      content: "console.log('hi');",
+    });
+    const { response } = mockResponse();
+    await resyncHandlers.github({ chunkSource }, response);
+
+    expect(fetchGithubFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "http://github.mycompany.com:8443/org/repo",
+      })
+    );
+  });
+
+  test("a chunkSource stored before the protocol was recorded still resyncs over https", async () => {
+    const legacy = `github://https://github.com/org/repo?payload=${encryptionWorker.encrypt(
+      JSON.stringify({
+        owner: "org",
+        project: "repo",
+        branch: "main",
+        path: "README.md",
+        pat: null,
+      })
+    )}`;
+
+    fetchGithubFile.mockResolvedValue({
+      success: true,
+      reason: null,
+      content: "# hello",
+    });
+    const { response } = mockResponse();
+    await resyncHandlers.github({ chunkSource: legacy }, response);
+
+    expect(fetchGithubFile).toHaveBeenCalledWith(
+      expect.objectContaining({ repoUrl: "https://github.com/org/repo" })
+    );
+  });
+
+  test("a public github.com repo round trips unchanged", async () => {
+    mockGithubApi();
+    const loader = new GitHubRepoLoader({
+      repo: "https://github.com/org/repo",
+      branch: "main",
+    });
+    await loader.init();
+
+    const chunkSource = generateChunkSource(
+      loader,
+      { metadata: { source: "README.md" } },
+      encryptionWorker
+    );
+
+    fetchGithubFile.mockResolvedValue({
+      success: true,
+      reason: null,
+      content: "# hello",
+    });
+    const { response } = mockResponse();
+    await resyncHandlers.github({ chunkSource }, response);
+
+    expect(fetchGithubFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "https://github.com/org/repo",
+        sourceFilePath: "README.md",
+      })
+    );
+  });
+});

--- a/collector/extensions/resync/index.js
+++ b/collector/extensions/resync/index.js
@@ -101,7 +101,10 @@ async function resyncGithub({ chunkSource }, response) {
       fetchGithubFile,
     } = require("../../utils/extensions/RepoLoader/GithubRepo");
     const { success, reason, content } = await fetchGithubFile({
-      repoUrl: `https:${source.pathname}`, // need to add back the real protocol
+      // need to add back the real protocol - older chunkSources have none and default to https.
+      repoUrl: `${source.searchParams.get("scheme") || "https"}:${
+        source.pathname
+      }`,
       branch: source.searchParams.get("branch"),
       accessToken: source.searchParams.get("pat"),
       sourceFilePath: source.searchParams.get("path"),

--- a/collector/utils/extensions/RepoLoader/GithubRepo/RepoLoader/index.js
+++ b/collector/utils/extensions/RepoLoader/GithubRepo/RepoLoader/index.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} RepoLoaderArgs
- * @property {string} repo - The GitHub repository URL.
+ * @property {string} repo - The GitHub repository URL. Can be github.com, a GitHub
+ * Enterprise Server instance, or a GHE.com data-residency subdomain.
  * @property {string} [branch] - The branch to load from (optional).
  * @property {string} [accessToken] - GitHub access token for authentication (optional).
  * @property {string[]} [ignorePaths] - Array of paths to ignore when loading (optional).
@@ -23,6 +24,7 @@ class GitHubRepoLoader {
     this.accessToken = args?.accessToken || null;
     this.ignorePaths = args?.ignorePaths || [];
 
+    this.apiBase = "https://api.github.com";
     this.author = null;
     this.project = null;
     this.branches = [];
@@ -51,35 +53,52 @@ class GitHubRepoLoader {
   }
 
   /**
+   * Resolves the REST API root for the host the repository lives on. Every flavor
+   * of GitHub serves the same REST API v3 endpoints - only the root differs.
+   * - github.com -> https://api.github.com
+   * - GHE.com data residency -> https://api.{subdomain}.ghe.com
+   * - GitHub Enterprise Server -> {origin}/api/v3
+   * @param {URL} url - The parsed repository URL.
+   * @returns {string} The API root, without a trailing slash.
+   */
+  #resolveApiBase(url) {
+    if (["github.com", "www.github.com"].includes(url.hostname))
+      return "https://api.github.com";
+    // Checked before .ghe.com so an api.* host is never doubled up.
+    if (url.hostname.startsWith("api.")) return url.origin;
+    if (url.hostname.endsWith(".ghe.com"))
+      return `${url.protocol}//api.${url.host}`;
+    return `${url.origin}/api/v3`;
+  }
+
+  /**
    * Validates the GitHub URL format.
-   * - ensure the url is valid
-   * - ensure the hostname is github.com
-   * - ensure the pathname is in the format of github.com/{author}/{project}
-   * - sets the author and project properties of class instance
+   * - ensure the url is valid and http(s)
+   * - ensure the pathname is in the format of {host}/{author}/{project}
+   * - sets the apiBase, author and project properties of class instance
    * @returns {boolean} True if the URL is valid, false otherwise.
    */
   #validGithubUrl() {
     try {
       const url = new URL(this.repo);
-
-      // Not a github url at all.
-      if (url.hostname !== "github.com") {
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
         console.log(
-          `[GitHub Loader]: Invalid GitHub URL provided! Hostname must be 'github.com'. Got ${url.hostname}`
+          `[GitHub Loader]: Invalid GitHub URL provided! Protocol must be http or https. Got ${url.protocol}`
         );
         return false;
       }
 
-      // Assume the url is in the format of github.com/{author}/{project}
+      // Assume the url is in the format of {host}/{author}/{project}
       // Remove the first slash from the pathname so we can split it properly.
       const [author, project, ..._rest] = url.pathname.slice(1).split("/");
       if (!author || !project) {
         console.log(
-          `[GitHub Loader]: Invalid GitHub URL provided! URL must be in the format of 'github.com/{author}/{project}'. Got ${url.pathname}`
+          `[GitHub Loader]: Invalid GitHub URL provided! URL must be in the format of '{host}/{author}/{project}'. Got ${url.pathname}`
         );
         return false;
       }
 
+      this.apiBase = this.#resolveApiBase(url);
       this.author = author;
       this.project = project;
       return true;
@@ -107,7 +126,7 @@ class GitHubRepoLoader {
 
   async #validateAccessToken() {
     if (!this.accessToken) return;
-    const valid = await fetch("https://api.github.com/octocat", {
+    const valid = await fetch(`${this.apiBase}/octocat`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
@@ -159,6 +178,8 @@ class GitHubRepoLoader {
       );
 
     const loader = new LCGithubLoader(this.repo, {
+      baseUrl: new URL(this.repo).origin,
+      apiUrl: this.apiBase,
       branch: this.branch,
       recursive: !!this.accessToken, // Recursive will hit rate limits.
       maxConcurrency: 5,
@@ -196,7 +217,7 @@ class GitHubRepoLoader {
     while (polling) {
       console.log(`Fetching page ${page} of branches for ${this.project}`);
       await fetch(
-        `https://api.github.com/repos/${this.author}/${this.project}/branches?per_page=100&page=${page}`,
+        `${this.apiBase}/repos/${this.author}/${this.project}/branches?per_page=100&page=${page}`,
         {
           method: "GET",
           headers: {
@@ -234,7 +255,7 @@ class GitHubRepoLoader {
   async fetchSingleFile(sourceFilePath) {
     try {
       return fetch(
-        `https://api.github.com/repos/${this.author}/${this.project}/contents/${sourceFilePath}?ref=${this.branch}`,
+        `${this.apiBase}/repos/${this.author}/${this.project}/contents/${sourceFilePath}?ref=${this.branch}`,
         {
           method: "GET",
           headers: {

--- a/collector/utils/extensions/RepoLoader/GithubRepo/index.js
+++ b/collector/utils/extensions/RepoLoader/GithubRepo/index.js
@@ -150,10 +150,12 @@ function generateChunkSource(repo, doc, encryptionWorker) {
     branch: repo.branch,
     path: doc.metadata.source,
     pat: !!repo.accessToken ? repo.accessToken : null,
+    // Enterprise instances may be served over http - the protocol cannot be assumed on resync.
+    scheme: new URL(repo.repo).protocol.replace(":", ""),
   };
   return `github://${repo.repo}?payload=${encryptionWorker.encrypt(
     JSON.stringify(payload)
   )}`;
 }
 
-module.exports = { loadGithubRepo, fetchGithubFile };
+module.exports = { loadGithubRepo, fetchGithubFile, generateChunkSource };

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1321,8 +1321,7 @@ const TRANSLATIONS = {
       description:
         "Import an entire public or private GitHub repository in a single click.",
       URL: "GitHub Repo URL",
-      URL_explained:
-        "Url of the GitHub repo you wish to collect - GitHub Enterprise Server instances are supported.",
+      URL_explained: "Url of the GitHub repo you wish to collect.",
       token: "GitHub Access Token",
       optional: "optional",
       token_explained: "Access Token to prevent rate limiting.",

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1321,7 +1321,8 @@ const TRANSLATIONS = {
       description:
         "Import an entire public or private GitHub repository in a single click.",
       URL: "GitHub Repo URL",
-      URL_explained: "Url of the GitHub repo you wish to collect.",
+      URL_explained:
+        "Url of the GitHub repo you wish to collect - GitHub Enterprise Server instances are supported.",
       token: "GitHub Access Token",
       optional: "optional",
       token_explained: "Access Token to prevent rate limiting.",


### PR DESCRIPTION
resolves #3790

## What
The GitHub data connector rejected any repo URL whose hostname wasn't exactly `github.com`, and hard-coded `https://api.github.com` for every API call. This made it impossible to use the connector against a GitHub Enterprise Server instance or a GHE.com data-residency subdomain.

Every flavor of GitHub serves the same REST API v3 endpoints - only the API root differs:
- `github.com` -> `https://api.github.com`
- GHE.com data residency -> `https://api.{subdomain}.ghe.com`
- GitHub Enterprise Server -> `{origin}/api/v3`

The loader now resolves the correct API root from the repo URL's host and uses it everywhere a request is made (branch listing, file contents, access token validation, and the recursive loader). `github.com` behavior is unchanged - all existing request URLs are byte-for-byte identical to before.

Also fixed a related bug surfaced while adding round-trip test coverage: resyncing a watched document from an Enterprise repo served over `http://` (e.g. with a custom port) silently flipped the scheme to `https://` on resync, because the chunkSource reconstruction hard-coded the protocol. The repo's own protocol/scheme is now captured at chunkSource-write time and restored on resync, following the same convention already used by the Gitea connector.

## Testing
Added unit tests covering: URL host resolution (github.com, GHES, GHE.com, api.* hosts, trailing slashes, extra path segments, `.git` suffix), URL rejection (missing project segment, non-http protocol, malformed URL), request URLs actually hit for each host type, access token validation against an Enterprise host, and the chunkSource encode/decode round trip including the http+port resync case (this test fails without the resync fix, confirming it's a real regression catch).

`npx jest` - 91/91 collector tests pass. `yarn lint:check` clean in both `collector/` and `frontend/`.