### PR TITLE
FoundryLocal overhaul

### DIFF
--- a/frontend/src/components/LLMSelection/FoundryOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/FoundryOptions/index.jsx
@@ -1,50 +1,81 @@
 import { useEffect, useState } from "react";
 import System from "@/models/system";
+import showToast from "@/utils/toast";
+import strDistance from "js-levenshtein";
+import { Info } from "@phosphor-icons/react";
+import { Tooltip } from "react-tooltip";
+import { LLM_PREFERENCE_CHANGED_EVENT } from "@/pages/GeneralSettings/LLMPreference";
+import ModelTable from "@/components/lib/ModelTable";
+import ModelTableLayout from "@/components/lib/ModelTable/layout";
+import ModelTableLoadingSkeleton from "@/components/lib/ModelTable/loading";
+import FoundryUtils from "@/models/utils/foundryUtils";
 
 export default function FoundryOptions({ settings }) {
-  const [models, setModels] = useState([]);
-  const [loading, setLoading] = useState(!!settings?.FoundryBasePath);
   const [basePath, setBasePath] = useState(settings?.FoundryBasePath);
-  const [model, setModel] = useState(settings?.FoundryModelPref || "");
+  const [tokenLimit, setTokenLimit] = useState(
+    settings?.FoundryModelTokenLimit || ""
+  );
+
+  const handleTokenLimitChange = (e) => {
+    setTokenLimit(e.target.value ? Number(e.target.value) : "");
+  };
+  const [selectedModelId, setSelectedModelId] = useState(
+    settings?.FoundryModelPref || ""
+  );
 
   useEffect(() => {
-    setModel(settings?.FoundryModelPref || "");
+    setSelectedModelId(settings?.FoundryModelPref || "");
   }, [settings?.FoundryModelPref]);
 
-  useEffect(() => {
-    async function fetchModels() {
-      try {
-        setLoading(true);
-        if (!basePath) throw new Error("Base path is required");
-        const { models, error } = await System.customModels(
-          "foundry",
-          null,
-          basePath
-        );
-        if (error) throw new Error(error);
-        setModels(models);
-      } catch (error) {
-        console.error("Error fetching Foundry models:", error);
-        setModels([]);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchModels();
-  }, [basePath]);
+  /**
+   * The context window is deliberately left blank on selection. An empty field
+   * means "let the server decide", which caps at a machine-friendly default
+   * rather than handing a laptop the model's full window. A value typed here is
+   * treated as an explicit override.
+   */
+  function handleModelSelected(modelId) {
+    setSelectedModelId(modelId);
+    window.dispatchEvent(new Event(LLM_PREFERENCE_CHANGED_EVENT));
+  }
 
   return (
-    <div className="flex flex-col gap-y-7">
+    <div className="w-full flex flex-col gap-y-7">
       <div className="flex gap-[36px] mt-1.5 flex-wrap">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
-            Base URL
-          </label>
+          <div className="flex items-center gap-1 mb-3">
+            <label className="text-white text-sm font-semibold block">
+              Base URL
+            </label>
+            <Tooltip
+              id="foundry-base-url"
+              place="top"
+              delayShow={300}
+              delayHide={800}
+              clickable={true}
+              className="tooltip !text-xs !opacity-100 z-99"
+              style={{
+                maxWidth: "300px",
+                whiteSpace: "normal",
+                wordWrap: "break-word",
+              }}
+            >
+              The URL where the Foundry Local service is running. Run
+              <b> foundry status</b> on the host to find it.
+            </Tooltip>
+            <div
+              className="text-theme-text-secondary cursor-pointer hover:bg-theme-bg-primary flex items-center justify-center rounded-full"
+              data-tooltip-id="foundry-base-url"
+              data-tooltip-place="top"
+              data-tooltip-delay-hide={800}
+            >
+              <Info size={18} className="text-theme-text-secondary" />
+            </div>
+          </div>
           <input
             type="url"
             name="FoundryBasePath"
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-            placeholder="eg: http://127.0.0.1:8080"
+            placeholder="eg: http://127.0.0.1:5272"
             defaultValue={settings?.FoundryBasePath}
             required={true}
             autoComplete="off"
@@ -53,58 +84,262 @@ export default function FoundryOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
-            Chat Model
-          </label>
-          {loading ? (
-            <select
-              name="FoundryModelPref"
-              required={true}
-              disabled={true}
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          <div className="flex items-center gap-1 mb-3">
+            <label className="text-white text-sm font-semibold block">
+              Model context window
+            </label>
+            <Tooltip
+              id="foundry-model-context-window"
+              place="top"
+              delayShow={300}
+              delayHide={800}
+              clickable={true}
+              className="tooltip !text-xs !opacity-100 z-99"
+              style={{
+                maxWidth: "350px",
+                whiteSpace: "normal",
+                wordWrap: "break-word",
+              }}
             >
-              <option>---- Loading ----</option>
-            </select>
-          ) : (
-            <select
-              name="FoundryModelPref"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              required={true}
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              Override the context window limit. Leave empty to auto-detect from
+              the model, or lower it if large context windows slow your machine
+              down.
+            </Tooltip>
+            <div
+              className="text-theme-text-secondary cursor-pointer hover:bg-theme-bg-primary flex items-center justify-center rounded-full"
+              data-tooltip-id="foundry-model-context-window"
+              data-tooltip-place="top"
+              data-tooltip-delay-hide={800}
             >
-              {models.length > 0 ? (
-                <>
-                  <option value="">-- Select a model --</option>
-                  {models.map((model) => (
-                    <option key={model.id} value={model.id}>
-                      {model.id}
-                    </option>
-                  ))}
-                </>
-              ) : (
-                <option disabled value="">
-                  No models found
-                </option>
-              )}
-            </select>
-          )}
-        </div>
-        <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
-            Model context window
-          </label>
+              <Info size={18} className="text-theme-text-secondary" />
+            </div>
+          </div>
           <input
             type="number"
             name="FoundryModelTokenLimit"
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-            placeholder="4096"
-            defaultValue={settings?.FoundryModelTokenLimit}
+            placeholder="Automatically managed"
+            min={1}
+            value={tokenLimit}
+            onChange={handleTokenLimitChange}
+            onScroll={(e) => e.target.blur()}
+            required={false}
             autoComplete="off"
-            min={0}
           />
         </div>
+        <FoundryModelSelection
+          selectedModelId={selectedModelId}
+          onModelSelected={handleModelSelected}
+          basePath={basePath}
+        />
       </div>
     </div>
+  );
+}
+
+function FoundryModelSelection({
+  selectedModelId,
+  onModelSelected,
+  basePath = null,
+}) {
+  const [customModels, setCustomModels] = useState([]);
+  const [filteredModels, setFilteredModels] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [canManage, setCanManage] = useState(false);
+
+  async function fetchModels() {
+    if (!basePath) {
+      setCustomModels([]);
+      setFilteredModels([]);
+      setSearchQuery("");
+      setCanManage(false);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const [{ models }, capabilities] = await Promise.all([
+      System.customModels("foundry", null, basePath),
+      FoundryUtils.capabilities(basePath),
+    ]);
+    setCustomModels(models || []);
+    setFilteredModels(models || []);
+    setCanManage(capabilities.canManage);
+    setSearchQuery("");
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    fetchModels();
+  }, [basePath]);
+
+  useEffect(() => {
+    if (!searchQuery || !customModels.length) {
+      setFilteredModels(customModels || []);
+      return;
+    }
+
+    const normalizedSearchQuery = searchQuery.toLowerCase().trim();
+    const matches = new Map();
+
+    customModels.forEach((model) => {
+      const name = model.name.toLowerCase();
+      if (name.includes(normalizedSearchQuery)) matches.set(model.id, model);
+      if (strDistance(name, normalizedSearchQuery) <= 2)
+        matches.set(model.id, model);
+    });
+
+    setFilteredModels(Array.from(matches.values()));
+  }, [searchQuery, customModels]);
+
+  async function uninstallModel(modelId) {
+    try {
+      if (
+        !window.confirm(
+          `Are you sure you want to uninstall this model? You will need to download it again to use it.`
+        )
+      )
+        return;
+
+      const { success, error } = await FoundryUtils.deleteModel(
+        modelId,
+        basePath
+      );
+      if (!success)
+        throw new Error(
+          error || "An error occurred while uninstalling the model"
+        );
+
+      const updatedModels = customModels.map((model) =>
+        model.id === modelId ? { ...model, downloaded: false } : model
+      );
+      setCustomModels(updatedModels);
+      setFilteredModels(updatedModels);
+      setSearchQuery("");
+    } catch (e) {
+      console.error("Error uninstalling model:", e);
+      showToast(
+        e.message || "An error occurred while uninstalling the model",
+        "error",
+        { clear: true }
+      );
+    }
+  }
+
+  async function downloadModel(modelId, fileSize, progressCallback) {
+    try {
+      if (
+        !window.confirm(
+          `Are you sure you want to download this model? It is ${fileSize} in size and may take a while to download.`
+        )
+      )
+        return;
+
+      const { success, error } = await FoundryUtils.downloadModel(
+        modelId,
+        basePath,
+        progressCallback
+      );
+      if (!success)
+        throw new Error(
+          error || "An error occurred while downloading the model"
+        );
+      progressCallback(100);
+
+      const updatedModels = customModels.map((model) =>
+        model.id === modelId ? { ...model, downloaded: true } : model
+      );
+      setCustomModels(updatedModels);
+      setFilteredModels(updatedModels);
+      setSearchQuery("");
+      onModelSelected(modelId);
+    } catch (e) {
+      console.error("Error downloading model:", e);
+      showToast(
+        e.message || "An error occurred while downloading the model",
+        "error",
+        { clear: true }
+      );
+    }
+  }
+
+  /**
+   * Pin everything already downloaded to the top, then group the rest by task.
+   * The pinned group is skipped when every model is downloaded, since it would
+   * just duplicate the whole list under a second heading.
+   */
+  function groupModels(models) {
+    const downloaded = models.filter((model) => model.downloaded);
+    const byType = models.reduce((acc, model) => {
+      acc[model.organization] = acc[model.organization] || [];
+      acc[model.organization].push(model);
+      return acc;
+    }, {});
+
+    const grouped = {};
+    if (downloaded.length && downloaded.length < models.length)
+      grouped["Downloaded Models"] = downloaded;
+    Object.keys(byType)
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((type) => (grouped[type] = byType[type]));
+    return grouped;
+  }
+
+  function handleSetActiveModel(modelId) {
+    if (modelId === selectedModelId) return;
+    onModelSelected(modelId);
+  }
+
+  const groupedModels = groupModels(filteredModels);
+  return (
+    <ModelTableLayout
+      fetchModels={fetchModels}
+      searchQuery={searchQuery}
+      setSearchQuery={setSearchQuery}
+      loading={loading}
+    >
+      <Tooltip
+        id="install-model-tooltip"
+        place="top"
+        className="tooltip !text-xs !opacity-100 z-99"
+      />
+      <input
+        type="hidden"
+        name="FoundryModelPref"
+        id="FoundryModelPref"
+        value={selectedModelId}
+      />
+      {loading ? (
+        <ModelTableLoadingSkeleton />
+      ) : filteredModels.length === 0 ? (
+        <div className="flex flex-col w-full gap-y-2 mt-4">
+          <p className="text-theme-text-secondary text-sm">No models found!</p>
+        </div>
+      ) : (
+        <>
+          {!canManage && (
+            <p className="text-theme-text-secondary text-xs italic mt-3">
+              This Foundry service only reports the models it already has.
+              Install more on the host with{" "}
+              <span className="font-mono">foundry model download</span>, then
+              refresh.
+            </p>
+          )}
+          {Object.entries(groupedModels).map(([group, models]) => (
+            <ModelTable
+              key={group}
+              alias={group}
+              models={models}
+              setActiveModel={handleSetActiveModel}
+              downloadModel={canManage ? downloadModel : null}
+              uninstallModel={canManage ? uninstallModel : null}
+              selectedModelId={selectedModelId}
+              ui={{ showRuntime: true }}
+            />
+          ))}
+        </>
+      )}
+    </ModelTableLayout>
   );
 }

--- a/frontend/src/components/LLMSelection/FoundryOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/FoundryOptions/index.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import System from "@/models/system";
-import showToast from "@/utils/toast";
 import strDistance from "js-levenshtein";
 import { Info } from "@phosphor-icons/react";
 import { Tooltip } from "react-tooltip";
@@ -193,77 +192,6 @@ function FoundryModelSelection({
     setFilteredModels(Array.from(matches.values()));
   }, [searchQuery, customModels]);
 
-  async function uninstallModel(modelId) {
-    try {
-      if (
-        !window.confirm(
-          `Are you sure you want to uninstall this model? You will need to download it again to use it.`
-        )
-      )
-        return;
-
-      const { success, error } = await FoundryUtils.deleteModel(
-        modelId,
-        basePath
-      );
-      if (!success)
-        throw new Error(
-          error || "An error occurred while uninstalling the model"
-        );
-
-      const updatedModels = customModels.map((model) =>
-        model.id === modelId ? { ...model, downloaded: false } : model
-      );
-      setCustomModels(updatedModels);
-      setFilteredModels(updatedModels);
-      setSearchQuery("");
-    } catch (e) {
-      console.error("Error uninstalling model:", e);
-      showToast(
-        e.message || "An error occurred while uninstalling the model",
-        "error",
-        { clear: true }
-      );
-    }
-  }
-
-  async function downloadModel(modelId, fileSize, progressCallback) {
-    try {
-      if (
-        !window.confirm(
-          `Are you sure you want to download this model? It is ${fileSize} in size and may take a while to download.`
-        )
-      )
-        return;
-
-      const { success, error } = await FoundryUtils.downloadModel(
-        modelId,
-        basePath,
-        progressCallback
-      );
-      if (!success)
-        throw new Error(
-          error || "An error occurred while downloading the model"
-        );
-      progressCallback(100);
-
-      const updatedModels = customModels.map((model) =>
-        model.id === modelId ? { ...model, downloaded: true } : model
-      );
-      setCustomModels(updatedModels);
-      setFilteredModels(updatedModels);
-      setSearchQuery("");
-      onModelSelected(modelId);
-    } catch (e) {
-      console.error("Error downloading model:", e);
-      showToast(
-        e.message || "An error occurred while downloading the model",
-        "error",
-        { clear: true }
-      );
-    }
-  }
-
   /**
    * Pin everything already downloaded to the top, then group the rest by task.
    * The pinned group is skipped when every model is downloaded, since it would
@@ -332,8 +260,8 @@ function FoundryModelSelection({
               alias={group}
               models={models}
               setActiveModel={handleSetActiveModel}
-              downloadModel={canManage ? downloadModel : null}
-              uninstallModel={canManage ? uninstallModel : null}
+              downloadModel={null}
+              uninstallModel={null}
               selectedModelId={selectedModelId}
               ui={{ showRuntime: true }}
             />

--- a/frontend/src/components/lib/ModelTable/index.jsx
+++ b/frontend/src/components/lib/ModelTable/index.jsx
@@ -118,15 +118,18 @@ function DeviceTypeTagWrapper({ text, bgClass, textClass }) {
 }
 
 /**
- * @param {{deviceType: ModelDefinition["deviceType"]}} deviceType
+ * Colored by device class, labelled by runtime when the provider knows one —
+ * "CUDA" or "WebGPU" tells you far more about whether a build will run on your
+ * machine than a bare "GPU" does.
+ * @param {{deviceType: ModelDefinition["deviceType"], runtime?: string}} props
  * @returns {React.ReactNode}
  */
-function DeviceTypeTag({ deviceType }) {
+function DeviceTypeTag({ deviceType, runtime = null }) {
   switch (deviceType?.toLowerCase()) {
     case "cpu":
       return (
         <DeviceTypeTagWrapper
-          text="CPU"
+          text={runtime || "CPU"}
           bgClass="bg-zinc-800 light:bg-zinc-200"
           textClass="text-theme-text-primary"
         />
@@ -134,7 +137,7 @@ function DeviceTypeTag({ deviceType }) {
     case "gpu":
       return (
         <DeviceTypeTagWrapper
-          text="GPU"
+          text={runtime || "GPU"}
           bgClass="bg-green-800 light:bg-green-200"
           textClass="text-theme-text-primary"
         />
@@ -142,19 +145,13 @@ function DeviceTypeTag({ deviceType }) {
     case "npu":
       return (
         <DeviceTypeTagWrapper
-          text="NPU"
+          text={runtime || "NPU"}
           bgClass="bg-indigo-800 light:bg-indigo-200"
           textClass="text-theme-text-primary"
         />
       );
     default:
-      return (
-        <DeviceTypeTagWrapper
-          text="CPU"
-          bgClass="bg-zinc-800 light:bg-zinc-200"
-          textClass="text-theme-text-primary"
-        />
-      );
+      return null;
   }
 }
 
@@ -244,7 +241,12 @@ function ModelRow({
         disabled={processing}
         onClick={handleSetActiveModel}
       >
-        {ui.showRuntime && <DeviceTypeTag deviceType={model.deviceType} />}
+        {ui.showRuntime && (
+          <DeviceTypeTag
+            deviceType={model.deviceType}
+            runtime={model.runtime}
+          />
+        )}
         {!ui.showRuntime &&
           model.downloaded &&
           alias === "Downloaded Models" && (
@@ -294,7 +296,9 @@ function ModelRow({
             )}
           </>
         ) : null}
-        {!model.downloaded && !processing && (
+        {/* Only offer the install affordance when the caller can actually
+        install — a provider may list a catalog it cannot download from. */}
+        {!model.downloaded && !processing && !!downloadModel && (
           <button
             type="button"
             data-tooltip-id="install-model-tooltip"

--- a/frontend/src/models/utils/foundryUtils.js
+++ b/frontend/src/models/utils/foundryUtils.js
@@ -1,14 +1,7 @@
 import { API_BASE } from "@/utils/constants";
 import { baseHeaders } from "@/utils/request";
-import { safeJsonParse } from "@/utils/request";
 
 const FoundryUtils = {
-  /**
-   * Report what the configured Foundry service supports. Model management is
-   * only possible against a daemon that exposes the REST management routes.
-   * @param {string} basePath - The base path of the Foundry service.
-   * @returns {Promise<{source: 'rest'|'openai', canManage: boolean}>}
-   */
   capabilities: async function (basePath = "") {
     try {
       const response = await fetch(`${API_BASE}/utils/foundry/capabilities`, {
@@ -21,109 +14,6 @@ const FoundryUtils = {
     } catch (error) {
       console.error("Error fetching Foundry capabilities:", error);
       return { source: "openai", canManage: false };
-    }
-  },
-
-  /**
-   * Download a Foundry model into the service's local storage.
-   * @param {string} modelId - The alias of the model to download.
-   * @param {string} basePath - The base path of the Foundry service.
-   * @param {(percentage: number) => void} progressCallback - Receives download progress.
-   * @returns {Promise<{success: boolean, error: string|null}>}
-   */
-  downloadModel: async function (
-    modelId,
-    basePath = "",
-    progressCallback = () => {}
-  ) {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve) => {
-      try {
-        const response = await fetch(
-          `${API_BASE}/utils/foundry/download-model`,
-          {
-            method: "POST",
-            headers: baseHeaders(),
-            body: JSON.stringify({ modelId, basePath }),
-          }
-        );
-
-        if (!response.ok)
-          throw new Error("Error downloading model: " + response.statusText);
-        const reader = response.body.getReader();
-        let done = false;
-
-        while (!done) {
-          const { value, done: readerDone } = await reader.read();
-          if (readerDone) {
-            done = true;
-            resolve({ success: true, error: null });
-            break;
-          }
-
-          const chunk = new TextDecoder("utf-8").decode(value);
-          for (const line of chunk.split("\n")) {
-            if (!line.startsWith("data:")) continue;
-            const data = safeJsonParse(line.slice(5));
-            switch (data?.type) {
-              case "success":
-                done = true;
-                resolve({ success: true, error: null });
-                break;
-              case "error":
-                done = true;
-                resolve({
-                  success: false,
-                  error: data?.error || data?.message,
-                });
-                break;
-              case "progress":
-                progressCallback(data?.percentage);
-                break;
-              default:
-                break;
-            }
-          }
-        }
-      } catch (error) {
-        console.error("Error downloading model:", error);
-        resolve({
-          success: false,
-          error:
-            error?.message || "An error occurred while downloading the model",
-        });
-      }
-    });
-  },
-
-  /**
-   * Remove a Foundry model from local storage.
-   * @param {string} modelId - The alias of the model to delete.
-   * @param {string} basePath - The base path of the Foundry service.
-   * @returns {Promise<{success: boolean, message?: string, error?: string}>}
-   */
-  deleteModel: async function (modelId, basePath = "") {
-    try {
-      const response = await fetch(`${API_BASE}/utils/foundry/delete-model`, {
-        method: "POST",
-        headers: baseHeaders(),
-        body: JSON.stringify({ modelId, basePath }),
-      });
-
-      const data = await response.json();
-      if (!response.ok || !data.success)
-        return {
-          success: false,
-          error: data.error || "An error occurred while deleting the model",
-        };
-
-      return { success: true, message: data.message };
-    } catch (error) {
-      console.error("Error deleting model:", error);
-      return {
-        success: false,
-        error: error?.message || "An error occurred while deleting the model",
-      };
     }
   },
 };

--- a/frontend/src/models/utils/foundryUtils.js
+++ b/frontend/src/models/utils/foundryUtils.js
@@ -1,0 +1,131 @@
+import { API_BASE } from "@/utils/constants";
+import { baseHeaders } from "@/utils/request";
+import { safeJsonParse } from "@/utils/request";
+
+const FoundryUtils = {
+  /**
+   * Report what the configured Foundry service supports. Model management is
+   * only possible against a daemon that exposes the REST management routes.
+   * @param {string} basePath - The base path of the Foundry service.
+   * @returns {Promise<{source: 'rest'|'openai', canManage: boolean}>}
+   */
+  capabilities: async function (basePath = "") {
+    try {
+      const response = await fetch(`${API_BASE}/utils/foundry/capabilities`, {
+        method: "POST",
+        headers: baseHeaders(),
+        body: JSON.stringify({ basePath }),
+      });
+      if (!response.ok) throw new Error(response.statusText);
+      return await response.json();
+    } catch (error) {
+      console.error("Error fetching Foundry capabilities:", error);
+      return { source: "openai", canManage: false };
+    }
+  },
+
+  /**
+   * Download a Foundry model into the service's local storage.
+   * @param {string} modelId - The alias of the model to download.
+   * @param {string} basePath - The base path of the Foundry service.
+   * @param {(percentage: number) => void} progressCallback - Receives download progress.
+   * @returns {Promise<{success: boolean, error: string|null}>}
+   */
+  downloadModel: async function (
+    modelId,
+    basePath = "",
+    progressCallback = () => {}
+  ) {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve) => {
+      try {
+        const response = await fetch(
+          `${API_BASE}/utils/foundry/download-model`,
+          {
+            method: "POST",
+            headers: baseHeaders(),
+            body: JSON.stringify({ modelId, basePath }),
+          }
+        );
+
+        if (!response.ok)
+          throw new Error("Error downloading model: " + response.statusText);
+        const reader = response.body.getReader();
+        let done = false;
+
+        while (!done) {
+          const { value, done: readerDone } = await reader.read();
+          if (readerDone) {
+            done = true;
+            resolve({ success: true, error: null });
+            break;
+          }
+
+          const chunk = new TextDecoder("utf-8").decode(value);
+          for (const line of chunk.split("\n")) {
+            if (!line.startsWith("data:")) continue;
+            const data = safeJsonParse(line.slice(5));
+            switch (data?.type) {
+              case "success":
+                done = true;
+                resolve({ success: true, error: null });
+                break;
+              case "error":
+                done = true;
+                resolve({
+                  success: false,
+                  error: data?.error || data?.message,
+                });
+                break;
+              case "progress":
+                progressCallback(data?.percentage);
+                break;
+              default:
+                break;
+            }
+          }
+        }
+      } catch (error) {
+        console.error("Error downloading model:", error);
+        resolve({
+          success: false,
+          error:
+            error?.message || "An error occurred while downloading the model",
+        });
+      }
+    });
+  },
+
+  /**
+   * Remove a Foundry model from local storage.
+   * @param {string} modelId - The alias of the model to delete.
+   * @param {string} basePath - The base path of the Foundry service.
+   * @returns {Promise<{success: boolean, message?: string, error?: string}>}
+   */
+  deleteModel: async function (modelId, basePath = "") {
+    try {
+      const response = await fetch(`${API_BASE}/utils/foundry/delete-model`, {
+        method: "POST",
+        headers: baseHeaders(),
+        body: JSON.stringify({ modelId, basePath }),
+      });
+
+      const data = await response.json();
+      if (!response.ok || !data.success)
+        return {
+          success: false,
+          error: data.error || "An error occurred while deleting the model",
+        };
+
+      return { success: true, message: data.message };
+    } catch (error) {
+      console.error("Error deleting model:", error);
+      return {
+        success: false,
+        error: error?.message || "An error occurred while deleting the model",
+      };
+    }
+  },
+};
+
+export default FoundryUtils;

--- a/server/endpoints/utils.js
+++ b/server/endpoints/utils.js
@@ -88,6 +88,9 @@ function utilEndpoints(app) {
 
   const { lemonadeUtilsEndpoints } = require("./utils/lemonadeUtilsEndpoints");
   lemonadeUtilsEndpoints(app);
+
+  const { foundryUtilsEndpoints } = require("./utils/foundryUtilsEndpoints");
+  foundryUtilsEndpoints(app);
 }
 
 function getGitVersion() {

--- a/server/endpoints/utils/foundryUtilsEndpoints.js
+++ b/server/endpoints/utils/foundryUtilsEndpoints.js
@@ -1,0 +1,122 @@
+const { validatedRequest } = require("../../utils/middleware/validatedRequest");
+const {
+  flexUserRoleValid,
+  ROLES,
+} = require("../../utils/middleware/multiUserProtected");
+const { reqBody } = require("../../utils/http");
+const FoundryModels = require("../../utils/AiProviders/foundry/models");
+
+function foundryUtilsEndpoints(app) {
+  if (!app) return;
+
+  /**
+   * Report what this host can do with Foundry. Managing models requires either
+   * the local `foundry` CLI or a pre-0.10 daemon that still serves the REST
+   * management routes; a container talking to a 0.10+ daemon has neither. The
+   * UI uses this to decide whether to offer install/uninstall actions.
+   */
+  app.post(
+    "/utils/foundry/capabilities",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      try {
+        const { basePath = null } = reqBody(request);
+        const capabilities = await FoundryModels.resolveSource(
+          basePath || process.env.FOUNDRY_BASE_PATH
+        );
+        return response.status(200).json(capabilities);
+      } catch (e) {
+        console.error(e);
+        return response
+          .status(200)
+          .json({ source: "openai", canManage: false, cliVersion: null });
+      }
+    }
+  );
+
+  app.post(
+    "/utils/foundry/download-model",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      try {
+        const { modelId, basePath = null } = reqBody(request);
+        if (!modelId) throw new Error("modelId is required");
+
+        response.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        });
+
+        const { success, error } = await FoundryModels.downloadModel(
+          modelId,
+          (percentage) =>
+            response.write(
+              `data: ${JSON.stringify({
+                type: "progress",
+                percentage,
+                message: `Downloading ${modelId}...`,
+              })}\n\n`
+            ),
+          basePath || process.env.FOUNDRY_BASE_PATH
+        );
+
+        if (!success)
+          throw new Error(
+            error || "An error occurred while downloading the model"
+          );
+
+        response.write(
+          `data: ${JSON.stringify({
+            type: "success",
+            percentage: 100,
+            message: "Model downloaded successfully",
+          })}\n\n`
+        );
+      } catch (e) {
+        console.error(e);
+        response.write(
+          `data: ${JSON.stringify({ type: "error", message: e.message })}\n\n`
+        );
+      } finally {
+        response.end();
+      }
+    }
+  );
+
+  app.post(
+    "/utils/foundry/delete-model",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      try {
+        const { modelId, basePath = null } = reqBody(request);
+        if (!modelId)
+          return response
+            .status(400)
+            .json({ success: false, error: "modelId is required" });
+
+        const { success, error } = await FoundryModels.deleteModel(
+          modelId,
+          basePath || process.env.FOUNDRY_BASE_PATH
+        );
+        if (!success)
+          return response.status(500).json({
+            success: false,
+            error: error || "An error occurred while deleting the model",
+          });
+
+        return response
+          .status(200)
+          .json({ success: true, message: `Deleted model: ${modelId}` });
+      } catch (e) {
+        console.error(e);
+        return response.status(500).json({
+          success: false,
+          error: e.message || "An error occurred while deleting the model",
+        });
+      }
+    }
+  );
+}
+
+module.exports = { foundryUtilsEndpoints };

--- a/server/endpoints/utils/foundryUtilsEndpoints.js
+++ b/server/endpoints/utils/foundryUtilsEndpoints.js
@@ -9,12 +9,6 @@ const FoundryModels = require("../../utils/AiProviders/foundry/models");
 function foundryUtilsEndpoints(app) {
   if (!app) return;
 
-  /**
-   * Report what this host can do with Foundry. Managing models requires either
-   * the local `foundry` CLI or a pre-0.10 daemon that still serves the REST
-   * management routes; a container talking to a 0.10+ daemon has neither. The
-   * UI uses this to decide whether to offer install/uninstall actions.
-   */
   app.post(
     "/utils/foundry/capabilities",
     [validatedRequest, flexUserRoleValid([ROLES.admin])],
@@ -29,91 +23,7 @@ function foundryUtilsEndpoints(app) {
         console.error(e);
         return response
           .status(200)
-          .json({ source: "openai", canManage: false, cliVersion: null });
-      }
-    }
-  );
-
-  app.post(
-    "/utils/foundry/download-model",
-    [validatedRequest, flexUserRoleValid([ROLES.admin])],
-    async (request, response) => {
-      try {
-        const { modelId, basePath = null } = reqBody(request);
-        if (!modelId) throw new Error("modelId is required");
-
-        response.writeHead(200, {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        });
-
-        const { success, error } = await FoundryModels.downloadModel(
-          modelId,
-          (percentage) =>
-            response.write(
-              `data: ${JSON.stringify({
-                type: "progress",
-                percentage,
-                message: `Downloading ${modelId}...`,
-              })}\n\n`
-            ),
-          basePath || process.env.FOUNDRY_BASE_PATH
-        );
-
-        if (!success)
-          throw new Error(
-            error || "An error occurred while downloading the model"
-          );
-
-        response.write(
-          `data: ${JSON.stringify({
-            type: "success",
-            percentage: 100,
-            message: "Model downloaded successfully",
-          })}\n\n`
-        );
-      } catch (e) {
-        console.error(e);
-        response.write(
-          `data: ${JSON.stringify({ type: "error", message: e.message })}\n\n`
-        );
-      } finally {
-        response.end();
-      }
-    }
-  );
-
-  app.post(
-    "/utils/foundry/delete-model",
-    [validatedRequest, flexUserRoleValid([ROLES.admin])],
-    async (request, response) => {
-      try {
-        const { modelId, basePath = null } = reqBody(request);
-        if (!modelId)
-          return response
-            .status(400)
-            .json({ success: false, error: "modelId is required" });
-
-        const { success, error } = await FoundryModels.deleteModel(
-          modelId,
-          basePath || process.env.FOUNDRY_BASE_PATH
-        );
-        if (!success)
-          return response.status(500).json({
-            success: false,
-            error: error || "An error occurred while deleting the model",
-          });
-
-        return response
-          .status(200)
-          .json({ success: true, message: `Deleted model: ${modelId}` });
-      } catch (e) {
-        console.error(e);
-        return response.status(500).json({
-          success: false,
-          error: e.message || "An error occurred while deleting the model",
-        });
+          .json({ source: "openai", canManage: false });
       }
     }
   );

--- a/server/storage/models/.gitignore
+++ b/server/storage/models/.gitignore
@@ -15,3 +15,4 @@ cometapi
 fireworks
 giteeai
 docker-model-runner
+foundry

--- a/server/utils/AiProviders/foundry/catalog.js
+++ b/server/utils/AiProviders/foundry/catalog.js
@@ -1,0 +1,304 @@
+const fs = require("fs");
+const path = require("path");
+const { safeJsonParse } = require("../../http");
+
+const cacheFolder = path.resolve(
+  process.env.STORAGE_DIR
+    ? path.resolve(process.env.STORAGE_DIR, "models", "foundry")
+    : path.resolve(__dirname, `../../../storage/models/foundry`)
+);
+
+/**
+ * The Foundry Local model catalog, read from the Azure AI registry.
+ *
+ * Foundry Local 0.10 removed the daemon's `/foundry/list` route, so a
+ * containerized install has no way to see anything it has not already
+ * downloaded — the full catalog now only exists in the host CLI, which we
+ * cannot invoke. This reads the same registry the CLI does so the model picker
+ * can still show what is available.
+ *
+ * Caveats worth knowing before relying on this:
+ *  - The endpoint is undocumented and gated only on a User-Agent, so treat it
+ *    as best-effort. Every failure path degrades to "no catalog" rather than
+ *    breaking model listing.
+ *  - It describes what *exists*, not what this machine can run or install.
+ *    Downloads still have to happen host-side on 0.10+.
+ *
+ * @see https://github.com/microsoft/foundry-local/issues/245
+ */
+class FoundryCatalog {
+  static CATALOG_URL =
+    "https://ai.azure.com/api/eastus/ux/v1.0/entities/crossRegion";
+
+  /** 1 week in ms — the catalog changes on release cadence, not hourly. */
+  static MAX_STALE = 6.048e8;
+
+  static PAGE_SIZE = 100;
+
+  /** Safety valve so a misbehaving continuationToken cannot loop forever. */
+  static MAX_PAGES = 20;
+
+  static REQUEST_TIMEOUT_MS = 30_000;
+
+  /** Execution providers Foundry Local ships. Spelling varies by row, so send both. */
+  static EXECUTION_PROVIDERS = [
+    "CPUExecutionProvider",
+    "QNNExecutionProvider",
+    "CUDAExecutionProvider",
+    "WebGpuExecutionProvider",
+    "WebGPUExecutionProvider",
+  ];
+
+  /** Only tasks that can back a chat provider. */
+  static CHAT_TASKS = ["chat-completion", "vision-language-chat"];
+
+  /**
+   * Friendly runtime names for the acceleration backend a variant is built for.
+   * `device` alone only says CPU/GPU/NPU — this says *which* GPU or NPU stack,
+   * which is what actually determines whether a machine can run the variant.
+   */
+  static RUNTIME_LABELS = {
+    CPUExecutionProvider: "CPU",
+    CUDAExecutionProvider: "CUDA",
+    WebGpuExecutionProvider: "WebGPU",
+    WebGPUExecutionProvider: "WebGPU",
+    QNNExecutionProvider: "QNN",
+    NvTensorRTRTXExecutionProvider: "TensorRT",
+    OpenVINOExecutionProvider: "OpenVINO",
+    VitisAIExecutionProvider: "VitisAI",
+    DmlExecutionProvider: "DirectML",
+  };
+
+  /**
+   * @param {string|null} executionProvider
+   * @param {string} deviceType
+   * @returns {string}
+   */
+  static #runtimeLabel(executionProvider, deviceType) {
+    if (!executionProvider) return deviceType;
+    return (
+      this.RUNTIME_LABELS[executionProvider] ??
+      // Unknown providers still read better with the suffix trimmed off.
+      executionProvider.replace(/ExecutionProvider$/, "")
+    );
+  }
+
+  static get cacheModelPath() {
+    return path.resolve(cacheFolder, "models.json");
+  }
+
+  static get cacheAtPath() {
+    return path.resolve(cacheFolder, ".cached_at");
+  }
+
+  static #log(text, ...args) {
+    console.log(`\x1b[36m[FoundryCatalog]\x1b[0m ${text}`, ...args);
+  }
+
+  /**
+   * True when there is no cache timestamp or it is older than MAX_STALE.
+   * @returns {boolean}
+   */
+  static #cacheIsStale() {
+    if (!fs.existsSync(this.cacheAtPath)) return true;
+    const timestampMs = Number(fs.readFileSync(this.cacheAtPath));
+    if (!Number.isFinite(timestampMs)) return true;
+    return Number(new Date()) - timestampMs > this.MAX_STALE;
+  }
+
+  /**
+   * Read whatever is on disk, regardless of age.
+   * @returns {CatalogModel[]|null}
+   */
+  static #readCache() {
+    if (!fs.existsSync(this.cacheModelPath)) return null;
+    const cached = safeJsonParse(
+      fs.readFileSync(this.cacheModelPath, { encoding: "utf-8" }),
+      null
+    );
+    return Array.isArray(cached) ? cached : null;
+  }
+
+  /**
+   * @param {CatalogModel[]} models
+   */
+  static #writeCache(models) {
+    try {
+      if (!fs.existsSync(cacheFolder))
+        fs.mkdirSync(cacheFolder, { recursive: true });
+      fs.writeFileSync(this.cacheModelPath, JSON.stringify(models), {
+        encoding: "utf-8",
+      });
+      fs.writeFileSync(this.cacheAtPath, String(Number(new Date())), {
+        encoding: "utf-8",
+      });
+    } catch (e) {
+      // A read-only or full disk should not take model listing down with it.
+      this.#log(`Could not write catalog cache: ${e.message}`);
+    }
+  }
+
+  /**
+   * @param {string|null} continuationToken
+   * @returns {Promise<{value: object[], continuationToken: string|null}>}
+   */
+  static async #fetchPage(continuationToken = null) {
+    const response = await fetch(this.CATALOG_URL, {
+      method: "POST",
+      headers: {
+        // The registry gates this response on the User-Agent, not on auth.
+        "User-Agent": "AzureAiStudio",
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(this.REQUEST_TIMEOUT_MS),
+      body: JSON.stringify({
+        resourceIds: [
+          { resourceId: "azureml", entityContainerType: "Registry" },
+        ],
+        indexEntitiesRequest: {
+          filters: [
+            { field: "type", operator: "eq", values: ["models"] },
+            { field: "kind", operator: "eq", values: ["Versioned"] },
+            { field: "labels", operator: "eq", values: ["latest"] },
+            {
+              field: "properties/variantInfo/variantMetadata/executionProvider",
+              operator: "eq",
+              values: this.EXECUTION_PROVIDERS,
+            },
+          ],
+          pageSize: this.PAGE_SIZE,
+          skip: null,
+          continuationToken,
+        },
+      }),
+    });
+
+    if (!response.ok)
+      throw new Error(`Catalog request failed with status ${response.status}`);
+    const body = await response.json();
+    const page = body?.indexEntitiesResponse ?? {};
+    return {
+      value: Array.isArray(page.value) ? page.value : [],
+      continuationToken: page.continuationToken ?? null,
+    };
+  }
+
+  /**
+   * @typedef {Object} CatalogVariant
+   * @property {string} name - Matches the id the daemon reports, eg `qwen3-0.6b-generic-gpu`.
+   * @property {'CPU'|'GPU'|'NPU'} deviceType
+   * @property {string|null} executionProvider
+   * @property {number} sizeMb
+   *
+   * @typedef {Object} CatalogModel
+   * @property {string} alias
+   * @property {string} task
+   * @property {number|null} contextLength
+   * @property {boolean} toolCalling
+   * @property {boolean} reasoning
+   * @property {boolean} vision
+   * @property {string|null} license
+   * @property {CatalogVariant[]} variants
+   */
+
+  /**
+   * Collapse raw registry rows (one per device variant) into one entry per
+   * alias, which is how Foundry itself presents models.
+   * @param {object[]} entities
+   * @returns {CatalogModel[]}
+   */
+  static #normalize(entities = []) {
+    const byAlias = new Map();
+
+    for (const entity of entities) {
+      const tags = entity?.annotations?.tags ?? {};
+      const alias = tags.alias;
+      if (!alias) continue;
+      if (!this.CHAT_TASKS.includes(String(tags.task))) continue;
+
+      const metadata = entity?.properties?.variantInfo?.variantMetadata ?? {};
+
+      // `azureml://…/models/<name>/versions/<n>` — <name> is what the daemon reports.
+      const assetId = String(entity.assetId ?? "");
+      const name = assetId.split("/models/")[1]?.split("/versions/")[0] ?? null;
+      if (!name) continue;
+
+      const deviceType = String(metadata.device ?? "CPU").toUpperCase();
+      const variant = {
+        name,
+        deviceType,
+        executionProvider: metadata.executionProvider ?? null,
+        runtime: this.#runtimeLabel(metadata.executionProvider, deviceType),
+        sizeMb: Math.round(Number(metadata.fileSizeBytes ?? 0) / 1e6),
+      };
+
+      const existing = byAlias.get(alias);
+      if (existing) {
+        existing.variants.push(variant);
+        continue;
+      }
+
+      byAlias.set(alias, {
+        alias,
+        task: String(tags.task),
+        contextLength: Number(tags.contextLength) || null,
+        toolCalling: String(tags.supportsToolCalling).toLowerCase() === "true",
+        reasoning: String(tags.supportsReasoning).toLowerCase() === "true",
+        // Foundry flags vision through the task and input modalities rather
+        // than a dedicated capability.
+        vision:
+          String(tags.task) === "vision-language-chat" ||
+          String(tags.inputModalities).toLowerCase().includes("image"),
+        license: tags.license ?? null,
+        variants: [variant],
+      });
+    }
+
+    return Array.from(byAlias.values());
+  }
+
+  /**
+   * Fetch every page and refresh the on-disk cache.
+   * @returns {Promise<CatalogModel[]>}
+   */
+  static async #fetchAll() {
+    const entities = [];
+    let continuationToken = null;
+
+    for (let page = 0; page < this.MAX_PAGES; page++) {
+      const result = await this.#fetchPage(continuationToken);
+      entities.push(...result.value);
+      continuationToken = result.continuationToken;
+      if (!continuationToken) break;
+    }
+
+    const models = this.#normalize(entities);
+    if (models.length) this.#writeCache(models);
+    return models;
+  }
+
+  /**
+   * The catalog, served from cache unless it is missing or older than a week.
+   * Never throws — an unreachable registry yields the stale cache if there is
+   * one, otherwise an empty list, and the caller falls back to listing only
+   * what the daemon already has.
+   * @returns {Promise<CatalogModel[]>}
+   */
+  static async models() {
+    const cached = this.#readCache();
+    if (cached && !this.#cacheIsStale()) return cached;
+
+    try {
+      this.#log("Catalog cache is missing or stale. Fetching from registry.");
+      const models = await this.#fetchAll();
+      this.#log(`Cached ${models.length} catalog models.`);
+      return models;
+    } catch (e) {
+      this.#log(`Could not fetch catalog: ${e.message}`);
+      // Stale beats empty — the catalog moves on release cadence.
+      return cached ?? [];
+    }
+  }
+}
+
+module.exports = FoundryCatalog;

--- a/server/utils/AiProviders/foundry/index.js
+++ b/server/utils/AiProviders/foundry/index.js
@@ -118,7 +118,7 @@ class FoundryLLM {
     if (!isPrematureClose) return error.message;
 
     FoundryLLM.#loadedModels.delete(model);
-    return `${model} was unloaded by Foundry Local mid-response. Send the message again to reload it.`;
+    return "Foundry Local crashed trying to reply to this message. You should change the message or try again.";
   }
 
   #appendContext(contextTexts = []) {

--- a/server/utils/AiProviders/foundry/index.js
+++ b/server/utils/AiProviders/foundry/index.js
@@ -10,8 +10,18 @@ const {
 } = require("../../helpers/chat/LLMPerformanceMonitor");
 
 const { OpenAI: OpenAIApi } = require("openai");
+const ToolCallTextFilter = require("./toolCallFilter.js");
 
 class FoundryLLM {
+  /**
+   * The largest context window we will select on the user's behalf.
+   * Foundry runs on the user's own machine with no performance setting, so a
+   * model advertising 128K would make an average laptop crawl. A user who
+   * explicitly sets a larger limit still gets it, up to the model's real window.
+   * @type {number}
+   */
+  static MAX_DEFAULT_CONTEXT_WINDOW = 16_000;
+
   /** @see FoundryLLM.cacheContextWindows */
   static modelContextWindows = {};
 
@@ -51,6 +61,66 @@ class FoundryLLM {
     };
   }
 
+  /**
+   * Models this process has already loaded, so the check costs nothing after
+   * the first message. Cleared for a model whenever it turns out to be gone.
+   * @type {Set<string>}
+   */
+  static #loadedModels = new Set();
+
+  /**
+   * Ensure the model is in memory before we try to infer with it.
+   *
+   * Foundry 0.10 stopped auto-loading on inference. A non-streaming request
+   * against an unloaded model returns a clean error, but a *streaming* one
+   * answers 200 with SSE headers and then drops the connection, surfacing only
+   * as an opaque "Premature close". Loading first avoids both.
+   * @returns {Promise<void>}
+   */
+  async assertModelLoaded() {
+    if (!this.model || FoundryLLM.#loadedModels.has(this.model)) return;
+    const FoundryModels = require("./models.js");
+
+    // The service reports fully-qualified variant ids while the preference is
+    // usually an alias, so match on either side of the colon-versioned name.
+    const loaded = await FoundryModels.loadedModels();
+    const isLoaded = loaded.some(
+      (id) => id === this.model || id.split(":")[0] === this.model
+    );
+    if (isLoaded) {
+      FoundryLLM.#loadedModels.add(this.model);
+      return;
+    }
+
+    this.#log(`Loading ${this.model} into Foundry Local...`);
+    const { success, error } = await FoundryModels.loadModel(this.model);
+    if (!success)
+      throw new Error(
+        `Could not load ${this.model} into Foundry Local: ${error}`
+      );
+    FoundryLLM.#loadedModels.add(this.model);
+  }
+
+  /**
+   * Turn a mid-stream failure into something actionable.
+   *
+   * A model evicted after we loaded it — by an idle timeout, or from the host —
+   * makes the service answer 200 and then drop the socket, which reaches us
+   * only as "Premature close". Forget it so the next message reloads it.
+   * @param {Error} error
+   * @param {string} model
+   * @returns {string}
+   */
+  static explainStreamError(error, model) {
+    const isPrematureClose =
+      error?.code === "ERR_STREAM_PREMATURE_CLOSE" ||
+      /premature close/i.test(error?.message ?? "");
+    if (!isPrematureClose) return error.message;
+
+    FoundryLLM.#loadedModels.delete(model);
+    return `${model} was unloaded by Foundry Local mid-response. Send the message again to reload it.`;
+  }
+
   #appendContext(contextTexts = []) {
     if (!contextTexts || !contextTexts.length) return "";
     return (
@@ -84,18 +154,35 @@ class FoundryLLM {
       if (Object.keys(FoundryLLM.modelContextWindows).length > 0 && !force)
         return;
 
+      // A 0.10+ daemon dropped maxInputTokens/maxOutputTokens from /v1/models,
+      // so the registry catalog is the only place the real window is published.
+      // Key every name a model can be selected by, since the preference may
+      // hold an alias or a fully-qualified variant id.
+      const FoundryCatalog = require("./catalog.js");
+      for (const model of await FoundryCatalog.models()) {
+        if (!model.contextLength) continue;
+        FoundryLLM.modelContextWindows[model.alias] = model.contextLength;
+        for (const variant of model.variants)
+          FoundryLLM.modelContextWindows[variant.name] = model.contextLength;
+      }
+
       const openai = new OpenAIApi({
         baseURL: parseFoundryBasePath(process.env.FOUNDRY_BASE_PATH),
         apiKey: null,
       });
       (await openai.models.list().then((result) => result.data)).map(
         (model) => {
+          // Whatever the daemon reports wins — it knows how the model was
+          // actually loaded. Older daemons are the only ones that report this.
           const contextWindow =
             Number(model.maxInputTokens) + Number(model.maxOutputTokens);
-          FoundryLLM.modelContextWindows[model.id] = contextWindow;
+          if (contextWindow > 0)
+            FoundryLLM.modelContextWindows[model.id] = contextWindow;
         }
       );
-      FoundryLLM.#slog(`Context windows cached for all models!`);
+      FoundryLLM.#slog(
+        `Context windows cached for ${Object.keys(FoundryLLM.modelContextWindows).length} model name(s).`
+      );
     } catch (e) {
       FoundryLLM.#slog(`Error caching context windows: ${e.message}`);
       return;
@@ -111,39 +198,42 @@ class FoundryLLM {
    * @returns {Promise<boolean>}
    */
   static async unloadModelFromEngine(modelName) {
-    const basePath = parseFoundryBasePath(process.env.FOUNDRY_BASE_PATH);
-    const baseUrl = new URL(basePath);
-    baseUrl.pathname = `/openai/unload/${modelName}`;
-    baseUrl.searchParams.set("force", "true");
-    return await fetch(baseUrl.toString())
-      .then((res) => res.json())
-      .catch(() => null);
+    const FoundryModels = require("./models.js");
+    FoundryLLM.#loadedModels.delete(modelName);
+    return await FoundryModels.unloadModel(modelName);
   }
 
+  /**
+   * Resolve the context window to run a model with.
+   *
+   * - A user-set limit wins, but is clamped to what the model actually supports.
+   * - With no user limit we cap at MAX_DEFAULT_CONTEXT_WINDOW rather than using
+   *   the model's full window: these run on the user's own hardware, and
+   *   silently handing a 128K window to a laptop makes the app crawl.
+   * - With nothing known at all we fall back to a conservative 4096.
+   *
+   * @param {string} modelName - Alias or fully-qualified variant id.
+   * @returns {number}
+   */
   static promptWindowLimit(modelName) {
-    if (Object.keys(FoundryLLM.modelContextWindows).length === 0) {
+    const modelLimit = Number(this.modelContextWindows[modelName]) || null;
+    if (!modelLimit)
       this.#slog(
-        "No context windows cached - Context window may be inaccurately reported."
+        `No context window known for ${modelName} - it may be inaccurately reported.`
       );
-      return process.env.FOUNDRY_MODEL_TOKEN_LIMIT || 4096;
-    }
 
-    let userDefinedLimit = null;
-    const systemDefinedLimit =
-      Number(this.modelContextWindows[modelName]) || 4096;
+    const envLimit = Number(process.env.FOUNDRY_MODEL_TOKEN_LIMIT);
+    const userDefinedLimit =
+      Number.isFinite(envLimit) && envLimit > 0 ? envLimit : null;
 
-    if (
-      process.env.FOUNDRY_MODEL_TOKEN_LIMIT &&
-      !isNaN(Number(process.env.FOUNDRY_MODEL_TOKEN_LIMIT)) &&
-      Number(process.env.FOUNDRY_MODEL_TOKEN_LIMIT) > 0
-    )
-      userDefinedLimit = Number(process.env.FOUNDRY_MODEL_TOKEN_LIMIT);
-
-    // The user defined limit is always higher priority than the context window limit, but it cannot be higher than the context window limit
-    // so we return the minimum of the two, if there is no user defined limit, we return the system defined limit as-is.
     if (userDefinedLimit !== null)
-      return Math.min(userDefinedLimit, systemDefinedLimit);
-    return systemDefinedLimit;
+      return modelLimit
+        ? Math.min(userDefinedLimit, modelLimit)
+        : userDefinedLimit;
+
+    return modelLimit
+      ? Math.min(modelLimit, FoundryLLM.MAX_DEFAULT_CONTEXT_WINDOW)
+      : 8192;
   }
 
   promptWindowLimit() {
@@ -152,6 +242,15 @@ class FoundryLLM {
 
   async isValidChatCompletionModel(_ = "") {
     return true;
+  }
+
+  /**
+   * Returns the capabilities of the model.
+   * @returns {Promise<{tools: 'unknown' | boolean, reasoning: 'unknown' | boolean, imageGeneration: 'unknown' | boolean, vision: 'unknown' | boolean}>}
+   */
+  async getModelCapabilities() {
+    const FoundryModels = require("./models.js");
+    return await FoundryModels.getModelCapabilities(this.model);
   }
 
   /**
@@ -209,6 +308,10 @@ class FoundryLLM {
         `Foundry chat: ${this.model} is not valid or defined model for chat completion!`
       );
 
+    // max_completion_tokens is required by Foundry (it caps output at 1024
+    // otherwise), so the window has to be resolved before the request is built.
+    await this.assertModelContextLimits();
+    await this.assertModelLoaded();
     const result = await LLMPerformanceMonitor.measureAsyncFunction(
       this.openai.chat.completions
         .create({
@@ -249,6 +352,8 @@ class FoundryLLM {
         `Foundry chat: ${this.model} is not valid or defined model for chat completion!`
       );
 
+    await this.assertModelContextLimits();
+    await this.assertModelLoaded();
     const measuredStreamRequest = await LLMPerformanceMonitor.measureStream({
       func: this.openai.chat.completions.create({
         model: this.model,
@@ -289,6 +394,9 @@ class FoundryLLM {
       let fullText = "";
       let reasoningText = "";
       let lastChunkTime = null; // null when first token is still not received.
+      // Foundry echoes tool calls into the content stream as raw markup on top
+      // of emitting them natively — keep that out of the chat window.
+      const toolCallFilter = new ToolCallTextFilter();
 
       // Establish listener to early-abort a streaming response
       // in case things go sideways or the user does not like the response.
@@ -387,15 +495,18 @@ class FoundryLLM {
           }
 
           if (token) {
-            fullText += token;
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: token,
-              close: false,
-              error: false,
-            });
+            const visible = toolCallFilter.push(token);
+            if (visible) {
+              fullText += visible;
+              writeResponseChunk(response, {
+                uuid,
+                sources: [],
+                type: "textResponseChunk",
+                textResponse: visible,
+                close: false,
+                error: false,
+              });
+            }
           }
 
           // finish_reason can be "stop", "length", etc. when complete
@@ -425,7 +536,7 @@ class FoundryLLM {
           type: "abort",
           textResponse: null,
           close: true,
-          error: e.message,
+          error: FoundryLLM.explainStreamError(e, this.model),
         });
         response.removeListener("close", handleAbort);
         clearInterval(timeoutCheck);

--- a/server/utils/AiProviders/foundry/models.js
+++ b/server/utils/AiProviders/foundry/models.js
@@ -42,7 +42,6 @@ class FoundryModels {
   /** Loading reads a multi-GB model off disk, so it gets a much longer leash. */
   static LOAD_TIMEOUT_MS = 300_000;
 
-
   static #log(text, ...args) {
     console.log(`\x1b[36m[FoundryModels]\x1b[0m ${text}`, ...args);
   }
@@ -303,7 +302,6 @@ class FoundryModels {
       return await this.#listFromOpenAiSurface(basePath);
     }
   }
-
 
   /**
    * @typedef {'unknown'|boolean} Capability

--- a/server/utils/AiProviders/foundry/models.js
+++ b/server/utils/AiProviders/foundry/models.js
@@ -1,5 +1,4 @@
 const { parseFoundryBasePath } = require("./index.js");
-const { safeJsonParse } = require("../../http");
 const FoundryCatalog = require("./catalog.js");
 
 /**
@@ -43,8 +42,6 @@ class FoundryModels {
   /** Loading reads a multi-GB model off disk, so it gets a much longer leash. */
   static LOAD_TIMEOUT_MS = 300_000;
 
-  static UNMANAGEABLE_ERROR =
-    "This Foundry service does not expose a model management API. Install models on the host with the Foundry Local CLI (`foundry model download <model>`), then refresh.";
 
   static #log(text, ...args) {
     console.log(`\x1b[36m[FoundryModels]\x1b[0m ${text}`, ...args);
@@ -307,107 +304,6 @@ class FoundryModels {
     }
   }
 
-  /**
-   * Download a model into the daemon's local storage.
-   * @param {string} modelId
-   * @param {(percentage: number) => void} onProgress
-   * @param {string} basePath
-   * @returns {Promise<{success: boolean, error: string|null}>}
-   */
-  static async downloadModel(
-    modelId,
-    onProgress = () => {},
-    basePath = process.env.FOUNDRY_BASE_PATH
-  ) {
-    const { source } = await this.resolveSource(basePath);
-    if (source !== "rest")
-      return { success: false, error: this.UNMANAGEABLE_ERROR };
-
-    const origin = this.#originOf(basePath);
-    try {
-      const catalog = await this.#fetchWithTimeout(
-        `${origin}/foundry/list`
-      ).then((res) => res.json());
-      const entries = Array.isArray(catalog) ? catalog : catalog?.models ?? [];
-      const model = entries.find(
-        (entry) => entry.alias === modelId || entry.name === modelId
-      );
-      if (!model)
-        throw new Error(`Model ${modelId} was not found in the catalog`);
-
-      // No timeout here — model downloads routinely run for many minutes.
-      const response = await fetch(`${origin}/openai/download`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: {
-            Uri: model.uri,
-            Name: model.name,
-            ProviderType: model.providerType,
-            Publisher: model.publisher ?? "",
-            PromptTemplate: model.promptTemplate ?? {},
-          },
-        }),
-      });
-      if (!response.ok)
-        throw new Error(`Download failed with status ${response.status}`);
-
-      // The daemon streams either `("file.onnx", 0.42)` tuples or `NN%` lines
-      // depending on its version, then a trailing JSON result object.
-      const reader = response.body.getReader();
-      let tail = "";
-      let lastPercentage = 0;
-
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-
-        const chunk = new TextDecoder("utf-8").decode(value);
-        tail = (tail + chunk).slice(-4096);
-
-        for (const line of chunk.split(/[\r\n]+/)) {
-          if (!line.trim()) continue;
-          const tuple = line.match(/\(\s*"[^"]*"\s*,\s*(\d*\.?\d+)\s*\)/);
-          const percent = line.match(/(\d+(?:\.\d+)?)%/);
-
-          let percentage = null;
-          if (tuple) percentage = Math.round(Number(tuple[1]) * 100);
-          else if (percent) percentage = Math.round(Number(percent[1]));
-          if (percentage === null) continue;
-
-          percentage = Math.min(Math.max(percentage, 0), 100);
-          // Progress restarts per file in a multi-part model, so only advance.
-          if (percentage > lastPercentage) {
-            lastPercentage = percentage;
-            onProgress(percentage);
-          }
-        }
-      }
-
-      // Failures are reported in the final JSON payload, not the status code.
-      const finalJson = tail.match(/\{[\s\S]*\}\s*$/);
-      const result = finalJson ? safeJsonParse(finalJson[0]) : null;
-      if (result?.Success === false)
-        throw new Error(result.ErrorMessage || "Model download failed");
-
-      onProgress(100);
-      return { success: true, error: null };
-    } catch (e) {
-      return { success: false, error: e.message };
-    }
-  }
-
-  /**
-   * The REST API has no delete route — removing a model is a host-side action.
-   * @returns {Promise<{success: boolean, error: string}>}
-   */
-  static async deleteModel() {
-    return {
-      success: false,
-      error:
-        "Removing models is not supported over the Foundry REST API. Remove it on the host with `foundry cache remove <model>`.",
-    };
-  }
 
   /**
    * @typedef {'unknown'|boolean} Capability

--- a/server/utils/AiProviders/foundry/models.js
+++ b/server/utils/AiProviders/foundry/models.js
@@ -1,0 +1,490 @@
+const { parseFoundryBasePath } = require("./index.js");
+const { safeJsonParse } = require("../../http");
+const FoundryCatalog = require("./catalog.js");
+
+/**
+ * @typedef {'rest'|'openai'} FoundrySource
+ *
+ * @typedef {Object} FoundryUiModel
+ * @property {string} id - What gets persisted as the model preference.
+ * @property {string} name
+ * @property {string} organization - Group heading in the model table.
+ * @property {number|null} size - Size in MB (null when unknown).
+ * @property {'CPU'|'GPU'|'NPU'|null} deviceType
+ * @property {boolean} downloaded
+ * @property {boolean} toolCalling
+ * @property {string|null} variantId - Fully-qualified model name, when known.
+ */
+
+/**
+ * Resolves Foundry models over HTTP only.
+ *
+ * AnythingLLM runs in a container here, so the `foundry` CLI — which lives on
+ * the host — is not reachable. Everything must go through the daemon's REST
+ * API, which comes in two flavors:
+ *
+ *  - `rest`   A pre-0.10 daemon that serves the management routes
+ *             (/foundry/list, /openai/models, /openai/download). This is the
+ *             only configuration where models can be browsed and installed
+ *             from AnythingLLM.
+ *  - `openai` A 0.10+ daemon, which dropped every management route and serves
+ *             only the OpenAI-compatible /v1 surface. Lists only what is
+ *             installed; management is a host-side action via the CLI.
+ *
+ * The Azure registry catalog (FoundryCatalog) is NOT used for listing — it
+ * advertises every hardware variant including ones this machine cannot run
+ * (e.g. QNN on macOS). It IS still consulted for metadata lookups: context
+ * windows, tool-calling support, reasoning, and vision capabilities.
+ */
+class FoundryModels {
+  /** Management probes and catalog reads should fail fast, not hang the UI. */
+  static REQUEST_TIMEOUT_MS = 10_000;
+
+  /** Loading reads a multi-GB model off disk, so it gets a much longer leash. */
+  static LOAD_TIMEOUT_MS = 300_000;
+
+  static UNMANAGEABLE_ERROR =
+    "This Foundry service does not expose a model management API. Install models on the host with the Foundry Local CLI (`foundry model download <model>`), then refresh.";
+
+  static #log(text, ...args) {
+    console.log(`\x1b[36m[FoundryModels]\x1b[0m ${text}`, ...args);
+  }
+
+  /**
+   * Normalize a base path to the daemon origin. Management routes live at the
+   * root while chat completions live under /v1, so the base path cannot be
+   * reused verbatim.
+   * @param {string} basePath
+   * @returns {string|null}
+   */
+  static #originOf(basePath = "") {
+    try {
+      return new URL(basePath).origin;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * @param {string} url
+   * @param {RequestInit} options
+   * @returns {Promise<Response>}
+   */
+  static #fetchWithTimeout(url, options = {}) {
+    return fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(this.REQUEST_TIMEOUT_MS),
+    });
+  }
+
+  /**
+   * Map a /foundry/list catalog entry into the UI shape.
+   * @param {object} model
+   * @param {Set<string>} cachedNames
+   * @returns {FoundryUiModel}
+   */
+  static #fromRestCatalog(model, cachedNames) {
+    const alias = model.alias || model.name;
+    const task = String(model.task ?? "");
+    return {
+      id: alias,
+      name: alias,
+      organization: task.toLowerCase().includes("chat")
+        ? "Chat"
+        : task || "Chat",
+      size: Number(model.fileSizeMb ?? 0),
+      deviceType: String(model.runtime?.deviceType ?? "CPU").toUpperCase(),
+      downloaded: cachedNames.has(model.name),
+      toolCalling: Boolean(model.supportsToolCalling),
+      variantId: model.name ?? null,
+    };
+  }
+
+  /**
+   * The models currently held in memory, as fully-qualified variant ids.
+   *
+   * `/models/loaded` is one of three management routes that survived the 0.10
+   * rewrite (with load and unload). None are in the published REST reference,
+   * but they are what the 1.x SDK talks to when pointed at a remote service.
+   * @param {string} basePath
+   * @returns {Promise<string[]>}
+   */
+  static async loadedModels(basePath = process.env.FOUNDRY_BASE_PATH) {
+    const origin = this.#originOf(basePath);
+    if (!origin) return [];
+    try {
+      const response = await this.#fetchWithTimeout(`${origin}/models/loaded`);
+      if (!response.ok) return [];
+      const loaded = await response.json();
+      return Array.isArray(loaded) ? loaded : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Load a model into memory. Foundry 0.10 stopped auto-loading on inference,
+   * so this has to happen before the first completion — otherwise a streaming
+   * request is answered with headers and then the connection is dropped.
+   * @param {string} modelId - Alias or fully-qualified variant id.
+   * @param {string} basePath
+   * @returns {Promise<{success: boolean, error: string|null}>}
+   */
+  static async loadModel(modelId, basePath = process.env.FOUNDRY_BASE_PATH) {
+    const origin = this.#originOf(basePath);
+    if (!origin || !modelId)
+      return { success: false, error: "No Foundry service or model was set." };
+
+    try {
+      // Loading pulls a multi-GB model into memory, well past the probe timeout.
+      const response = await fetch(
+        `${origin}/models/load/${encodeURIComponent(modelId)}`,
+        { signal: AbortSignal.timeout(this.LOAD_TIMEOUT_MS) }
+      );
+      if (!response.ok)
+        throw new Error(
+          `Foundry could not load ${modelId} (HTTP ${response.status}). Is the model downloaded?`
+        );
+      return { success: true, error: null };
+    } catch (e) {
+      return { success: false, error: e.message };
+    }
+  }
+
+  /**
+   * Release a model from memory.
+   * @param {string} modelId
+   * @param {string} basePath
+   * @returns {Promise<boolean>}
+   */
+  static async unloadModel(modelId, basePath = process.env.FOUNDRY_BASE_PATH) {
+    const origin = this.#originOf(basePath);
+    if (!origin || !modelId) return false;
+    try {
+      const response = await this.#fetchWithTimeout(
+        `${origin}/models/unload/${encodeURIComponent(modelId)}`
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Infer the device class from a variant id's suffix.
+   * Variant ids follow the pattern `<name>-<backend>-<device>`, e.g.
+   * `qwen2.5-0.5b-instruct-cuda-gpu`, `Phi-4-mini-reasoning-generic-cpu`,
+   * `qwen2.5-1.5b-instruct-qnn-npu`.
+   * @param {string} modelId
+   * @returns {'CPU'|'GPU'|'NPU'|null}
+   */
+  static #deviceTypeFromId(modelId = "") {
+    const lower = modelId.toLowerCase();
+    if (lower.endsWith("-cpu")) return "CPU";
+    if (lower.endsWith("-gpu")) return "GPU";
+    if (lower.endsWith("-npu")) return "NPU";
+    return null;
+  }
+
+  /**
+   * List models from a 0.10+ daemon, which only reports what it has installed.
+   * Device type is parsed from the variant id suffix; size is enriched from the
+   * Azure catalog cache when available.
+   * @param {string} basePath
+   * @returns {Promise<{models: FoundryUiModel[], source: FoundrySource, canManage: boolean}>}
+   */
+  static async #listFromOpenAiSurface(basePath) {
+    try {
+      const { OpenAI: OpenAIApi } = require("openai");
+      const openai = new OpenAIApi({
+        baseURL: parseFoundryBasePath(basePath),
+        apiKey: null,
+      });
+
+      const catalogVariants = await this.#catalogVariantIndex();
+      const models = await openai.models.list().then((result) =>
+        result.data.map((model) => {
+          const deviceType = this.#deviceTypeFromId(model.id);
+          const catalogHit = catalogVariants.get(model.id.toLowerCase());
+          return {
+            id: model.id,
+            name: model.id,
+            organization: "Available Models",
+            size: catalogHit?.sizeMb ?? null,
+            deviceType,
+            downloaded: true,
+            toolCalling: false,
+            variantId: model.id,
+          };
+        })
+      );
+      return { models, source: "openai", canManage: false };
+    } catch (e) {
+      this.#log(`Could not list models: ${e.message}`);
+      return { models: [], source: "openai", canManage: false };
+    }
+  }
+
+  /**
+   * Build a case-insensitive index of catalog variant names → variant data.
+   * Returns an empty map when the catalog is unavailable — never throws.
+   * @returns {Promise<Map<string, import("./catalog.js").CatalogVariant>>}
+   */
+  static async #catalogVariantIndex() {
+    try {
+      const catalog = await FoundryCatalog.models();
+      const index = new Map();
+      for (const model of catalog) {
+        for (const variant of model.variants) {
+          index.set(variant.name.toLowerCase(), variant);
+        }
+      }
+      return index;
+    } catch {
+      return new Map();
+    }
+  }
+
+  /**
+   * Determine which surface the configured daemon exposes.
+   * @param {string} basePath
+   * @returns {Promise<{source: FoundrySource, canManage: boolean}>}
+   */
+  static async resolveSource(basePath = process.env.FOUNDRY_BASE_PATH) {
+    const origin = this.#originOf(basePath);
+    if (!origin) return { source: "openai", canManage: false };
+
+    try {
+      const response = await this.#fetchWithTimeout(`${origin}/foundry/list`);
+      if (response.ok) return { source: "rest", canManage: true };
+    } catch {
+      // Unreachable, or a 0.10+ daemon that no longer routes this path.
+    }
+    return { source: "openai", canManage: false };
+  }
+
+  /**
+   * List models from whichever surface is available.
+   * @param {string} basePath
+   * @returns {Promise<{models: FoundryUiModel[], source: FoundrySource, canManage: boolean}>}
+   */
+  static async listModels(basePath = process.env.FOUNDRY_BASE_PATH) {
+    const { source, canManage } = await this.resolveSource(basePath);
+    const origin = this.#originOf(basePath);
+    if (source !== "rest") return await this.#listFromOpenAiSurface(basePath);
+
+    try {
+      const [catalog, cached] = await Promise.all([
+        this.#fetchWithTimeout(`${origin}/foundry/list`).then((res) =>
+          res.json()
+        ),
+        this.#fetchWithTimeout(`${origin}/openai/models`)
+          .then((res) => res.json())
+          .catch(() => []),
+      ]);
+
+      const cachedNames = new Set(Array.isArray(cached) ? cached : []);
+      const entries = Array.isArray(catalog) ? catalog : catalog?.models ?? [];
+
+      // The catalog lists one entry per device variant. Collapse to one row per
+      // alias, preferring a variant that is already downloaded so the table
+      // reflects local state.
+      const byAlias = entries
+        .map((model) => this.#fromRestCatalog(model, cachedNames))
+        .reduce((acc, model) => {
+          const existing = acc.get(model.id);
+          if (!existing || (model.downloaded && !existing.downloaded))
+            acc.set(model.id, model);
+          return acc;
+        }, new Map());
+
+      return { models: Array.from(byAlias.values()), source, canManage };
+    } catch (e) {
+      this.#log(
+        `REST catalog lookup failed, falling back to /v1/models: ${e.message}`
+      );
+      return await this.#listFromOpenAiSurface(basePath);
+    }
+  }
+
+  /**
+   * Download a model into the daemon's local storage.
+   * @param {string} modelId
+   * @param {(percentage: number) => void} onProgress
+   * @param {string} basePath
+   * @returns {Promise<{success: boolean, error: string|null}>}
+   */
+  static async downloadModel(
+    modelId,
+    onProgress = () => {},
+    basePath = process.env.FOUNDRY_BASE_PATH
+  ) {
+    const { source } = await this.resolveSource(basePath);
+    if (source !== "rest")
+      return { success: false, error: this.UNMANAGEABLE_ERROR };
+
+    const origin = this.#originOf(basePath);
+    try {
+      const catalog = await this.#fetchWithTimeout(
+        `${origin}/foundry/list`
+      ).then((res) => res.json());
+      const entries = Array.isArray(catalog) ? catalog : catalog?.models ?? [];
+      const model = entries.find(
+        (entry) => entry.alias === modelId || entry.name === modelId
+      );
+      if (!model)
+        throw new Error(`Model ${modelId} was not found in the catalog`);
+
+      // No timeout here — model downloads routinely run for many minutes.
+      const response = await fetch(`${origin}/openai/download`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: {
+            Uri: model.uri,
+            Name: model.name,
+            ProviderType: model.providerType,
+            Publisher: model.publisher ?? "",
+            PromptTemplate: model.promptTemplate ?? {},
+          },
+        }),
+      });
+      if (!response.ok)
+        throw new Error(`Download failed with status ${response.status}`);
+
+      // The daemon streams either `("file.onnx", 0.42)` tuples or `NN%` lines
+      // depending on its version, then a trailing JSON result object.
+      const reader = response.body.getReader();
+      let tail = "";
+      let lastPercentage = 0;
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        const chunk = new TextDecoder("utf-8").decode(value);
+        tail = (tail + chunk).slice(-4096);
+
+        for (const line of chunk.split(/[\r\n]+/)) {
+          if (!line.trim()) continue;
+          const tuple = line.match(/\(\s*"[^"]*"\s*,\s*(\d*\.?\d+)\s*\)/);
+          const percent = line.match(/(\d+(?:\.\d+)?)%/);
+
+          let percentage = null;
+          if (tuple) percentage = Math.round(Number(tuple[1]) * 100);
+          else if (percent) percentage = Math.round(Number(percent[1]));
+          if (percentage === null) continue;
+
+          percentage = Math.min(Math.max(percentage, 0), 100);
+          // Progress restarts per file in a multi-part model, so only advance.
+          if (percentage > lastPercentage) {
+            lastPercentage = percentage;
+            onProgress(percentage);
+          }
+        }
+      }
+
+      // Failures are reported in the final JSON payload, not the status code.
+      const finalJson = tail.match(/\{[\s\S]*\}\s*$/);
+      const result = finalJson ? safeJsonParse(finalJson[0]) : null;
+      if (result?.Success === false)
+        throw new Error(result.ErrorMessage || "Model download failed");
+
+      onProgress(100);
+      return { success: true, error: null };
+    } catch (e) {
+      return { success: false, error: e.message };
+    }
+  }
+
+  /**
+   * The REST API has no delete route — removing a model is a host-side action.
+   * @returns {Promise<{success: boolean, error: string}>}
+   */
+  static async deleteModel() {
+    return {
+      success: false,
+      error:
+        "Removing models is not supported over the Foundry REST API. Remove it on the host with `foundry cache remove <model>`.",
+    };
+  }
+
+  /**
+   * @typedef {'unknown'|boolean} Capability
+   * @typedef {{tools: Capability, reasoning: Capability, imageGeneration: Capability, vision: Capability}} ModelCapabilities
+   */
+
+  /** Capabilities we could not determine at all. */
+  static get UNKNOWN_CAPABILITIES() {
+    return {
+      tools: "unknown",
+      reasoning: "unknown",
+      imageGeneration: "unknown",
+      vision: "unknown",
+    };
+  }
+
+  /**
+   * Find a model in the Azure registry catalog by alias or variant name.
+   * @param {string} modelId
+   * @returns {Promise<import("./catalog.js").CatalogModel|null>}
+   */
+  static async #catalogEntry(modelId) {
+    const catalog = await FoundryCatalog.models();
+    return (
+      catalog.find(
+        (model) =>
+          model.alias === modelId ||
+          model.variants.some((variant) => variant.name === modelId)
+      ) ?? null
+    );
+  }
+
+  /**
+   * Report what a model can do.
+   *
+   * The registry catalog describes tool calling, reasoning and vision, so it is
+   * the richest source and is consulted first. The daemon's own REST catalog
+   * only advertises tool calling. Foundry Local has no image generation on any
+   * surface, so that is a hard false rather than "unknown".
+   * @param {string} modelId
+   * @param {string} basePath
+   * @returns {Promise<ModelCapabilities>}
+   */
+  static async getModelCapabilities(
+    modelId,
+    basePath = process.env.FOUNDRY_BASE_PATH
+  ) {
+    if (!modelId) return this.UNKNOWN_CAPABILITIES;
+    try {
+      const entry = await this.#catalogEntry(modelId);
+      if (entry)
+        return {
+          tools: entry.toolCalling,
+          reasoning: entry.reasoning,
+          imageGeneration: false,
+          vision: entry.vision,
+        };
+
+      const { models, source } = await this.listModels(basePath);
+      if (source !== "rest") return this.UNKNOWN_CAPABILITIES;
+
+      const match = models.find(
+        (model) => model.id === modelId || model.variantId === modelId
+      );
+      if (!match) return this.UNKNOWN_CAPABILITIES;
+
+      return {
+        tools: Boolean(match.toolCalling),
+        reasoning: "unknown",
+        imageGeneration: false,
+        vision: "unknown",
+      };
+    } catch (e) {
+      this.#log(`Could not determine model capabilities: ${e.message}`);
+      return this.UNKNOWN_CAPABILITIES;
+    }
+  }
+}
+
+module.exports = FoundryModels;

