### PR TITLE
fix: broken star history chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ premium-sponsors (reserved for $100/mth sponsors who request to be called out he
 
 [![anythingllm contributors](https://contrib.rocks/image?repo=mintplex-labs/anything-llm)](https://github.com/mintplex-labs/anything-llm/graphs/contributors)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.com/#mintplex-labs/anything-llm&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.dera.page/#mintplex-labs/anything-llm&Date)
 
 ## 🔗 More Products
 

--- a/locales/README.fa-IR.md
+++ b/locales/README.fa-IR.md
@@ -247,7 +247,7 @@ AnythingLLM توسط Mintplex Labs Inc دارای ویژگی تله‌متری �
 
 [![مشارکت‌کنندگان anythingllm](https://contrib.rocks/image?repo=mintplex-labs/anything-llm)](https://github.com/mintplex-labs/anything-llm/graphs/contributors)
 
-[![نمودار تاریخچه ستاره‌ها](https://api.star-history.com/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.com/#mintplex-labs/anything-llm&Date)
+[![نمودار تاریخچه ستاره‌ها](https://star-history.dera.page/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.dera.page/#mintplex-labs/anything-llm&Date)
 
 ## 🔗 محصولات بیشتر
 

--- a/locales/README.tr-TR.md
+++ b/locales/README.tr-TR.md
@@ -221,7 +221,7 @@ Bu verileri doğrulamak için kod içinde **`Telemetry.sendTelemetry` çağrıla
 
 [![anythingllm contributors](https://contrib.rocks/image?repo=mintplex-labs/anything-llm)](https://github.com/mintplex-labs/anything-llm/graphs/contributors)
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.com/#mintplex-labs/anything-llm&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.dera.page/#mintplex-labs/anything-llm&Date)
 
 ## 🔗 Diğer Ürünler
 

--- a/locales/README.zh-CN.md
+++ b/locales/README.zh-CN.md
@@ -239,7 +239,7 @@ Mintplex Labs和社区维护了许多部署方法、脚本和模板，您可以�
 
 [![anythingllm 的贡献者们](https://contrib.rocks/image?repo=mintplex-labs/anything-llm)](https://github.com/mintplex-labs/anything-llm/graphs/contributors)
 
-[![Star 历史图](https://api.star-history.com/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.com/#mintplex-labs/anything-llm&Date)
+[![Star 历史图](https://star-history.dera.page/svg?repos=mintplex-labs/anything-llm&type=Timeline)](https://star-history.dera.page/#mintplex-labs/anything-llm&Date)
 
 ## 🔗 更多产品
 


### PR DESCRIPTION
The star history chart in our READMEs is currently broken and no longer renders. This fixes the chart by pointing it to a working star history service.

Updated files:
- README.md
- locales/README.tr-TR.md
- locales/README.zh-CN.md
- locales/README.fa-IR.md