### PR TITLE
docs(gcp): describe what the deployment actually creates

### DIFF
--- a/cloud-deployments/gcp/deployment/DEPLOY.md
+++ b/cloud-deployments/gcp/deployment/DEPLOY.md
@@ -2,13 +2,22 @@
 
 With a GCP account you can easily deploy a private AnythingLLM instance on GCP. This will create a url that you can access from any browser over HTTP (HTTPS not supported). This single instance will run on your own keys and they will not be exposed - however if you want your instance to be protected it is highly recommend that you set a password once setup is complete.
 
-The output of this cloudformation stack will be:
-- 1 GCP VM
-- 1 Security Group with 0.0.0.0/0 access on Ports 22 & 3001
-- 1 GCP VM Volume `gb2` of 10Gib minimum
+This deployment is created with GCP Deployment Manager, and produces:
+- 1 Compute Engine VM (`n1-standard-1`, Ubuntu 20.04 LTS, zone `us-central1-a`)
+- 1 attached 10 GB persistent boot disk, deleted with the instance
+- 1 external IP on the `default` network
+
+It does **not** create a firewall rule. The `default` network allows SSH on port 22, but not port 3001, so the instance will not be reachable in a browser until you allow that port yourself:
+
+```
+gcloud compute firewall-rules create anything-llm-3001 \
+  --network default --allow tcp:3001
+```
+
+`--source-ranges` defaults to `0.0.0.0/0`; restrict it to your own address if you do not want the instance open to the internet. The instance carries no network tags, so the rule applies to it without `--target-tags`.
 
 **Requirements**
-- An GCP account with billing information.
+- A GCP account with billing information.
 
 ## How to deploy on GCP
 Open your terminal
@@ -21,7 +30,7 @@ Open your terminal
 
   ```
 
-  gcloud deployment-manager deployments create anything-llm-deployment --config gcp/deployment/gcp_deploy_anything_llm.yaml
+  gcloud deployment-manager deployments create anything-llm-deployment --config cloud-deployments/gcp/deployment/gcp_deploy_anything_llm.yaml
 
   ```
 


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [x] 📝 docs (Documentation updates)

### Relevant Issues

None open for this.

### Description

`cloud-deployments/gcp/deployment/DEPLOY.md` described the AWS stack. It said the output of "this cloudformation stack" would include "1 Security Group with 0.0.0.0/0 access on Ports 22 & 3001" — CloudFormation and security groups are AWS concepts, and that line matches what `cloudformation_create_anythingllm.json` really does create.

The GCP template beside it, `gcp_deploy_anything_llm.yaml`, contains exactly one resource: a `compute.v1.instance`. **No firewall rule.** That matters beyond wording, because GCP's `default` network ships with rules for tcp:22, tcp:3389 and internal traffic, and nothing for 3001. So the deployment succeeds, the startup script brings the container up, and the instance is still unreachable in a browser — while the doc says a rule opening 3001 was created for you.

The resource list now matches the template, and the missing rule is called out with the command to add it:

```
gcloud compute firewall-rules create anything-llm-3001 \
  --network default --allow tcp:3001
```

`--target-tags` is deliberately omitted: the instance in the template carries no network tags, so a tagged rule would not apply to it.

One other fix in the same file: the deploy step passes `--config gcp/deployment/gcp_deploy_anything_llm.yaml`, but no step before it clones the repository or changes directory, so that relative path resolves for nobody. It now points at the path the file has in a clone.

### Additional Information

Offered as context rather than scope: Google discontinued support for Deployment Manager on April 1 2026, and since June 30 2026 new users cannot enable the API or create a first deployment. Anyone arriving at this doc fresh today cannot run it at all, so this directory may deserve a broader look than a documentation correction. The image the template pins, `ubuntu-2004-lts`, is also past end of life.

Happy to add the firewall resource to the template instead if you would rather the deployment work out of the box — that seemed like a security decision to leave with you, since opening 3001 to the internet exposes an instance that has no password until setup is completed.

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

This change is a single Markdown file, so `yarn lint` and the Docker build have nothing to cover and I did not run them. "Tested" here means the claims were checked against the template rather than asserted: the yaml's only resource is the instance, and the `default` network's stock rules do not include 3001.
