### PR TITLE
Per workspace agent skills

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/index.jsx
@@ -38,16 +38,13 @@ export default function AgentSkillsTab({
     mcpServers,
     loading,
     mcpLoading,
-    isSkillEnabled,
-    toggleSkill,
-    toggleImportedSkill,
-    toggleFlow,
-    toggleMcpTool,
+    hasOverrides,
+    instanceSkillEnabled,
+    skillState,
+    resetOverrides,
     isMultiUser,
     isSubSkillEnabled,
-    toggleSubSkill,
-    disabledSubSkills,
-  } = useAgentSkillsState(defaultSkills);
+  } = useAgentSkillsState(defaultSkills, workspace);
 
   const configurableSkills = getConfigurableSkills(t, {
     fileSystemAgentAvailable,
@@ -70,14 +67,9 @@ export default function AgentSkillsTab({
     flows,
     mcpServers,
     isMultiUser,
-    isSkillEnabled,
-    toggleSkill,
+    instanceSkillEnabled,
+    skillState,
     isSubSkillEnabled,
-    toggleSubSkill,
-    toggleImportedSkill,
-    toggleFlow,
-    toggleMcpTool,
-    disabledSubSkills,
   });
 
   // Section expansion helpers
@@ -184,6 +176,22 @@ export default function AgentSkillsTab({
           {t("chat_window.use_agent_session_to_use_tools")}
         </p>
       )}
+      <div className="flex shrink-0 items-center justify-between gap-2 px-2">
+        <span className="text-[10px] text-zinc-500 light:text-slate-400 truncate">
+          {t("chat_window.skills_for_workspace", {
+            workspace: workspace?.name,
+          })}
+        </span>
+        {hasOverrides && (
+          <button
+            type="button"
+            onClick={resetOverrides}
+            className="border-none bg-transparent shrink-0 cursor-pointer text-[10px] text-zinc-400 light:text-slate-500 hover:text-white light:hover:text-slate-900"
+          >
+            {t("chat_window.reset_workspace_skills")}
+          </button>
+        )}
+      </div>
       {totalItemCount >= MIN_ITEMS_TO_SHOW_SEARCH && (
         <SearchInput
           value={searchQuery}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useAgentSkillsState.js
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useAgentSkillsState.js
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import Admin from "@/models/admin";
 import System from "@/models/system";
-import AgentPlugins from "@/models/experimental/agentPlugins";
+import Workspace from "@/models/workspace";
 import AgentFlows from "@/models/agentFlows";
 import MCPServers from "@/models/mcpServers";
+import { safeJsonParse } from "@/utils/request";
 import { getSubSkillPreferenceKeys } from "./skillRegistry";
 import useSubSkillPreferences from "./useSubSkillPreferences";
 import { toggleAgentSessionTool } from "@/utils/chat/agent";
@@ -11,8 +12,10 @@ import { toggleAgentSessionTool } from "@/utils/chat/agent";
 /**
  * Core hook for managing all agent skill state.
  * Handles fetching, toggling, and persisting skill preferences.
+ * Toggles write an override onto the workspace; the instance-wide settings stay
+ * the defaults that workspaces without an override inherit.
  */
-export default function useAgentSkillsState(defaultSkills) {
+export default function useAgentSkillsState(defaultSkills, workspace) {
   // Core skill state
   const [fileSystemAgentAvailable, setFileSystemAgentAvailable] =
     useState(false);
@@ -22,6 +25,7 @@ export default function useAgentSkillsState(defaultSkills) {
   const [importedSkills, setImportedSkills] = useState([]);
   const [flows, setFlows] = useState([]);
   const [mcpServers, setMcpServers] = useState([]);
+  const [overrides, setOverrides] = useState({});
   const [loading, setLoading] = useState(true);
   const [mcpLoading, setMcpLoading] = useState(true);
 
@@ -37,7 +41,7 @@ export default function useAgentSkillsState(defaultSkills) {
   async function fetchSkillSettings() {
     try {
       const subSkillPrefKeys = getSubSkillPreferenceKeys();
-      const [prefs, flowsRes, fsAgentAvailable, multiUserMode] =
+      const [prefs, flowsRes, fsAgentAvailable, multiUserMode, currWorkspace] =
         await Promise.all([
           Admin.systemPreferencesByFields([
             "disabled_agent_skills",
@@ -48,6 +52,7 @@ export default function useAgentSkillsState(defaultSkills) {
           AgentFlows.listFlows(),
           System.isFileSystemAgentAvailable(),
           System.isMultiUserMode(),
+          Workspace.bySlug(workspace?.slug),
         ]);
 
       if (prefs?.settings) {
@@ -57,6 +62,7 @@ export default function useAgentSkillsState(defaultSkills) {
         subSkillPrefs.loadFromSettings(prefs.settings);
       }
       if (flowsRes?.flows) setFlows(flowsRes.flows);
+      setOverrides(safeJsonParse(currWorkspace?.agentConfig, {}));
       setFileSystemAgentAvailable(fsAgentAvailable);
       setIsMultiUser(!!multiUserMode);
     } catch (e) {
@@ -77,122 +83,67 @@ export default function useAgentSkillsState(defaultSkills) {
     }
   }
 
-  // Skill enabled/disabled checks
-  const isSkillEnabled = useCallback(
-    (key) => {
-      return key in defaultSkills
+  // On/off state a built-in skill has in the instance-wide settings, ignoring this workspace.
+  const instanceSkillEnabled = useCallback(
+    (key) =>
+      key in defaultSkills
         ? !disabledDefaults.includes(key)
-        : enabledConfigurable.includes(key);
-    },
+        : enabledConfigurable.includes(key),
     [defaultSkills, disabledDefaults, enabledConfigurable]
   );
 
-  // Toggle functions
-  const toggleSkill = useCallback(
-    async (key) => {
-      const toggleItem = (arr, item) =>
-        arr.includes(item) ? arr.filter((s) => s !== item) : [...arr, item];
-      const newEnabled = !isSkillEnabled(key);
+  /**
+   * Whether a skill is on for this workspace, and the toggle that flips it.
+   * Only skills that differ from the instance are stored, so the rest follow it.
+   * @param {string} id - skill key, hubId, `@@flow_<uuid>`, MCP `<server>-<tool>`, or sub-skill name
+   * @param {boolean} instanceDefault - state of this skill in the instance-wide settings
+   * @param {string|null} [opts.serverName] - MCP server name, needed to re-enable an MCP tool mid-session
+   * @returns {{enabled: boolean, toggle: function}}
+   */
+  const skillState = useCallback(
+    (id, instanceDefault, { serverName = null } = {}) => {
+      const enabled = overrides[id] ?? instanceDefault;
+      return {
+        enabled,
+        toggle: async () => {
+          const updated = { ...overrides };
+          if (enabled === instanceDefault) updated[id] = !enabled;
+          else delete updated[id];
 
-      if (key in defaultSkills) {
-        const updated = toggleItem(disabledDefaults, key);
-        setDisabledDefaults(updated);
-        await Admin.updateSystemPreferences({
-          disabled_agent_skills: updated.join(","),
-          default_agent_skills: enabledConfigurable.join(","),
-        });
-        toggleAgentSessionTool(key, newEnabled);
-        return;
-      }
-
-      const updated = toggleItem(enabledConfigurable, key);
-      setEnabledConfigurable(updated);
-      await Admin.updateSystemPreferences({
-        disabled_agent_skills: disabledDefaults.join(","),
-        default_agent_skills: updated.join(","),
-      });
-      toggleAgentSessionTool(key, newEnabled);
+          setOverrides(updated);
+          await Workspace.update(workspace.slug, { agentConfig: updated });
+          toggleAgentSessionTool(id, !enabled, serverName);
+        },
+      };
     },
-    [defaultSkills, disabledDefaults, enabledConfigurable, isSkillEnabled]
+    [overrides, workspace]
   );
 
-  const toggleImportedSkill = useCallback(async (skill) => {
-    const newActive = !skill.active;
-    setImportedSkills((prev) =>
-      prev.map((s) =>
-        s.hubId === skill.hubId ? { ...s, active: newActive } : s
-      )
-    );
-    await AgentPlugins.toggleFeature(skill.hubId, newActive);
-    toggleAgentSessionTool(skill.hubId, newActive);
-  }, []);
-
-  const toggleFlow = useCallback(async (flow) => {
-    const newActive = !flow.active;
-    setFlows((prev) =>
-      prev.map((f) => (f.uuid === flow.uuid ? { ...f, active: newActive } : f))
-    );
-    await AgentFlows.toggleFlow(flow.uuid, newActive);
-    toggleAgentSessionTool(`@@flow_${flow.uuid}`, newActive);
-  }, []);
-
-  const toggleMcpTool = useCallback(
-    async (serverName, toolName, currentlyEnabled) => {
-      const newEnabled = !currentlyEnabled;
-      setMcpServers((prev) => {
-        return prev.map((server) => {
-          if (server.name !== serverName) return server;
-          const currentSuppressed =
-            server.config?.anythingllm?.suppressedTools || [];
-          const newSuppressed = newEnabled
-            ? currentSuppressed.filter((t) => t !== toolName)
-            : [...currentSuppressed, toolName];
-          return {
-            ...server,
-            config: {
-              ...server.config,
-              anythingllm: {
-                ...server.config?.anythingllm,
-                suppressedTools: newSuppressed,
-              },
-            },
-          };
-        });
-      });
-      await MCPServers.toggleTool(serverName, toolName, newEnabled);
-      toggleAgentSessionTool(
-        `${serverName}-${toolName}`,
-        newEnabled,
-        serverName
-      );
-    },
-    []
-  );
+  // A running agent session keeps the tools it started with until restarted.
+  const resetOverrides = useCallback(async () => {
+    setOverrides({});
+    await Workspace.update(workspace.slug, { agentConfig: null });
+  }, [workspace]);
 
   return {
     // State
     fileSystemAgentAvailable,
     isMultiUser,
-    disabledDefaults,
-    enabledConfigurable,
     importedSkills,
     flows,
     mcpServers,
     loading,
     mcpLoading,
+    hasOverrides: Object.keys(overrides).length > 0,
 
     // Skill checks
-    isSkillEnabled,
+    instanceSkillEnabled,
+    skillState,
 
     // Toggle functions
-    toggleSkill,
-    toggleImportedSkill,
-    toggleFlow,
-    toggleMcpTool,
+    resetOverrides,
 
     // Sub-skill preferences (delegated)
     isSubSkillEnabled: subSkillPrefs.isSubSkillEnabled,
-    toggleSubSkill: subSkillPrefs.toggleSubSkill,
-    disabledSubSkills: subSkillPrefs.disabledSubSkills,
   };
 }

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useSkillSections.js
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useSkillSections.js
@@ -12,29 +12,37 @@ import {
 function buildSkillItem({
   key,
   title,
-  isEnabled,
-  onToggle,
   t,
+  instanceSkillEnabled,
+  skillState,
   isSubSkillEnabled,
-  toggleSubSkill,
 }) {
   const subSkills = getSubSkillsForSkill(key, t);
-  const parentEnabled = isEnabled(key);
+  const { enabled: parentEnabled, toggle } = skillState(
+    key,
+    instanceSkillEnabled(key)
+  );
 
   return {
     id: key,
     name: title,
     enabled: parentEnabled,
-    onToggle: () => onToggle(key),
+    onToggle: toggle,
     hasSubSkills: hasSubSkills(key),
     subSkills: subSkills
-      ? subSkills.map((sub) => ({
-          id: `${key}::${sub.name}`,
-          name: sub.title,
-          enabled: parentEnabled && isSubSkillEnabled(key, sub.name),
-          onToggle: () => toggleSubSkill(key, sub.name),
-          parentEnabled,
-        }))
+      ? subSkills.map((sub) => {
+          const { enabled, toggle } = skillState(
+            sub.name,
+            isSubSkillEnabled(key, sub.name)
+          );
+          return {
+            id: `${key}::${sub.name}`,
+            name: sub.title,
+            enabled: parentEnabled && enabled,
+            onToggle: toggle,
+            parentEnabled,
+          };
+        })
       : null,
   };
 }
@@ -52,17 +60,18 @@ export default function useSkillSections({
   flows,
   mcpServers,
   isMultiUser,
-  isSkillEnabled,
-  toggleSkill,
+  instanceSkillEnabled,
+  skillState,
   isSubSkillEnabled,
-  toggleSubSkill,
-  toggleImportedSkill,
-  toggleFlow,
-  toggleMcpTool,
-  disabledSubSkills,
 }) {
   return useMemo(() => {
     const sectionList = [];
+    const skillItemOpts = {
+      t,
+      instanceSkillEnabled,
+      skillState,
+      isSubSkillEnabled,
+    };
 
     // Agent Skills (default + configurable)
     const skillItems = [];
@@ -71,17 +80,7 @@ export default function useSkillSections({
       ...configurableSkills,
     })) {
       if (isMultiUser && mode?.includes("singleUserOnly")) continue;
-      skillItems.push(
-        buildSkillItem({
-          key,
-          title,
-          isEnabled: isSkillEnabled,
-          onToggle: toggleSkill,
-          t,
-          isSubSkillEnabled,
-          toggleSubSkill,
-        })
-      );
+      skillItems.push(buildSkillItem({ key, title, ...skillItemOpts }));
     }
     if (skillItems.length > 0) {
       sectionList.push({
@@ -97,15 +96,7 @@ export default function useSkillSections({
     for (const [key, { title }] of Object.entries(appIntegrationSkills)) {
       if (isMultiUser && !isSkillMultiUserSupported(key)) continue;
       appIntegrationItems.push(
-        buildSkillItem({
-          key,
-          title,
-          isEnabled: isSkillEnabled,
-          onToggle: toggleSkill,
-          t,
-          isSubSkillEnabled,
-          toggleSubSkill,
-        })
+        buildSkillItem({ key, title, ...skillItemOpts })
       );
     }
     if (appIntegrationItems.length > 0) {
@@ -119,12 +110,15 @@ export default function useSkillSections({
 
     // Custom Skills (imported)
     if (importedSkills.length > 0) {
-      const items = importedSkills.map((skill) => ({
-        id: skill.hubId,
-        name: skill.name,
-        enabled: skill.active,
-        onToggle: () => toggleImportedSkill(skill),
-      }));
+      const items = importedSkills.map((skill) => {
+        const { enabled, toggle } = skillState(skill.hubId, skill.active);
+        return {
+          id: skill.hubId,
+          name: skill.name,
+          enabled,
+          onToggle: toggle,
+        };
+      });
       sectionList.push({
         id: "custom-skills",
         name: t("chat_window.custom_skills"),
@@ -135,12 +129,16 @@ export default function useSkillSections({
 
     // Agent Flows
     if (flows.length > 0) {
-      const items = flows.map((flow) => ({
-        id: flow.uuid,
-        name: flow.name,
-        enabled: flow.active,
-        onToggle: () => toggleFlow(flow),
-      }));
+      const items = flows.map((flow) => {
+        const id = `@@flow_${flow.uuid}`;
+        const { enabled, toggle } = skillState(id, flow.active);
+        return {
+          id,
+          name: flow.name,
+          enabled,
+          onToggle: toggle,
+        };
+      });
       sectionList.push({
         id: "agent-flows",
         name: t("chat_window.agent_flows"),
@@ -153,17 +151,20 @@ export default function useSkillSections({
     for (const server of mcpServers) {
       if (!server.running || server.tools.length === 0) continue;
       const suppressedTools = server.config?.anythingllm?.suppressedTools || [];
-      const items = server.tools.map((tool) => ({
-        id: `mcp::${server.name}::${tool.name}`,
-        name: tool.name,
-        enabled: !suppressedTools.includes(tool.name),
-        onToggle: () =>
-          toggleMcpTool(
-            server.name,
-            tool.name,
-            !suppressedTools.includes(tool.name)
-          ),
-      }));
+      const items = server.tools.map((tool) => {
+        const id = `${server.name}-${tool.name}`;
+        const { enabled, toggle } = skillState(
+          id,
+          !suppressedTools.includes(tool.name),
+          { serverName: server.name }
+        );
+        return {
+          id,
+          name: tool.name,
+          enabled,
+          onToggle: toggle,
+        };
+      });
       sectionList.push({
         id: `mcp-${server.name}`,
         name: titleCase(server.name.replace(/[_-]/g, " ")),
@@ -183,13 +184,8 @@ export default function useSkillSections({
     flows,
     mcpServers,
     isMultiUser,
-    isSkillEnabled,
-    toggleSkill,
+    instanceSkillEnabled,
+    skillState,
     isSubSkillEnabled,
-    toggleSubSkill,
-    toggleImportedSkill,
-    toggleFlow,
-    toggleMcpTool,
-    disabledSubSkills,
   ]);
 }

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useSubSkillPreferences.js
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useSubSkillPreferences.js
@@ -1,11 +1,8 @@
 import { useState, useCallback } from "react";
-import Admin from "@/models/admin";
 import { SUB_SKILL_REGISTRY, getPreferenceKeyForSkill } from "./skillRegistry";
-import { toggleAgentSessionTool } from "@/utils/chat/agent";
 
 /**
- * Hook to manage sub-skill preferences for all skills in the registry.
- * Handles loading, checking enabled state, and toggling sub-skills.
+ * Hook to read the instance-wide sub-skill preferences for all skills in the registry.
  *
  * This hook eliminates the need for separate state variables for each skill's
  * sub-skills. Adding a new skill with sub-skills only requires updating the
@@ -45,36 +42,8 @@ export default function useSubSkillPreferences() {
     [disabledSubSkills]
   );
 
-  /**
-   * Toggle a sub-skill's enabled state.
-   */
-  const toggleSubSkill = useCallback(
-    async (skillKey, subSkillName) => {
-      const prefKey = getPreferenceKeyForSkill(skillKey);
-      if (!prefKey) return;
-
-      const current = disabledSubSkills[prefKey] ?? [];
-      const updated = current.includes(subSkillName)
-        ? current.filter((s) => s !== subSkillName)
-        : [...current, subSkillName];
-
-      setDisabledSubSkills((prev) => ({
-        ...prev,
-        [prefKey]: updated,
-      }));
-
-      await Admin.updateSystemPreferences({
-        [prefKey]: updated.join(","),
-      });
-      toggleAgentSessionTool(subSkillName, !updated.includes(subSkillName));
-    },
-    [disabledSubSkills]
-  );
-
   return {
     loadFromSettings,
     isSubSkillEnabled,
-    toggleSubSkill,
-    disabledSubSkills,
   };
 }

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1585,6 +1585,10 @@ const TRANSLATIONS = {
     custom_skills: "Custom Skills",
     agent_flows: "Agent Flows",
     sub_skills: "Sub-skills",
+    skills_for_workspace: "Skills for {{workspace}}",
+    workspace_agent_skills_description:
+      "Turn skills on or off for this workspace only. Anything you leave alone follows the instance defaults.",
+    reset_workspace_skills: "Reset to defaults",
     no_tools_found: "No matching tools found",
     loading_mcp_servers: "Loading MCP servers...",
     start_agent_session: "Start Agent Session",

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentSkills/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentSkills/index.jsx
@@ -1,0 +1,135 @@
+import { useTranslation } from "react-i18next";
+import { SimpleToggleSwitch } from "@/components/lib/Toggle";
+import {
+  getDefaultSkills,
+  getConfigurableSkills,
+  getAppIntegrationSkills,
+} from "@/pages/Admin/Agents/skills";
+import useAgentSkillsState from "@/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useAgentSkillsState";
+import useSkillSections from "@/components/WorkspaceChat/ChatContainer/PromptInput/ToolsMenu/Tabs/AgentSkills/useSkillSections";
+
+const SKELETON_ROWS = 8;
+
+/**
+ * Per-workspace agent skill toggles. Anything left untouched follows the
+ * instance-wide skills configured under Admin > Agent Skills.
+ * @param {object} props
+ * @param {object} props.workspace
+ */
+export default function WorkspaceAgentSkills({ workspace }) {
+  const { t } = useTranslation();
+  const defaultSkills = getDefaultSkills(t);
+  const appIntegrationSkills = getAppIntegrationSkills(t);
+  const {
+    fileSystemAgentAvailable,
+    importedSkills,
+    flows,
+    mcpServers,
+    loading,
+    hasOverrides,
+    instanceSkillEnabled,
+    skillState,
+    resetOverrides,
+    isMultiUser,
+    isSubSkillEnabled,
+  } = useAgentSkillsState(defaultSkills, workspace);
+
+  const sections = useSkillSections({
+    t,
+    defaultSkills,
+    configurableSkills: getConfigurableSkills(t, { fileSystemAgentAvailable }),
+    appIntegrationSkills,
+    importedSkills,
+    flows,
+    mcpServers,
+    isMultiUser,
+    instanceSkillEnabled,
+    skillState,
+    isSubSkillEnabled,
+  });
+
+  if (loading)
+    return (
+      <div className="flex flex-col gap-y-4">
+        <Header t={t} />
+        <div className="flex flex-col gap-y-2">
+          {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+            <div
+              key={i}
+              className="h-[30px] rounded bg-white/10 light:bg-slate-200 animate-pulse"
+            />
+          ))}
+        </div>
+      </div>
+    );
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-start justify-between gap-x-4">
+        <Header t={t} />
+        {hasOverrides && (
+          <button
+            type="button"
+            onClick={resetOverrides}
+            className="border-none bg-transparent shrink-0 cursor-pointer text-xs text-white text-opacity-60 hover:text-opacity-100"
+          >
+            {t("chat_window.reset_workspace_skills")}
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-y-5">
+        {sections.map((section) => (
+          <div key={section.id} className="flex flex-col gap-y-1">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-white text-opacity-40">
+              {section.name}
+            </p>
+            {section.items.map((item) => (
+              <div key={item.id}>
+                <SkillToggle
+                  name={item.name}
+                  enabled={item.enabled}
+                  onToggle={item.onToggle}
+                />
+                {item.enabled &&
+                  item.subSkills?.map((subItem) => (
+                    <SkillToggle
+                      key={subItem.id}
+                      name={subItem.name}
+                      enabled={subItem.enabled}
+                      onToggle={subItem.onToggle}
+                      indented
+                    />
+                  ))}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Header({ t }) {
+  return (
+    <div className="flex flex-col gap-y-1">
+      <p className="text-white text-sm font-semibold">
+        {t("chat_window.agent_skills")}
+      </p>
+      <p className="text-white text-opacity-60 text-xs font-medium">
+        {t("chat_window.workspace_agent_skills_description")}
+      </p>
+    </div>
+  );
+}
+
+function SkillToggle({ name, enabled, onToggle, indented = false }) {
+  return (
+    <div
+      className={`flex items-center justify-between gap-x-4 py-1.5 ${indented ? "pl-4" : ""}`}
+    >
+      <span className="text-white text-sm">{name}</span>
+      <SimpleToggleSwitch size="md" enabled={enabled} onChange={onToggle} />
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/index.jsx
@@ -4,6 +4,7 @@ import showToast from "@/utils/toast";
 import { castToType } from "@/utils/types";
 import { useEffect, useRef, useState } from "react";
 import AgentLLMSelection from "./AgentLLMSelection";
+import WorkspaceAgentSkills from "./AgentSkills";
 import Admin from "@/models/admin";
 import * as Skeleton from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
@@ -87,6 +88,7 @@ export default function WorkspaceAgentConfiguration({ workspace }) {
         />
         {(!user || user?.role === "admin") && (
           <>
+            <WorkspaceAgentSkills workspace={workspace} />
             {!hasChanges && (
               <div className="flex flex-col gap-y-4">
                 <a
@@ -97,8 +99,8 @@ export default function WorkspaceAgentConfiguration({ workspace }) {
                 </a>
                 <p className="text-white text-opacity-60 text-xs font-medium">
                   Customize and enhance the default agent's capabilities by
-                  enabling or disabling specific skills. These settings will be
-                  applied across all workspaces.
+                  enabling or disabling specific skills. These settings apply to
+                  every workspace that has not overridden them above.
                 </p>
               </div>
             )}

--- a/server/__tests__/models/workspace.test.js
+++ b/server/__tests__/models/workspace.test.js
@@ -244,6 +244,35 @@ describeValidation("router_id", () => {
   });
 });
 
+describeValidation("agentConfig", () => {
+  it("serializes a map of skill id to boolean", () => {
+    expect(
+      Workspace.validations.agentConfig({ "web-browsing": true, memory: false })
+    ).toBe(JSON.stringify({ "web-browsing": true, memory: false }));
+  });
+
+  it("accepts an already serialized map", () => {
+    expect(Workspace.validations.agentConfig('{"memory":false}')).toBe(
+      JSON.stringify({ memory: false })
+    );
+  });
+
+  it("drops entries that are not boolean valued", () => {
+    expect(
+      Workspace.validations.agentConfig({ memory: "yes", "web-browsing": true })
+    ).toBe(JSON.stringify({ "web-browsing": true }));
+  });
+
+  it("returns null for empty, malformed, or missing values", () => {
+    expect(Workspace.validations.agentConfig(null)).toBe(null);
+    expect(Workspace.validations.agentConfig(undefined)).toBe(null);
+    expect(Workspace.validations.agentConfig({})).toBe(null);
+    expect(Workspace.validations.agentConfig(["memory"])).toBe(null);
+    expect(Workspace.validations.agentConfig("not json")).toBe(null);
+    expect(Workspace.validations.agentConfig({ memory: "yes" })).toBe(null);
+  });
+});
+
 describeValidation("lastUpdatedAt", () => {
   it("passes a valid ISO date string through as a Date", () => {
     const result = Workspace.validations.lastUpdatedAt(

--- a/server/__tests__/utils/agents/defaults.test.js
+++ b/server/__tests__/utils/agents/defaults.test.js
@@ -10,6 +10,7 @@ jest.mock("../../../models/systemPromptVariables");
 jest.mock("../../../models/systemSettings");
 jest.mock("../../../utils/agents/imported", () => ({
   activeImportedPlugins: jest.fn().mockReturnValue([]),
+  validateImportedPluginHandler: jest.fn().mockReturnValue(false),
 }));
 jest.mock("../../../utils/agentFlows", () => ({
   AgentFlows: {
@@ -22,7 +23,12 @@ jest.mock("../../../utils/MCP", () => {
   }));
 });
 
-const { WORKSPACE_AGENT } = require("../../../utils/agents/defaults");
+const AgentPlugins = require("../../../utils/agents/aibitat/plugins");
+const {
+  WORKSPACE_AGENT,
+  workspaceEnabledMCPTools,
+  disabledWorkspaceSkillNames,
+} = require("../../../utils/agents/defaults");
 
 describe("WORKSPACE_AGENT.getDefinition", () => {
   beforeEach(() => {
@@ -138,5 +144,66 @@ describe("WORKSPACE_AGENT.getDefinition", () => {
       null,
       workspace.id
     );
+  });
+});
+
+describe("workspace agent skill overrides", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    SystemPromptVariables.expandSystemPromptVariables.mockImplementation(
+      async (prompt) => prompt
+    );
+    SystemSettings.getValueOrFallback = jest.fn().mockResolvedValue("[]");
+  });
+
+  async function functionsFor(agentConfig) {
+    const { functions } = await WORKSPACE_AGENT.getDefinition(
+      "openai",
+      { id: 1, name: "Test Workspace", agentConfig },
+      { id: 1 }
+    );
+    return functions;
+  }
+
+  it("inherits the instance defaults when the workspace has no overrides", async () => {
+    expect(await functionsFor(null)).toContain(AgentPlugins.memory.name);
+  });
+
+  it("drops a default skill the workspace turned off", async () => {
+    const functions = await functionsFor(
+      JSON.stringify({ [AgentPlugins.memory.name]: false })
+    );
+    expect(functions).not.toContain(AgentPlugins.memory.name);
+  });
+
+  it("adds a configurable skill the workspace turned on", async () => {
+    const functions = await functionsFor(
+      JSON.stringify({ [AgentPlugins.webBrowsing.name]: true })
+    );
+    expect(functions).toContain(AgentPlugins.webBrowsing.name);
+  });
+
+  it("resolves disabled overrides into the function names to remove", () => {
+    const names = disabledWorkspaceSkillNames({
+      agentConfig: JSON.stringify({
+        [AgentPlugins.memory.name]: false,
+        "github-create_issue": false,
+        "web-browsing": true,
+      }),
+    });
+    expect(names).toEqual([AgentPlugins.memory.name, "github-create_issue"]);
+  });
+
+  it("extracts enabled MCP tool names for a given server", () => {
+    const workspace = {
+      agentConfig: JSON.stringify({
+        "github-create_issue": true,
+        "github-list_repos": false,
+        "docker-list_containers": true,
+      }),
+    };
+    expect(workspaceEnabledMCPTools(workspace, "github")).toEqual([
+      "create_issue",
+    ]);
   });
 });

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -7,6 +7,7 @@ const { v4: uuidv4 } = require("uuid");
 const { User } = require("./user");
 const { PromptHistory } = require("./promptHistory");
 const { SystemSettings } = require("./systemSettings");
+const { safeJsonParse } = require("../utils/http");
 
 function isNullOrNaN(value) {
   if (value === null) return true;
@@ -30,6 +31,7 @@ function isNullOrNaN(value) {
  * @property {string} agentModel - The agent model of the workspace
  * @property {string} queryRefusalResponse - The query refusal response of the workspace
  * @property {string} vectorSearchMode - The vector search mode of the workspace
+ * @property {string|null} agentConfig - JSON map of agent skill id to boolean overriding the instance-wide agent skill settings
  */
 
 const Workspace = {
@@ -55,6 +57,7 @@ const Workspace = {
     "agentModel",
     "queryRefusalResponse",
     "vectorSearchMode",
+    "agentConfig",
     "router_id",
   ],
 
@@ -130,6 +133,25 @@ const Workspace = {
       )
         return "default";
       return value;
+    },
+    agentConfig: (value) => {
+      if (value === null || value === undefined) return null;
+      const overrides =
+        typeof value === "string" ? safeJsonParse(value) : value;
+      if (
+        !overrides ||
+        typeof overrides !== "object" ||
+        Array.isArray(overrides)
+      )
+        return null;
+
+      const validated = {};
+      for (const [skill, enabled] of Object.entries(overrides)) {
+        if (typeof skill !== "string" || typeof enabled !== "boolean") continue;
+        validated[skill.slice(0, 255)] = enabled;
+      }
+      if (!Object.keys(validated).length) return null;
+      return JSON.stringify(validated);
     },
     router_id: (value) => {
       if ([null, undefined, "", "none"].includes(value)) return null;

--- a/server/prisma/migrations/20260818232358_init/migration.sql
+++ b/server/prisma/migrations/20260818232358_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN "agentConfig" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -139,6 +139,7 @@ model workspaces {
   agentModel                   String?
   queryRefusalResponse         String?
   vectorSearchMode             String?                        @default("default")
+  agentConfig                  String? // JSON agent skill overrides; null inherits the instance-wide settings
   router_id                    Int? // No relation to prevent whole table migration (SQLite limitation)
   workspace_users              workspace_users[]
   documents                    workspace_documents[]

--- a/server/utils/MCP/index.js
+++ b/server/utils/MCP/index.js
@@ -23,9 +23,14 @@ class MCPCompatibilityLayer extends MCPHypervisor {
    * Convert an MCP server name to an AnythingLLM Agent plugin
    * @param {string} name - The base name of the MCP server to convert - not the tool name. eg: `docker-mcp` not `docker-mcp:list-containers`
    * @param {Object} aibitat - The aibitat object to pass to the plugin
+   * @param {string[]} unsuppressedTools - Tool names to load even when the server config suppresses them.
    * @returns {Promise<{name: string, description: string, plugin: Function}[]|null>} Array of plugin configurations or null if not found
    */
-  async convertServerToolsToPlugins(name, _aibitat = null) {
+  async convertServerToolsToPlugins(
+    name,
+    _aibitat = null,
+    unsuppressedTools = []
+  ) {
     const mcp = this.mcps[name];
     if (!mcp) return null;
 
@@ -39,7 +44,9 @@ class MCPCompatibilityLayer extends MCPHypervisor {
     }
     if (!tools || !tools.length) return null;
 
-    const suppressedTools = this.getSuppressedTools(name);
+    const suppressedTools = this.getSuppressedTools(name).filter(
+      (tool) => !unsuppressedTools.includes(tool)
+    );
     const totalTools = tools.length;
     tools = tools.filter((tool) => !suppressedTools.includes(tool.name));
     const suppressedCount = totalTools - tools.length;

--- a/server/utils/agents/defaults.js
+++ b/server/utils/agents/defaults.js
@@ -86,11 +86,14 @@ const WORKSPACE_AGENT = {
     return {
       role,
       functions: [
-        ...(await agentSkillsFromSystemSettings()),
-        ...clarifyingQuestionsSkills,
-        ...ImportedPlugin.activeImportedPlugins(),
-        ...AgentFlows.activeFlowPlugins(),
-        ...(await new MCPCompatibilityLayer().activeMCPServers()),
+        ...new Set([
+          ...(await agentSkillsFromSystemSettings(workspace)),
+          ...clarifyingQuestionsSkills,
+          ...ImportedPlugin.activeImportedPlugins(),
+          ...AgentFlows.activeFlowPlugins(),
+          ...(await new MCPCompatibilityLayer().activeMCPServers()),
+          ...workspaceEnabledExternalSkills(workspace),
+        ]),
       ],
     };
   },
@@ -118,13 +121,71 @@ async function clarifyingQuestionsSkillIfEnabled() {
 }
 
 /**
+ * Agent skill overrides set on a workspace. Maps any identifier `resolveAgentSkill`
+ * accepts to a boolean that forces the skill on or off regardless of the
+ * instance-wide settings. Skills absent from the map inherit those settings.
+ * @param {import("@prisma/client").workspaces | null} workspace
+ * @returns {Record<string, boolean>}
+ */
+function workspaceSkillOverrides(workspace = null) {
+  return safeJsonParse(workspace?.agentConfig, {});
+}
+
+/**
+ * Loadable identifiers for agent flows and imported plugins a workspace enabled that
+ * the instance-wide config leaves inactive. Built-in skills are resolved by
+ * `agentSkillsFromSystemSettings` and MCP tools by `workspaceEnabledMCPTools`.
+ * @param {import("@prisma/client").workspaces | null} workspace
+ * @returns {string[]}
+ */
+function workspaceEnabledExternalSkills(workspace = null) {
+  return Object.entries(workspaceSkillOverrides(workspace))
+    .filter(
+      ([skill, enabled]) =>
+        enabled &&
+        (skill.startsWith("@@flow_") ||
+          ImportedPlugin.validateImportedPluginHandler(skill))
+    )
+    .flatMap(([skill]) => resolveAgentSkill(skill).loadable);
+}
+
+/**
+ * Tool names on a given MCP server that a workspace enabled, so they can be excluded
+ * from the instance-wide suppression list when the server is loaded for that workspace.
+ * @param {import("@prisma/client").workspaces | null} workspace
+ * @param {string} serverName
+ * @returns {string[]}
+ */
+function workspaceEnabledMCPTools(workspace = null, serverName = "") {
+  const prefix = `${serverName}-`;
+  return Object.entries(workspaceSkillOverrides(workspace))
+    .filter(([skill, enabled]) => enabled && skill.startsWith(prefix))
+    .map(([skill]) => skill.slice(prefix.length));
+}
+
+/**
+ * Aibitat function names a workspace turned off. Applied once plugins are attached
+ * since MCP servers load as a whole and their tools can only be dropped by the name
+ * they registered under.
+ * @param {import("@prisma/client").workspaces | null} workspace
+ * @returns {string[]}
+ */
+function disabledWorkspaceSkillNames(workspace = null) {
+  return Object.entries(workspaceSkillOverrides(workspace))
+    .filter(([_, enabled]) => !enabled)
+    .flatMap(([skill]) => resolveAgentSkill(skill).registered);
+}
+
+/**
  * Fetches and preloads the names/identifiers for plugins that will be dynamically
  * loaded later
+ * @param {import("@prisma/client").workspaces | null} workspace - applies this workspace's skill overrides when given
  * @returns {Promise<string[]>}
  */
-async function agentSkillsFromSystemSettings() {
+async function agentSkillsFromSystemSettings(workspace = null) {
   const systemFunctions = [];
   const isMultiUser = await SystemSettings.isMultiUserMode();
+  const overrides = workspaceSkillOverrides(workspace);
 
   // Load non-imported built-in skills that are configurable, but are default enabled.
   const _disabledDefaultSkills = safeJsonParse(
@@ -135,18 +196,29 @@ async function agentSkillsFromSystemSettings() {
     []
   );
   DEFAULT_SKILLS.forEach((skill) => {
-    if (!_disabledDefaultSkills.includes(skill))
+    if (overrides[skill] ?? !_disabledDefaultSkills.includes(skill))
       systemFunctions.push(AgentPlugins[skill].name);
   });
 
   // Load non-imported built-in skills that are configurable.
-  const _setting = safeJsonParse(
+  const _enabledSettingSkills = safeJsonParse(
     await SystemSettings.getValueOrFallback(
       { label: "default_agent_skills" },
       "[]"
     ),
     []
   );
+  const _setting = [
+    ...new Set([
+      ..._enabledSettingSkills,
+      ...Object.keys(overrides).filter(
+        (skill) =>
+          overrides[skill] &&
+          AgentPlugins.hasOwnProperty(skill) &&
+          !DEFAULT_SKILLS.includes(skill)
+      ),
+    ]),
+  ].filter((skill) => overrides[skill] !== false);
 
   // Pre-load disabled sub-skills and availability for configured skills
   const skillFilterState = {};
@@ -177,7 +249,10 @@ async function agentSkillsFromSystemSettings() {
         const filterState = skillFilterState[skillName];
         if (filterState) {
           if (!filterState.available) continue;
-          if (filterState.disabledSubSkills.includes(subPlugin.name)) continue;
+          const subSkillEnabled =
+            overrides[subPlugin.name] ??
+            !filterState.disabledSubSkills.includes(subPlugin.name);
+          if (!subSkillEnabled) continue;
         }
 
         systemFunctions.push(
@@ -260,6 +335,8 @@ function resolveAgentSkill(skill = "", { serverName = null } = {}) {
 module.exports = {
   USER_AGENT,
   WORKSPACE_AGENT,
-  agentSkillsFromSystemSettings,
   resolveAgentSkill,
+  workspaceSkillOverrides,
+  workspaceEnabledMCPTools,
+  disabledWorkspaceSkillNames,
 };

--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -13,7 +13,8 @@ const { safeJsonParse } = require("../http");
 const {
   USER_AGENT,
   WORKSPACE_AGENT,
-  agentSkillsFromSystemSettings,
+  workspaceEnabledMCPTools,
+  disabledWorkspaceSkillNames,
 } = require("./defaults");
 const { AgentHandler } = require(".");
 const {
@@ -330,7 +331,8 @@ class EphemeralAgentHandler extends AgentHandler {
         const plugins =
           await new MCPCompatibilityLayer().convertServerToolsToPlugins(
             mcpPluginName,
-            this.aibitat
+            this.aibitat,
+            workspaceEnabledMCPTools(this.#workspace, mcpPluginName)
           );
         if (!plugins) {
           this.log(
@@ -393,6 +395,9 @@ class EphemeralAgentHandler extends AgentHandler {
       this.aibitat.use(AIbitatPlugin.plugin(callOpts));
       this.log(`Attached ${name} plugin to Agent cluster`);
     }
+
+    for (const name of disabledWorkspaceSkillNames(this.#workspace))
+      this.aibitat.removeFunction(name);
   }
 
   async #loadAgents() {
@@ -403,22 +408,14 @@ class EphemeralAgentHandler extends AgentHandler {
       ? await User.get({ id: Number(this.#userId) })
       : null;
 
-    this.aibitat.agent(
-      WORKSPACE_AGENT.name,
-      await WORKSPACE_AGENT.getDefinition(
-        this.provider,
-        this.#workspace,
-        user,
-        this.#prompt
-      )
+    const workspaceAgentDef = await WORKSPACE_AGENT.getDefinition(
+      this.provider,
+      this.#workspace,
+      user,
+      this.#prompt
     );
-
-    this.#funcsToLoad = [
-      ...(await agentSkillsFromSystemSettings()),
-      ...ImportedPlugin.activeImportedPlugins(),
-      ...AgentFlows.activeFlowPlugins(),
-      ...(await new MCPCompatibilityLayer().activeMCPServers()),
-    ];
+    this.aibitat.agent(WORKSPACE_AGENT.name, workspaceAgentDef);
+    this.#funcsToLoad = workspaceAgentDef.functions;
   }
 
   async init() {

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -12,6 +12,9 @@ const {
   USER_AGENT,
   WORKSPACE_AGENT,
   resolveAgentSkill,
+  workspaceSkillOverrides,
+  workspaceEnabledMCPTools,
+  disabledWorkspaceSkillNames,
 } = require("./defaults");
 const ImportedPlugin = require("./imported");
 const { AgentFlows } = require("../agentFlows");
@@ -568,6 +571,8 @@ class AgentHandler {
   async #attachPlugins(args) {
     for (const name of this.#funcsToLoad)
       await this.#attachPluginByName(name, args);
+    for (const name of disabledWorkspaceSkillNames(this.invocation.workspace))
+      this.aibitat.removeFunction(name);
   }
 
   /**
@@ -644,7 +649,8 @@ class AgentHandler {
       const plugins =
         await new MCPCompatibilityLayer().convertServerToolsToPlugins(
           mcpPluginName,
-          this.aibitat
+          this.aibitat,
+          workspaceEnabledMCPTools(this.invocation.workspace, mcpPluginName)
         );
       if (!plugins) {
         this.log(
@@ -721,6 +727,15 @@ class AgentHandler {
     if (!skill || !this.aibitat?.agents.has(WORKSPACE_AGENT.name)) return;
     const { loadable, registered } = resolveAgentSkill(skill, { serverName });
     const agent = () => this.aibitat.agents.get(WORKSPACE_AGENT.name);
+
+    // Mirror the override onto the cached workspace so plugin loading sees the same
+    // state the user just saved - MCP servers read it to decide which tools to attach.
+    const workspace = this.invocation.workspace;
+    if (workspace)
+      workspace.agentConfig = JSON.stringify({
+        ...workspaceSkillOverrides(workspace),
+        [skill]: enabled,
+      });
 
     if (enabled) {
       for (const entry of loadable) {


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #3855 

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- add nullable agentConfig column on workspaces storing agent skill overrides, null inherits the instance settings
- scope the in-chat tools menu to the current workspace instead of writing instance-wide settings
- add an agent skills section to workspace settings with a reset to defaults action
- apply workspace overrides to built-in skills, sub-skills, imported plugins, agent flows and MCP tools
- keep overrides working mid-session so toggles apply on the agent's next turn
- only store skills that differ from the instance so everything else keeps following instance changes
- add tests for the agentConfig validation and workspace override resolution

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

- [x] Multiuser mode tested
- [ ] Translations PR (will be done after review)

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
