### PR TITLE
Fix broken relative links in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a name="readme-top"></a>
 
 > [!NOTE]
-> We are also working on [Open Computer](/open-computer) which gives an entire computer environment for AI Agents to use.
+> We are also working on [Open Computer](./open-computer) which gives an entire computer environment for AI Agents to use.
 >
 > This will bring AnythingLLM's agent capabilities to a new level and a novel UX paradigm for AI Agent use.
 >
@@ -50,7 +50,7 @@ Chat with your docs. Automate complex workflows with AI Agents. Hyper-configurab
 <details>
 <summary><kbd>Watch the demo!</kbd></summary>
 
-[![Watch the video](/images/youtube.png)](https://youtu.be/f95rGD9trL0)
+[![Watch the video](./images/youtube.png)](https://youtu.be/f95rGD9trL0)
 
 </details>
 
@@ -85,7 +85,7 @@ AnythingLLM supports multiple users as well where you can control the access and
 
 **Large Language Models (LLMs):**
 
-- [Any open-source llama.cpp compatible model](/server/storage/models/README.md#text-generation-llm-selection)
+- [Any open-source llama.cpp compatible model](./server/storage/models/README.md#text-generation-llm-selection)
 - [OpenAI](https://openai.com)
 - [OpenAI (Generic)](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
@@ -126,7 +126,7 @@ AnythingLLM supports multiple users as well where you can control the access and
 
 **Embedder models:**
 
-- [AnythingLLM Native Embedder](/server/storage/models/README.md) (default)
+- [AnythingLLM Native Embedder](./server/storage/models/README.md) (default)
 - [OpenAI](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
 - [Gemini](https://ai.google.dev/)

--- a/locales/README.fa-IR.md
+++ b/locales/README.fa-IR.md
@@ -45,7 +45,7 @@
 <details>
 <summary><kbd>دموی ویدیویی را تماشا کنید!</kbd></summary>
 
-[![Watch the video](/images/youtube.png)](https://youtu.be/f95rGD9trL0)
+[![Watch the video](../images/youtube.png)](https://youtu.be/f95rGD9trL0)
 
 </details>
 <div dir="rtl">
@@ -65,11 +65,11 @@ AnythingLLM همچنین از چندین کاربر پشتیبانی می‌کن
 - 🖼️ **پشتیبانی از چند مدل (هم LLMهای متن‌باز و هم تجاری!)**
 - 👤 پشتیبانی از چند کاربر و سیستم مجوزها _فقط در نسخه Docker_
 - 🦾 عامل‌ها در فضای کاری شما (مرور وب، اجرای کد و غیره)
-- 💬 [ویجت چت قابل جاسازی سفارشی برای وب‌سایت شما](../embed/README.md) _فقط در نسخه Docker_
+- 💬 [ویجت چت قابل جاسازی سفارشی برای وب‌سایت شما](https://github.com/Mintplex-Labs/anythingllm-embed/blob/main/README.md) _فقط در نسخه Docker_
 - 📖 پشتیبانی از انواع مختلف سند (PDF، TXT، DOCX و غیره)
 - رابط کاربری ساده چت با قابلیت کشیدن و رها کردن و استنادهای واضح
 - ۱۰۰٪ آماده استقرار در فضای ابری
-- سازگار با تمام [ارائه‌دهندگان محبوب LLM متن‌باز و تجاری](#supported-llms-embedder-models-speech-models-and-vector-databases)
+- سازگار با تمام [ارائه‌دهندگان محبوب LLM متن‌باز و تجاری](#llmها-مدلهای-embedder-مدلهای-گفتاری-و-پایگاههای-داده-برداری-پشتیبانی-شده)
 - دارای اقدامات داخلی صرفه‌جویی در هزینه و زمان برای مدیریت اسناد بسیار بزرگ در مقایسه با سایر رابط‌های کاربری چت
 - API کامل توسعه‌دهنده برای یکپارچه‌سازی‌های سفارشی!
 - و موارد بیشتر... نصب کنید و کشف کنید!
@@ -78,7 +78,7 @@ AnythingLLM همچنین از چندین کاربر پشتیبانی می‌کن
 
 **مدل‌های زبانی بزرگ (LLMs):**
 
-- [Any open-source llama.cpp compatible model](/server/storage/models/README.md#text-generation-llm-selection)
+- [Any open-source llama.cpp compatible model](../server/storage/models/README.md#text-generation-llm-selection)
 - [OpenAI](https://openai.com)
 - [OpenAI (Generic)](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
@@ -116,7 +116,7 @@ AnythingLLM همچنین از چندین کاربر پشتیبانی می‌کن
 
 **مدل‌های Embedder:**
 
-- [AnythingLLM Native Embedder](/server/storage/models/README.md) (پیش‌فرض)
+- [AnythingLLM Native Embedder](../server/storage/models/README.md) (پیش‌فرض)
 - [OpenAI](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
 - [LocalAi (همه)](https://localai.io/)

--- a/locales/README.ja-JP.md
+++ b/locales/README.ja-JP.md
@@ -43,7 +43,7 @@
 <details>
 <summary><kbd>デモを見る！</kbd></summary>
 
-[![ビデオを見る](/images/youtube.png)](https://youtu.be/f95rGD9trL0)
+[![ビデオを見る](../images/youtube.png)](https://youtu.be/f95rGD9trL0)
 
 </details>
 
@@ -71,7 +71,7 @@ AnythingLLMは複数ユーザーもサポートしており、インスタンス
 
 **言語学習モデル：**
 
-- [llama.cpp互換の任意のオープンソースモデル](/server/storage/models/README.md#text-generation-llm-selection)
+- [llama.cpp互換の任意のオープンソースモデル](../server/storage/models/README.md#text-generation-llm-selection)
 - [OpenAI](https://openai.com)
 - [OpenAI (汎用)](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
@@ -102,7 +102,7 @@ AnythingLLMは複数ユーザーもサポートしており、インスタンス
 
 **埋め込みモデル：**
 
-- [AnythingLLMネイティブ埋め込み](/server/storage/models/README.md)（デフォルト）
+- [AnythingLLMネイティブ埋め込み](../server/storage/models/README.md)（デフォルト）
 - [OpenAI](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
 - [LocalAi (すべて)](https://localai.io/)
@@ -145,7 +145,7 @@ AnythingLLMは複数ユーザーもサポートしており、インスタンス
 - `server`: すべてのインタラクションを処理し、すべてのベクトルDB管理およびLLMインタラクションを行うNodeJS expressサーバー。
 - `collector`: UIからドキュメントを処理および解析するNodeJS expressサーバー。
 - `docker`: Dockerの指示およびビルドプロセス + ソースからのビルド情報。
-- `embed`: [埋め込みウィジェット](../embed/README.md)の生成に特化したコード。
+- `embed`: [埋め込みウィジェット](https://github.com/Mintplex-Labs/anythingllm-embed/blob/main/README.md)の生成に特化したコード。
 
 ## 🛳 セルフホスティング
 

--- a/locales/README.tr-TR.md
+++ b/locales/README.tr-TR.md
@@ -43,7 +43,7 @@ Herhangi bir belgeyi, kaynağı veya içeriği sohbet sırasında herhangi bir b
 <details>
 <summary><kbd>Demoyu izle!</kbd></summary>
 
-[![Video'yu izle](/images/youtube.png)](https://youtu.be/f95rGD9trL0)
+[![Video'yu izle](../images/youtube.png)](https://youtu.be/f95rGD9trL0)
 
 </details>
 
@@ -64,7 +64,7 @@ AnythingLLM ayrıca birden fazla kullanıcıyı da destekler; burada örneğin g
 - 📖 Çoklu belge türü desteği (PDF, TXT, DOCX vb.)
 - Sade ve kullanışlı sohbet arayüzü, sürükle-bırak özelliği ve net kaynak gösterimi.
 - %100 bulut konuşlandırmaya hazır.
-- [Tüm popüler kapalı ve açık kaynak LLM sağlayıcılarıyla](#supported-llms-embedder-models-speech-models-and-vector-databases) uyumlu.
+- [Tüm popüler kapalı ve açık kaynak LLM sağlayıcılarıyla](#desteklenen-llmler-embedding-modelleri-konuşma-modelleri-ve-vektör-veritabanları) uyumlu.
 - Büyük belgeleri yönetirken zaman ve maliyet tasarrufu sağlayan dahili optimizasyonlar.
 - Özel entegrasyonlar için tam kapsamlı Geliştirici API’si.
 - Ve çok daha fazlası... Kurup keşfedin!
@@ -73,7 +73,7 @@ AnythingLLM ayrıca birden fazla kullanıcıyı da destekler; burada örneğin g
 
 **Büyük Dil Modelleri (LLMs):**
 
-- [Any open-source llama.cpp compatible model](/server/storage/models/README.md#text-generation-llm-selection)
+- [Any open-source llama.cpp compatible model](../server/storage/models/README.md#text-generation-llm-selection)
 - [OpenAI](https://openai.com)
 - [OpenAI (Generic)](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
@@ -109,7 +109,7 @@ AnythingLLM ayrıca birden fazla kullanıcıyı da destekler; burada örneğin g
 
 **Embedder modelleri:**
 
-- [AnythingLLM Native Embedder](/server/storage/models/README.md) (default)
+- [AnythingLLM Native Embedder](../server/storage/models/README.md) (default)
 - [OpenAI](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
 - [LocalAi (all)](https://localai.io/)

--- a/locales/README.zh-CN.md
+++ b/locales/README.zh-CN.md
@@ -43,7 +43,7 @@
 <details>
 <summary><kbd>观看演示视频！</kbd></summary>
 
-[![观看视频](/images/youtube.png)](https://youtu.be/f95rGD9trL0)
+[![观看视频](../images/youtube.png)](https://youtu.be/f95rGD9trL0)
 
 </details>
 
@@ -74,7 +74,7 @@ AnythingLLM还支持多用户，您可以控制每个用户的访问权限和体
 
 **支持的LLM：**
 
-- [任何与llama.cpp兼容的开源模型](/server/storage/models/README.md#text-generation-llm-selection)
+- [任何与llama.cpp兼容的开源模型](../server/storage/models/README.md#text-generation-llm-selection)
 - [OpenAI](https://openai.com)
 - [OpenAI (通用)](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
@@ -111,7 +111,7 @@ AnythingLLM还支持多用户，您可以控制每个用户的访问权限和体
 
 **支持的嵌入模型：**
 
-- [AnythingLLM原生嵌入器](/server/storage/models/README.md)（默认）
+- [AnythingLLM原生嵌入器](../server/storage/models/README.md)（默认）
 - [OpenAI](https://openai.com)
 - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
 - [LocalAI (全部)](https://localai.io/)


### PR DESCRIPTION
### What does this PR do?

Fixes broken markdown links in the main README and the four locale READMEs (fa-IR, ja-JP, tr-TR, zh-CN). All of these 404 today when clicked on GitHub:

- **Root-relative links**: links written with a leading slash, e.g. `/server/storage/models/README.md` or `/images/youtube.png`, resolve against `github.com` instead of the repo, so they 404. Converted to proper relative paths (`./server/...` from the root README, `../server/...` from `locales/`). Targets verified to exist, including the `#text-generation-llm-selection` anchor.
- **`../embed/README.md` links** (fa-IR, ja-JP): the `embed/` directory is empty in the repo, so the README is gone. The embed widget now lives in [Mintplex-Labs/anythingllm-embed](https://github.com/Mintplex-Labs/anythingllm-embed); the main README already links there, so the locale READMEs now use the same target.
- **Dead localized anchors** (fa-IR, tr-TR): the feature list linked the English anchor `#supported-llms-embedder-models-speech-models-and-vector-databases`, but those files translate the heading. Updated to the slug of the actual localized heading (verified with the GitHub anchor algorithm).

### What it doesn't touch

Two other dead links exist (`docker/HOW_TO_USE_DOCKER.md` → deleted `ollama/README.md`, `open-computer/README.md` → deleted `BUILD-QEMU.md`); their intended replacement isn't obvious from the current tree, so I left them out of this PR.

### Review checklist

- [x] Docs / README only — no functional changes
- [x] Every changed link target verified to exist