### PR TITLE
Fix README sponsors block, bump chart to v1.16.0, adjust CI VEX steps

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,27 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/apt-packages:1": {
+      "version": "1.0.6",
+      "resolved": "ghcr.io/devcontainers-extra/features/apt-packages@sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd",
+      "integrity": "sha256:55c54412112da81b9381e470cdbbe55278564950d1ff536ce925b1e8e096babd"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.5.0",
+      "resolved": "ghcr.io/devcontainers/features/terraform@sha256:bc9eaf21aaba050bace59f411c282cb58058535a48232c059e60c19f86caa8f5",
+      "integrity": "sha256:bc9eaf21aaba050bace59f411c282cb58058535a48232c059e60c19f86caa8f5",
+      "dependsOn": [
+        "ghcr.io/devcontainers/features/github-cli:1"
+      ]
+    },
+    "ghcr.io/dhoeric/features/hadolint:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/dhoeric/features/hadolint@sha256:993e7e6f14b7f53aafefb081eb8396ea08f3d48aebb23c91fbaa10651ca0a835",
+      "integrity": "sha256:993e7e6f14b7f53aafefb081eb8396ea08f3d48aebb23c91fbaa10651ca0a835"
+    }
+  }
+}


### PR DESCRIPTION
Why

This PR cleans up recently introduced documentation and CI updates that broke markdown rendering and updates chart/image tagging to v1.16.0. It also temporarily disables VEX attestation steps in CI until docker/scout-cli issues are resolved.

What changed

- Fix malformed sponsors block in README so markdown renders correctly.
- Bump Helm chart and values image tag to "1.16.0".
- Comment out VEX attestation steps in GitHub Actions with a TODO referencing the upstream docker/scout-cli issue.
- Add .devcontainer/devcontainer-lock.json (local devcontainer lock) as a committed file.

Notes for reviewers

- The VEX steps were intentionally commented out; consider gating them behind an ENABLE_VEX flag and pinning docker-scout version when re-enabling.
- Recommend replacing curl|sh installs with a pinned checksum or packaging step to reduce supply-chain risk.
- Run: `helm lint` and `markdownlint` locally or via CI to validate docs and chart changes.

N/A