### PR TITLE
fix: OCR 1-bit scanned PDFs instead of dropping pages

### DIFF
--- a/collector/__tests__/utils/OCRLoader/index.test.js
+++ b/collector/__tests__/utils/OCRLoader/index.test.js
@@ -14,6 +14,23 @@ describe("toSharpRawInput", () => {
     expect(raw.data).toEqual(Buffer.from([255, 0, 255, 0, 255, 0, 255, 0]));
   });
 
+  test("handles widths that are not a multiple of 8 (row padding bits)", () => {
+    // width 10 -> rowBytes = 2, last 6 bits of each row are padding.
+    // Row 0: 1111111111 (padding 000000), row 1: 0000000000 (padding 111111)
+    const packed = Buffer.from([0b11111111, 0b11000000, 0b00000000, 0b00111111]);
+    const raw = OCRLoader.toSharpRawInput({
+      width: 10,
+      height: 2,
+      data: packed,
+      kind: 1,
+    });
+    expect(raw.channels).toBe(1);
+    expect(raw.data.length).toBe(20);
+    expect(raw.data).toEqual(
+      Buffer.from([...Array(10).fill(255), ...Array(10).fill(0)])
+    );
+  });
+
   test("detects packed 1-bit by buffer length when kind is omitted", () => {
     const width = 2480;
     const height = 2;

--- a/collector/__tests__/utils/OCRLoader/index.test.js
+++ b/collector/__tests__/utils/OCRLoader/index.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest, node */
+const OCRLoader = require("../../../utils/OCRLoader");
+
+describe("toSharpRawInput", () => {
+  test("expands packed 1-bit DeviceGray so Sharp gets integer channels", () => {
+    const packed = Buffer.from([0b10101010]);
+    const raw = OCRLoader.toSharpRawInput({
+      width: 8,
+      height: 1,
+      data: packed,
+      kind: 1,
+    });
+    expect(raw.channels).toBe(1);
+    expect(raw.data).toEqual(Buffer.from([255, 0, 255, 0, 255, 0, 255, 0]));
+  });
+
+  test("detects packed 1-bit by buffer length when kind is omitted", () => {
+    const width = 2480;
+    const height = 2;
+    const packed = Buffer.alloc(Math.ceil(width / 8) * height, 0xff);
+    const raw = OCRLoader.toSharpRawInput({ width, height, data: packed });
+    expect(raw.channels).toBe(1);
+    expect(raw.data.length).toBe(width * height);
+    expect(raw.data[0]).toBe(255);
+  });
+
+  test("passes through 8-bit gray and copies the buffer", () => {
+    const data = Buffer.from([1, 2, 3, 4]);
+    const raw = OCRLoader.toSharpRawInput({ width: 2, height: 2, data });
+    expect(raw.channels).toBe(1);
+    data[0] = 99;
+    expect(raw.data[0]).toBe(1);
+  });
+
+  test("passes through RGB", () => {
+    const data = Buffer.alloc(2 * 2 * 3, 128);
+    const raw = OCRLoader.toSharpRawInput({ width: 2, height: 2, data });
+    expect(raw.channels).toBe(3);
+    expect(raw.data.length).toBe(12);
+  });
+
+  test("returns null for empty or mismatched buffers", () => {
+    expect(OCRLoader.toSharpRawInput(null)).toBeNull();
+    expect(
+      OCRLoader.toSharpRawInput({
+        width: 8,
+        height: 1,
+        data: Buffer.from([1, 2]),
+      })
+    ).toBeNull();
+  });
+});

--- a/collector/utils/OCRLoader/index.js
+++ b/collector/utils/OCRLoader/index.js
@@ -275,6 +275,67 @@ class OCRLoader {
 }
 
 /**
+ * pdf.js ImageKind.GRAYSCALE_1BPP. Packed 1-bit rows are ceil(width/8) bytes.
+ * @type {number}
+ */
+const PDFJS_GRAYSCALE_1BPP = 1;
+
+/**
+ * Unpack pdf.js packed 1-bit DeviceGray into 8-bit grayscale Sharp can ingest.
+ * Bit 1 is white, bit 0 is black (PDF DeviceGray).
+ *
+ * @param {Buffer|Uint8Array} packed
+ * @param {number} width
+ * @param {number} height
+ * @returns {Buffer|null}
+ */
+function unpackPackedGray1Bpp(packed, width, height) {
+  if (!packed || width <= 0 || height <= 0) return null;
+  const rowBytes = Math.ceil(width / 8);
+  if (packed.length < rowBytes * height) return null;
+
+  const out = Buffer.alloc(width * height);
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * rowBytes;
+    for (let x = 0; x < width; x++) {
+      const byte = packed[rowStart + (x >> 3)];
+      const bit = (byte >> (7 - (x & 7))) & 1;
+      out[y * width + x] = bit ? 255 : 0;
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a Sharp `raw` input from a pdf.js image object.
+ * Copies the source buffer so concurrent OCR workers cannot share backing memory.
+ * 1-bit CCITT/bitonal scans (issue #6118) are expanded to 8-bit gray.
+ *
+ * @param {{width?: number, height?: number, data?: ArrayLike<number>, kind?: number}} img
+ * @returns {{data: Buffer, width: number, height: number, channels: number}|null}
+ */
+function toSharpRawInput(img) {
+  const width = img?.width;
+  const height = img?.height;
+  if (!width || !height || !img.data) return null;
+
+  const src = Buffer.from(img.data);
+  const isPacked1Bpp =
+    img.kind === PDFJS_GRAYSCALE_1BPP ||
+    src.length === Math.ceil(width / 8) * height;
+
+  if (isPacked1Bpp) {
+    const unpacked = unpackPackedGray1Bpp(src, width, height);
+    if (!unpacked) return null;
+    return { data: unpacked, width, height, channels: 1 };
+  }
+
+  const channels = src.length / width / height;
+  if (![1, 2, 3, 4].includes(channels)) return null;
+  return { data: src, width, height, channels };
+}
+
+/**
  * Converts a PDF page to a buffer using Sharp.
  * @param {Object} options - The options for the Sharp PDF page object.
  * @param {Object} options.page - The PDFJS page proxy object.
@@ -313,14 +374,14 @@ class PDFSharp {
 
           const name = ops.argsArray[i][0];
           const img = await page.objs.get(name);
-          const { width, height } = img;
-          const size = img.data.length;
-          const channels = size / width / height;
+          const raw = toSharpRawInput(img);
+          if (!raw) continue;
+          const { data, width, height, channels } = raw;
           const targetDPI = 70;
           const targetWidth = Math.floor(width * (targetDPI / 72));
           const targetHeight = Math.floor(height * (targetDPI / 72));
 
-          const image = this.sharp(img.data, {
+          const image = this.sharp(data, {
             raw: { width, height, channels },
             density: targetDPI,
           })
@@ -352,4 +413,6 @@ class PDFSharp {
   }
 }
 
+OCRLoader.toSharpRawInput = toSharpRawInput;
+OCRLoader.unpackPackedGray1Bpp = unpackPackedGray1Bpp;
 module.exports = OCRLoader;


### PR DESCRIPTION
## Summary
- `PDFSharp.pageToBuffer` treated every pdf.js image buffer as 8-bit-per-channel raw pixels (`channels = data.length / width / height`).
- Scanned PDFs that use 1-bit DeviceGray + CCITT Group 4 (typical copier/scanner output) are packed at 1 bit per pixel. Sharp then throws `Expected width, height and channels for raw pixel input`, the page is skipped, and OCR still reports success with most pages missing.
- Unpack packed 1-bit grayscale to 8-bit before Sharp. RGB/JPEG scans are unchanged. The source buffer is copied so concurrent OCR workers do not share backing memory.

Fixes #6118

## Test plan
- [x] Unit tests for packed 1-bit expansion, length-based detection, RGB/gray passthrough, and buffer copying
- [ ] Upload a 1-bit CCITT scanned PDF (the bitonal fixture from #6118) and confirm every page OCRs instead of all-but-one being dropped
- [ ] Upload a normal JPEG/RGB scanned PDF and confirm OCR still works