### PR TITLE
chore: drop two package scripts whose targets are gone

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "prisma:reset": "truncate -s 0 server/storage/anythingllm.db && yarn prisma:migrate",
     "prod:server": "cd server && yarn start",
     "prod:frontend": "cd frontend && yarn build",
-    "generate:cloudformation": "node cloud-deployments/aws/cloudformation/generate.mjs",
-    "generate::gcp_deployment": "node cloud-deployments/gcp/deployment/generate.mjs",
     "translations:verify": "cd frontend/src/locales && node verifyTranslations.mjs",
     "translations:normalize": "cd frontend/src/locales && node normalizeEn.mjs && cd ../../.. && cd frontend && yarn lint && cd .. && yarn translations:verify",
     "translations:prune": "cd frontend/src/locales && node findUnusedTranslations.mjs --delete && cd ../../../ && yarn translations:normalize",


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [x] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

None open for this.

### Description

Two root scripts point at a file that is not in the repository:

```
"generate:cloudformation": "node cloud-deployments/aws/cloudformation/generate.mjs",
"generate::gcp_deployment": "node cloud-deployments/gcp/deployment/generate.mjs",
```

There is no `generate.mjs` anywhere in the tree — `find . -name generate.mjs` outside `node_modules` returns nothing — so both fail immediately:

```
$ node cloud-deployments/aws/cloudformation/generate.mjs
node:internal/modules/cjs/loader:1573
  throw err;
  ^
Error: Cannot find module '.../cloud-deployments/aws/cloudformation/generate.mjs'
```

Nothing in the repository, the workflows, or the docs invokes either one, so this removes them rather than repairing them. The deployment assets they once produced, `cloudformation_create_anythingllm.json` and `gcp_deploy_anything_llm.yaml`, are both checked in and used directly by their `DEPLOY.md` instructions.

Worth noting in passing rather than fixing here: the second name has a doubled colon, `generate::gcp_deployment`, unlike every other script in the file. Renaming it seemed like the wrong repair for a script that cannot run.

### Additional Information

If either script is still wanted, the fix is restoring the generator rather than the entry, and I am happy to leave them alone instead — say the word.

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

This change removes two lines from `package.json` and touches no source, so `yarn lint` and the Docker build have nothing to cover and I did not run them. I confirmed `package.json` still parses and that both scripts fail on the current tree before removal.