--- a/server/utils/AiProviders/foundry/models.js
+++ b/server/utils/AiProviders/foundry/models.js
@@ -357,7 +357,7 @@ class FoundryModels {
           tools: entry.toolCalling,
           reasoning: entry.reasoning,
           imageGeneration: false,
-          vision: entry.vision,
+          vision: false, // entry.vision - currently no vision models work on any hardware for some reason,
         };
 
       const { models, source } = await this.listModels(basePath);

--- a/server/utils/AiProviders/foundry/toolCallFilter.js
+++ b/server/utils/AiProviders/foundry/toolCallFilter.js
@@ -1,0 +1,107 @@
+/**
+ * Strips `<tool_call>…</tool_call>` markup out of streamed assistant text.
+ *
+ * Foundry Local emits a tool call *twice*: once properly, as OpenAI
+ * `delta.tool_calls`, and again as raw markup inside `delta.content`:
+ *
+ *   <tool_call>
+ *   {"name": "web-scraping", "arguments": {"url": "https://anythingllm.com"}}
+ *   </tool_call>
+ *
+ * The native copy is what actually invokes the tool, so the text copy is pure
+ * noise — but it reaches the chat window verbatim. Filtering has to survive the
+ * tags being split across chunks (`<tool` / `_call>`), so this holds back any
+ * trailing text that could still turn out to be the start of an opening tag.
+ */
+class ToolCallTextFilter {
+  static OPEN = "<tool_call>";
+  static CLOSE = "</tool_call>";
+
+  constructor() {
+    /** Text withheld pending a decision — a partial tag, or a suppressed block. */
+    this.buffer = "";
+    /** True once an opening tag is seen, until its closing tag arrives. */
+    this.suppressing = false;
+  }
+
+  /**
+   * How many characters at the end of `text` could be the beginning of `tag`.
+   * `"hello <tool"` against `"<tool_call>"` returns 5, so those are held back
+   * rather than emitted and then regretted.
+   * @param {string} text
+   * @param {string} tag
+   * @returns {number}
+   */
+  static #partialTagLength(text, tag) {
+    const max = Math.min(text.length, tag.length - 1);
+    for (let length = max; length > 0; length--) {
+      if (tag.startsWith(text.slice(text.length - length))) return length;
+    }
+    return 0;
+  }
+
+  /**
+   * Feed the next chunk of assistant text.
+   * @param {string} text
+   * @returns {string} The portion safe to show the user, possibly empty.
+   */
+  push(text = "") {
+    this.buffer += text;
+    let emitted = "";
+
+    // Each pass consumes one tag; loop because a chunk may contain several.
+    for (;;) {
+      if (this.suppressing) {
+        const close = this.buffer.indexOf(ToolCallTextFilter.CLOSE);
+        // Still inside a tool call — keep swallowing until the tag closes.
+        if (close === -1) return emitted;
+        this.buffer = this.buffer.slice(
+          close + ToolCallTextFilter.CLOSE.length
+        );
+        this.suppressing = false;
+        continue;
+      }
+
+      const open = this.buffer.indexOf(ToolCallTextFilter.OPEN);
+      if (open !== -1) {
+        emitted += this.buffer.slice(0, open);
+        this.buffer = this.buffer.slice(open + ToolCallTextFilter.OPEN.length);
+        this.suppressing = true;
+        continue;
+      }
+
+      const held = ToolCallTextFilter.#partialTagLength(
+        this.buffer,
+        ToolCallTextFilter.OPEN
+      );
+      emitted += this.buffer.slice(0, this.buffer.length - held);
+      this.buffer = this.buffer.slice(this.buffer.length - held);
+      return emitted;
+    }
+  }
+
+  /**
+   * Release anything still held once the stream ends. Text withheld as a
+   * possible partial tag turned out to be ordinary text; an unterminated tool
+   * call stays suppressed.
+   * @returns {string}
+   */
+  flush() {
+    const remainder = this.suppressing ? "" : this.buffer;
+    this.buffer = "";
+    return remainder;
+  }
+
+  /**
+   * Remove tool-call markup from a complete (non-streamed) string.
+   * @param {string} text
+   * @returns {string}
+   */
+  static clean(text = "") {
+    if (!text.includes(ToolCallTextFilter.OPEN)) return text;
+    const filter = new ToolCallTextFilter();
+    return `${filter.push(text)}${filter.flush()}`;
+  }
+}
+
+module.exports = ToolCallTextFilter;

