### PR TITLE
fix: select the physical LAN adapter for the mobile pairing QR code

### DIFF
--- a/frontend/src/pages/GeneralSettings/MobileConnections/ConnectionModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/MobileConnections/ConnectionModal/index.jsx
@@ -87,13 +87,13 @@ export default function MobileConnectModal({ isOpen, onClose }) {
  */
 function processConnectionUrl(url) {
   /*
-   * In dev mode, the connectionURL() method uses the `ip` module
+   * In dev mode, the connectionURL() method uses the local LAN address
    * see server/models/mobileDevice.js `connectionURL()` method.
    *
    * In prod mode, this method returns the absolute path since we will always want to use
    * the real instance hostname. If the domain changes, we should be able to inherit it from the client side
    * since the backend has no knowledge of the domain since typically it is run behind a reverse proxy or in a container - or both.
-   * So `ip` is useless in prod mode since it would only resolve to the internal IP address of the container or if non-containerized,
+   * So the local LAN address is useless in prod mode since it would only resolve to the internal IP address of the container or if non-containerized,
    * the local IP address may not be the preferred instance access point (eg: using custom domain)
    *
    * If the url does not start with http, we assume it is a relative path and add the origin to it.

--- a/server/__tests__/utils/helpers/networkInterface.test.js
+++ b/server/__tests__/utils/helpers/networkInterface.test.js
@@ -1,0 +1,250 @@
+/* eslint-env jest */
+
+/**
+ * Tests for the LAN address lookup used to build the mobile pairing QR code.
+ * The address must belong to the physical Ethernet/Wi-Fi adapter and not to a
+ * VPN tunnel or hypervisor switch, which are not reachable from other devices.
+ *
+ * Related issue: https://github.com/Mintplex-Labs/anything-llm/issues/6129
+ */
+
+jest.mock("os");
+
+// A Windows machine running NordVPN, WSL and VMware - the setup from the issue.
+const WINDOWS_INTERFACES = {
+  "Loopback Pseudo-Interface 1": [
+    { address: "127.0.0.1", family: "IPv4", mac: "00:00:00:00:00:00", internal: true },
+  ],
+  "vEthernet (WSL)": [
+    { address: "172.28.240.1", family: "IPv4", mac: "00:15:5d:01:02:03", internal: false },
+  ],
+  "vEthernet (Default Switch)": [
+    { address: "172.19.128.1", family: "IPv4", mac: "00:15:5d:04:05:06", internal: false },
+  ],
+  NordLynx: [
+    { address: "10.5.0.2", family: "IPv4", mac: "00:00:00:00:00:00", internal: false },
+  ],
+  "VMware Network Adapter VMnet1": [
+    { address: "192.168.74.1", family: "IPv4", mac: "00:50:56:c0:00:01", internal: false },
+  ],
+  "Wi-Fi": [
+    { address: "169.254.11.4", family: "IPv4", mac: "a0:51:0b:11:22:33", internal: false },
+  ],
+  Ethernet: [
+    { address: "fe80::2e98:466b:a898:5caa", family: "IPv6", mac: "74:56:3c:c2:9f:a9", internal: false },
+    { address: "192.168.1.42", family: "IPv4", mac: "74:56:3c:c2:9f:a9", internal: false },
+  ],
+};
+
+const ethernet = (address = "192.168.1.42") => [
+  { address, family: "IPv4", mac: "74:56:3c:c2:9f:a9", internal: false },
+];
+
+function resolveAddress(interfaces) {
+  const os = require("os");
+  os.networkInterfaces.mockReturnValue(interfaces);
+  const {
+    getLocalNetworkAddress,
+  } = require("../../../utils/helpers/networkInterface");
+  return getLocalNetworkAddress();
+}
+
+describe("getLocalNetworkAddress", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe("physical adapter selection", () => {
+    test("returns the physical Ethernet address on a VPN + WSL + VMware machine", () => {
+      expect(resolveAddress(WINDOWS_INTERFACES)).toBe("192.168.1.42");
+    });
+
+    test("never returns a virtual, link-local, loopback or IPv6 address", () => {
+      const result = resolveAddress(WINDOWS_INTERFACES);
+      expect(result).not.toBe("172.28.240.1");
+      expect(result).not.toBe("172.19.128.1");
+      expect(result).not.toBe("10.5.0.2");
+      expect(result).not.toBe("192.168.74.1");
+      expect(result).not.toBe("169.254.11.4");
+      expect(result).not.toBe("127.0.0.1");
+      expect(result).not.toContain(":");
+    });
+
+    test("ignores IPv4 reported with the legacy numeric family", () => {
+      expect(
+        resolveAddress({
+          Ethernet: [{ address: "192.168.1.42", family: 4, mac: "74:56:3c:c2:9f:a9", internal: false }],
+        })
+      ).toBe("192.168.1.42");
+    });
+  });
+
+  describe("virtual adapter exclusion", () => {
+    const excludedAdapters = [
+      "vEthernet (nat)",
+      "Hyper-V Virtual Ethernet Adapter",
+      "VirtualBox Host-Only Network",
+      "VMware Network Adapter VMnet8",
+      "Bluetooth Network Connection",
+      "Tailscale",
+      "ZeroTier One",
+      "OpenVPN TAP-Windows6",
+      "vmnet8",
+      "bridge100",
+      "PANGP Virtual Ethernet Adapter",
+      "Surfshark Wintun Tunnel",
+      "tun0",
+      "utun3",
+      "docker0",
+      "br-1a2b3c",
+      "ppp0",
+    ];
+
+    // A real MAC and a private address, so only the name can rule it out.
+    test.each(excludedAdapters)("skips %s in favor of the real adapter", (name) => {
+      expect(
+        resolveAddress({
+          [name]: [{ address: "10.99.0.5", family: "IPv4", mac: "0a:11:22:33:44:55", internal: false }],
+          Ethernet: ethernet(),
+        })
+      ).toBe("192.168.1.42");
+    });
+
+    test("matches adapter names case-insensitively", () => {
+      expect(
+        resolveAddress({
+          NORDLYNX: [{ address: "10.5.0.2", family: "IPv4", mac: "0a:11:22:33:44:55", internal: false }],
+          Ethernet: ethernet(),
+        })
+      ).toBe("192.168.1.42");
+    });
+  });
+
+  describe("does not exclude real adapters that merely contain a short fragment", () => {
+    const realAdapters = [
+      "Neptune Ethernet Controller",
+      "NETGEAR WG311 Wireless Adapter",
+      "Datapath Gigabit Ethernet",
+      "TAPS Industrial NIC",
+      "Thunderbolt Bridge",
+      "bridge0",
+      "br0",
+    ];
+
+    // The VPN is listed first so a wrongly excluded name loses to the fallback.
+    test.each(realAdapters)("keeps %s", (name) => {
+      expect(
+        resolveAddress({
+          NordLynx: [{ address: "10.5.0.2", family: "IPv4", mac: "00:00:00:00:00:00", internal: false }],
+          [name]: ethernet("192.168.1.77"),
+        })
+      ).toBe("192.168.1.77");
+    });
+  });
+
+  describe("ranking", () => {
+    test("keeps enumeration order between equally private adapters", () => {
+      expect(
+        resolveAddress({
+          "Ethernet 2": [{ address: "10.1.2.3", family: "IPv4", mac: "74:56:3c:c2:9f:aa", internal: false }],
+          Ethernet: ethernet(),
+        })
+      ).toBe("10.1.2.3");
+    });
+
+    test("prefers a private address over a public one", () => {
+      expect(
+        resolveAddress({
+          "Ethernet 2": [{ address: "203.0.113.7", family: "IPv4", mac: "74:56:3c:c2:9f:aa", internal: false }],
+          Ethernet: ethernet("10.1.2.3"),
+        })
+      ).toBe("10.1.2.3");
+    });
+
+    test("treats 172.32 as public since it is outside the private range", () => {
+      expect(
+        resolveAddress({
+          "Ethernet 2": [{ address: "172.32.0.1", family: "IPv4", mac: "74:56:3c:c2:9f:aa", internal: false }],
+          Ethernet: ethernet("10.1.2.3"),
+        })
+      ).toBe("10.1.2.3");
+    });
+
+    test("returns a 10.x address when it is the only private candidate", () => {
+      expect(resolveAddress({ Ethernet: ethernet("10.1.2.3") })).toBe("10.1.2.3");
+    });
+
+    test("prefers a real MAC over an all-zero MAC when otherwise tied", () => {
+      expect(
+        resolveAddress({
+          "Ethernet 2": [{ address: "192.168.1.10", family: "IPv4", mac: "00:00:00:00:00:00", internal: false }],
+          Ethernet: ethernet(),
+        })
+      ).toBe("192.168.1.42");
+    });
+  });
+
+  describe("fallbacks and error cases", () => {
+    test("falls back to the first non-internal IPv4 when every adapter is excluded", () => {
+      expect(
+        resolveAddress({
+          "Loopback Pseudo-Interface 1": [
+            { address: "127.0.0.1", family: "IPv4", mac: "00:00:00:00:00:00", internal: true },
+          ],
+          NordLynx: [{ address: "10.5.0.2", family: "IPv4", mac: "00:00:00:00:00:00", internal: false }],
+          "vEthernet (WSL)": [
+            { address: "172.28.240.1", family: "IPv4", mac: "00:15:5d:01:02:03", internal: false },
+          ],
+        })
+      ).toBe("10.5.0.2");
+    });
+
+    test("returns null when only loopback is present", () => {
+      expect(
+        resolveAddress({
+          "Loopback Pseudo-Interface 1": [
+            { address: "127.0.0.1", family: "IPv4", mac: "00:00:00:00:00:00", internal: true },
+          ],
+        })
+      ).toBeNull();
+    });
+
+    test("returns null when only IPv6 addresses are present", () => {
+      expect(
+        resolveAddress({
+          Ethernet: [
+            { address: "fe80::2e98:466b:a898:5caa", family: "IPv6", mac: "74:56:3c:c2:9f:a9", internal: false },
+          ],
+        })
+      ).toBeNull();
+    });
+
+    test("returns null when there are no interfaces at all", () => {
+      expect(resolveAddress({})).toBeNull();
+    });
+
+    test("returns null when os.networkInterfaces throws", () => {
+      const os = require("os");
+      os.networkInterfaces.mockImplementation(() => {
+        throw new Error("EPERM");
+      });
+      const {
+        getLocalNetworkAddress,
+      } = require("../../../utils/helpers/networkInterface");
+      expect(() => getLocalNetworkAddress()).not.toThrow();
+      expect(getLocalNetworkAddress()).toBeNull();
+    });
+
+    test("ignores malformed entries and still returns the good address", () => {
+      expect(
+        resolveAddress({
+          "Broken Adapter": null,
+          "Empty Adapter": [],
+          "Partial Adapter": [{ family: "IPv4", internal: false }, { address: "  ", family: "IPv4", internal: false }],
+          Ethernet: ethernet(),
+        })
+      ).toBe("192.168.1.42");
+    });
+  });
+});

--- a/server/models/mobileDevice.js
+++ b/server/models/mobileDevice.js
@@ -1,6 +1,6 @@
 const prisma = require("../utils/prisma");
 const { v4: uuidv4 } = require("uuid");
-const ip = require("ip");
+const { getLocalNetworkAddress } = require("../utils/helpers/networkInterface");
 
 /**
  * @typedef {Object} TemporaryMobileDeviceRequest
@@ -99,8 +99,13 @@ const MobileDevice = {
   connectionURL: function (user = null) {
     let baseUrl = "/api/mobile";
     if (process.env.NODE_ENV === "production") baseUrl = "/api/mobile";
-    else
-      baseUrl = `http://${ip.address()}:${process.env.SERVER_PORT || 3001}/api/mobile`;
+    else {
+      // Leave the relative path when no LAN address is found so the client can
+      // tell the user the instance is not reachable from another device.
+      const localAddress = getLocalNetworkAddress();
+      if (localAddress)
+        baseUrl = `http://${localAddress}:${process.env.SERVER_PORT || 3001}/api/mobile`;
+    }
 
     const tempToken = this.registerTempToken(user);
     baseUrl = `${baseUrl}?t=${tempToken}`;

--- a/server/package.json
+++ b/server/package.json
@@ -63,7 +63,6 @@
     "fast-levenshtein": "^3.0.0",
     "fix-path": "^4.0.0",
     "graphql": "^16.7.1",
-    "ip": "^2.0.1",
     "joi": "^17.11.0",
     "joi-password-complexity": "^5.2.0",
     "js-tiktoken": "^1.0.8",

--- a/server/utils/helpers/networkInterface.js
+++ b/server/utils/helpers/networkInterface.js
@@ -1,0 +1,101 @@
+const ZERO_MAC = "00:00:00:00:00:00";
+
+// Adapter names that belong to hypervisors, containers or VPN clients.
+const VIRTUAL_ADAPTER_FRAGMENTS = [
+  "vethernet",
+  "hyper-v",
+  "virtualbox",
+  "vmware",
+  "vmnet",
+  "bridge1",
+  "loopback",
+  "bluetooth",
+  "nordlynx",
+  "tap-windows",
+  "wintun",
+  "openvpn",
+  "wireguard",
+  "tailscale",
+  "zerotier",
+  "anyconnect",
+  "pangp",
+  "pulse secure",
+  "zscaler",
+  "forticlient",
+  "docker",
+  "virbr",
+  "vboxnet",
+];
+
+// Matched as a prefix on device-style names only - too short for a substring
+// match, which would catch descriptive names like "TAPS Industrial NIC".
+const VIRTUAL_ADAPTER_PREFIXES = [
+  "tun",
+  "tap",
+  "utun",
+  "ppp",
+  "veth",
+  "br-",
+  "wg",
+];
+
+function isVirtualAdapter(name = "") {
+  const adapter = String(name).toLowerCase();
+  if (VIRTUAL_ADAPTER_FRAGMENTS.some((fragment) => adapter.includes(fragment)))
+    return true;
+  if (/\s/.test(adapter)) return false;
+  return VIRTUAL_ADAPTER_PREFIXES.some((prefix) => adapter.startsWith(prefix));
+}
+
+// Private ranges are not ordered against each other - a real LAN is as likely
+// to be on 10.x as on 192.168.x, so only private-over-public is ranked.
+function addressRank(address = "") {
+  if (address.startsWith("192.168.")) return 0;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(address)) return 0;
+  if (address.startsWith("10.")) return 0;
+  return 1;
+}
+
+function compareCandidates(a, b) {
+  const rankDiff = addressRank(a.address) - addressRank(b.address);
+  if (rankDiff !== 0) return rankDiff;
+  // Tunnel adapters report an all-zero MAC while physical NICs do not.
+  return (a.mac === ZERO_MAC ? 1 : 0) - (b.mac === ZERO_MAC ? 1 : 0);
+}
+
+/**
+ * Finds the LAN address of this machine so other devices on the same network
+ * can reach the instance. Virtual, container and VPN adapters are skipped since
+ * their addresses are not reachable from the LAN.
+ * @returns {string|null} The IPv4 address, or null when there is no usable one.
+ */
+function getLocalNetworkAddress() {
+  const os = require("os");
+  try {
+    const candidates = [];
+    for (const [name, addresses] of Object.entries(
+      os.networkInterfaces() || {}
+    )) {
+      for (const config of addresses || []) {
+        if (!config?.address || !String(config.address).trim()) continue;
+        if (config.internal === true) continue;
+        if (config.family !== "IPv4" && config.family !== 4) continue;
+        if (config.address.startsWith("169.254.")) continue; // APIPA/link-local
+        candidates.push({ name, address: config.address, mac: config.mac });
+      }
+    }
+    if (candidates.length === 0) return null;
+
+    const physical = candidates.filter(
+      (candidate) => !isVirtualAdapter(candidate.name)
+    );
+    if (physical.length === 0) return candidates[0].address;
+    return physical.sort(compareCandidates)[0].address;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  getLocalNetworkAddress,
+};

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -4086,11 +4086,6 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
-ip@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz"
-  integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"


### PR DESCRIPTION
resolves #6129

On Windows, the mobile pairing QR code can point at the wrong network interface (e.g. a VPN or virtual adapter) instead of the physical LAN adapter, so the phone can't reach the desktop app.

Adds `getLocalNetworkAddress()` to pick the physical LAN interface instead of taking the first address returned by `ip.address()`, and uses it when building the mobile pairing URL.