### PR TITLE
fix(docker): check the port the server is actually listening on

### DIFF
--- a/docker/docker-healthcheck.sh
+++ b/docker/docker-healthcheck.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Send a request to the specified URL
-response=$(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:3001/api/ping)
+# The server boots with `process.env.SERVER_PORT || 3001`, so check the same port it is listening on
+response=$(curl --write-out '%{http_code}' --silent --output /dev/null "http://localhost:${SERVER_PORT:-3001}/api/ping")
 
 # If the HTTP response code is 200 (OK), the server is up
 if [ "$response" -eq 200 ]; then


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

connect #1206

### Description

`docker/docker-healthcheck.sh` probes a hardcoded `3001`, but the server boots on `process.env.SERVER_PORT || 3001` (`server/index.js:180`, and `:76` for the SSL path). When `SERVER_PORT` is set to anything else the app runs fine and the healthcheck keeps failing, so Docker marks the container `unhealthy` for as long as it is up.

This is #1206, where the reporter showed `docker ps` listing the container unhealthy while the app worked. The answer there was a per-compose override:

```yaml
healthcheck:
  test: "curl --silent --fail http://localhost:$${SERVER_PORT}/api/ping/ > /dev/null || exit 1"
```

That works, and this change is the same lookup applied in the script itself so it is not needed per deployment. The suggestion to update the baked-in file was posted to that issue after it was closed, so it never got picked up.

The default is preserved: with `SERVER_PORT` unset or empty, `${SERVER_PORT:-3001}` yields `3001` and behavior is exactly as before.

Verified against a local server on port 3009:

| script | `SERVER_PORT` | result |
| --- | --- | --- |
| current | `3009` | `Server is down`, exit 1 |
| this PR | `3009` | `Server is up`, exit 0 |
| this PR | unset | falls back to 3001 (unchanged) |
| this PR | empty | falls back to 3001 (unchanged) |

Scope note: this covers the cases where `SERVER_PORT` is in the container environment — compose `env_file`/`environment`, `docker run -e`, or an image that sets it, as `cloud-deployments/huggingface-spaces/Dockerfile` does. It does not change the flow where `.env` is only mounted into the container and read by the node process alone; that keeps the previous 3001 fallback rather than regressing.

`cloud-deployments/openshift/Dockerfile` uses the same script and benefits identically.

### Visuals (if applicable)

Not applicable, this is a shell script with no rendered surface.

### Additional Information

One line changed plus one comment. No behavior change when `SERVER_PORT` is unset.

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

`yarn lint` is unchecked because this touches no JavaScript; the repo's lint scripts do not cover `docker/*.sh`. `bash -n docker/docker-healthcheck.sh` passes, and the functional testing is the table above. The Docker build box is unchecked because I did not build the image locally.