--- a/server/utils/agents/aibitat/providers/foundry.js
+++ b/server/utils/agents/aibitat/providers/foundry.js
@@ -107,6 +107,13 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
     };
   }
 
+  #isPrematureClose(error) {
+    return (
+      error?.code === "ERR_STREAM_PREMATURE_CLOSE" ||
+      /premature close/i.test(error?.message ?? "")
+    );
+  }
+
   // ---- UnTooled callbacks (used when native tool calling is not supported) ----
 
   async #handleFunctionCallChat({ messages = [] }) {
@@ -124,7 +131,9 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
           throw new Error("Microsoft Foundry Local chat: No results length!");
         return result.choices[0].message.content;
       })
-      .catch((_) => {
+      .catch((e) => {
+        if (this.#isPrematureClose(e))
+          throw new Error(FoundryLLM.explainStreamError(e, this.model));
         return null;
       });
   }
@@ -173,6 +182,8 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
     } catch (error) {
       console.error(error.message, error);
       if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (this.#isPrematureClose(error))
+        throw new Error(FoundryLLM.explainStreamError(error, this.model));
       if (
         error instanceof OpenAI.RateLimitError ||
         error instanceof OpenAI.InternalServerError ||
@@ -222,6 +233,8 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
     } catch (error) {
       console.error(error.message, error);
       if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (this.#isPrematureClose(error))
+        throw new Error(FoundryLLM.explainStreamError(error, this.model));
       if (
         error instanceof OpenAI.RateLimitError ||
         error instanceof OpenAI.InternalServerError ||

--- a/server/utils/agents/aibitat/providers/foundry.js
+++ b/server/utils/agents/aibitat/providers/foundry.js
@@ -2,14 +2,18 @@ const OpenAI = require("openai");
 const Provider = require("./ai-provider.js");
 const InheritMultiple = require("./helpers/classes.js");
 const UnTooled = require("./helpers/untooled.js");
+const { tooledStream, tooledComplete } = require("./helpers/tooled.js");
+const { RetryError } = require("../error.js");
 const {
   parseFoundryBasePath,
   FoundryLLM,
 } = require("../../../AiProviders/foundry/index.js");
+const ToolCallTextFilter = require("../../../AiProviders/foundry/toolCallFilter.js");
 
 /**
- * The agent provider for the Foundry provider.
- * Uses untooled because it doesn't support tool calling.
+ * The agent provider for Microsoft Foundry Local.
+ * Uses native OpenAI-compatible tool calling when the selected model advertises
+ * support for it, falling back to the UnTooled prompt-based approach otherwise.
  */
 class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
   model;
@@ -26,6 +30,8 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
     this._client = client;
     this.model = model;
     this.verbose = true;
+    this._supportsToolCalling = null;
+    this._llm = null;
   }
 
   /**
@@ -41,17 +47,70 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   /**
-   * Whether this provider supports native OpenAI-compatible tool calling.
-   * - Foundry needs more explict testing to determine if it supports tool calling.
-   * For now, we'll return false until we can get definitive results.
-   * @returns {boolean}
+   * The provider instance backing capability and context-window lookups.
+   * Built once and reused — constructing it spins up an embedder, which is
+   * wasted work on every completion.
+   * @returns {FoundryLLM}
    */
-  async supportsNativeToolCalling() {
-    return false;
+  #llm() {
+    if (!this._llm) this._llm = new FoundryLLM(null, this.model);
+    return this._llm;
   }
 
+  /**
+   * Resolve the model's context window before a request is built. Foundry caps
+   * output at 1024 tokens when max_completion_tokens is unset, so every path
+   * that sends a completion has to know the window first.
+   * @returns {Promise<void>}
+   */
+  async #assertContextLimits() {
+    await this.#llm().assertModelContextLimits();
+    await this.#llm().assertModelLoaded();
+  }
+
+  /**
+   * Whether the selected model supports native OpenAI-compatible tool calling.
+   * Foundry reports this per-model in its catalog; a service that exposes no
+   * catalog reports "unknown", in which case we fall back to UnTooled.
+   * @returns {Promise<boolean>}
+   */
+  async supportsNativeToolCalling() {
+    if (this.optsOutOfNativeToolCallingViaEnv(this.providerTag)) return false;
+    if (this._supportsToolCalling !== null) return this._supportsToolCalling;
+    const capabilities = await this.#llm().getModelCapabilities();
+    this._supportsToolCalling = capabilities.tools === true;
+    return this._supportsToolCalling;
+  }
+
+  /**
+   * Foundry echoes every tool call into `delta.content` as raw
+   * `<tool_call>…</tool_call>` markup on top of emitting it natively, so the
+   * markup would otherwise be printed into the chat. Wrap the event handler to
+   * strip it from text chunks while leaving every other event untouched.
+   * @param {function|null} eventHandler
+   * @returns {function|null}
+   */
+  #filterToolCallMarkup(eventHandler) {
+    if (!eventHandler) return eventHandler;
+    const filter = new ToolCallTextFilter();
+
+    return (event, payload) => {
+      if (
+        event !== "reportStreamEvent" ||
+        payload?.type !== "textResponseChunk"
+      )
+        return eventHandler(event, payload);
+
+      const content = filter.push(payload.content ?? "");
+      if (!content) return;
+      return eventHandler(event, { ...payload, content });
+    };
+  }
+
+  // ---- UnTooled callbacks (used when native tool calling is not supported) ----
+
   async #handleFunctionCallChat({ messages = [] }) {
-    await FoundryLLM.cacheContextWindows();
+    await this.#assertContextLimits();
     return await this.client.chat.completions
       .create({
         model: this.model,
@@ -71,7 +130,7 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
   }
 
   async #handleFunctionCallStream({ messages = [] }) {
-    await FoundryLLM.cacheContextWindows();
+    await this.#assertContextLimits();
     return await this.client.chat.completions.create({
       model: this.model,
       stream: true,
@@ -80,23 +139,98 @@ class FoundryProvider extends InheritMultiple([Provider, UnTooled]) {
     });
   }
 
+  /**
+   * Stream a chat completion with tool calling support.
+   * Uses native tool calling when supported, otherwise falls back to UnTooled.
+   */
   async stream(messages, functions = [], eventHandler = null) {
-    return await UnTooled.prototype.stream.call(
-      this,
-      messages,
-      functions,
-      this.#handleFunctionCallStream.bind(this),
-      eventHandler
+    const useNative = await this.supportsNativeToolCalling();
+
+    if (!useNative) {
+      return await UnTooled.prototype.stream.call(
+        this,
+        messages,
+        functions,
+        this.#handleFunctionCallStream.bind(this),
+        eventHandler
+      );
+    }
+
+    this.providerLog(
+      "Provider.stream (tooled) - will process this chat completion."
     );
+
+    try {
+      await this.#assertContextLimits();
+      return await tooledStream(
+        this.client,
+        this.model,
+        messages,
+        functions,
+        this.#filterToolCallMarkup(eventHandler),
+        { provider: this }
+      );
+    } catch (error) {
+      console.error(error.message, error);
+      if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (
+        error instanceof OpenAI.RateLimitError ||
+        error instanceof OpenAI.InternalServerError ||
+        error instanceof OpenAI.APIError
+      ) {
+        throw new RetryError(error.message);
+      }
+      throw error;
+    }
   }
 
+  /**
+   * Create a non-streaming completion with tool calling support.
+   * Uses native tool calling when supported, otherwise falls back to UnTooled.
+   */
   async complete(messages, functions = []) {
-    return await UnTooled.prototype.complete.call(
-      this,
-      messages,
-      functions,
-      this.#handleFunctionCallChat.bind(this)
-    );
+    const useNative = await this.supportsNativeToolCalling();
+
+    if (!useNative) {
+      return await UnTooled.prototype.complete.call(
+        this,
+        messages,
+        functions,
+        this.#handleFunctionCallChat.bind(this)
+      );
+    }
+
+    try {
+      await this.#assertContextLimits();
+      const result = await tooledComplete(
+        this.client,
+        this.model,
+        messages,
+        functions,
+        this.getCost.bind(this),
+        { provider: this }
+      );
+
+      if (result.retryWithError) {
+        return this.complete([...messages, result.retryWithError], functions);
+      }
+
+      // Same markup echo as the streaming path, minus the chunk boundaries.
+      if (typeof result?.result === "string")
+        result.result = ToolCallTextFilter.clean(result.result);
+      return result;
+    } catch (error) {
+      console.error(error.message, error);
+      if (error instanceof OpenAI.AuthenticationError) throw error;
+      if (
+        error instanceof OpenAI.RateLimitError ||
+        error instanceof OpenAI.InternalServerError ||
+        error instanceof OpenAI.APIError
+      ) {
+        throw new RetryError(error.message);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/server/utils/helpers/customModels.js
+++ b/server/utils/helpers/customModels.js
@@ -12,7 +12,6 @@ const { parseNvidiaNimBasePath } = require("../AiProviders/nvidiaNim");
 const { fetchPPIOModels } = require("../AiProviders/ppio");
 const { GeminiLLM } = require("../AiProviders/gemini");
 const { fetchCometApiModels } = require("../AiProviders/cometapi");
-const { parseFoundryBasePath } = require("../AiProviders/foundry");
 const { getDockerModels } = require("../AiProviders/dockerModelRunner");
 const { getAllLemonadeModels } = require("../AiProviders/lemonade");
 
@@ -939,26 +938,19 @@ async function getMoonshotAiModels(_apiKey = null) {
   return { models, error: null };
 }
 
+/**
+ * List Foundry models for the model picker.
+ *
+ * Resolves against whichever management surface this host exposes — see the
+ * models module for how that is determined and what each one can report.
+ * @see {@link ../AiProviders/foundry/models}
+ */
 async function getFoundryModels(basePath = null) {
   try {
-    const { OpenAI: OpenAIApi } = require("openai");
-    const openai = new OpenAIApi({
-      baseURL: parseFoundryBasePath(basePath || process.env.FOUNDRY_BASE_PATH),
-      apiKey: null,
-    });
-    const models = await openai.models
-      .list()
-      .then((results) =>
-        results.data.map((model) => ({
-          ...model,
-          name: model.id,
-        }))
-      )
-      .catch((e) => {
-        console.error(`Foundry:listModels`, e.message);
-        return [];
-      });
-
+    const FoundryModels = require("../AiProviders/foundry/models");
+    const { models } = await FoundryModels.listModels(
+      basePath || process.env.FOUNDRY_BASE_PATH
+    );
     return { models, error: null };
   } catch (e) {
     console.error(`Foundry:getFoundryModels`, e.message);


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #5792

### Description

Overhaul Microsoft Foundry Local provider for CLI 0.10.0+

Add Azure catalog client with disk-cached lookups for context window,
capability (tools/reasoning/vision), and size metadata, but remove it
as a model listing source since it advertises variants for hardware the
host may not have (e.g. QNN on macOS). Models now come exclusively from
the daemon's /v1/models surface.

Parse device type (CPU/GPU/NPU) from the variant id suffix rather than
catalog execution providers. Unknown devices render no tag. Enrich
listed models with file size from the catalog when available.

Add streaming ToolCallTextFilter to strip <tool_call> markup Foundry
echoes into delta.content. Add assertModelLoaded() pre-flight, catalog-
seeded context window caching, and 16K-ceiling promptWindowLimit().

Rewrite the agent provider with native tool calling support and
automatic UnTooled fallback based on per-model capability detection.

Rewrite FoundryOptions frontend with ModelTable-based picker, search,
grouped display, base URL and context window inputs. Context window is
left blank on model select so the server auto-caps to a safe default.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
