### PR TITLE
fix: require auth on env-dump endpoints

### DIFF
--- a/server/endpoints/api/system/index.js
+++ b/server/endpoints/api/system/index.js
@@ -13,7 +13,7 @@ const { validApiKey } = require("../../../utils/middleware/validApiKey");
 function apiSystemEndpoints(app) {
   if (!app) return;
 
-  app.get("/v1/system/env-dump", async (_, response) => {
+  app.get("/v1/system/env-dump", [validApiKey], async (_, response) => {
     /*
    #swagger.tags = ['System Settings']
    #swagger.description = 'Dump all settings to file storage'

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -86,7 +86,7 @@ function systemEndpoints(app) {
     response.sendStatus(200);
   });
 
-  app.get("/env-dump", async (_, response) => {
+  app.get("/env-dump", [validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager])], async (_, response) => {
     if (process.env.NODE_ENV !== "production")
       return response.sendStatus(200).end();
     dumpENV();


### PR DESCRIPTION
Adds missing authentication to the two env-dump routes, found during a security review (per your SECURITY.md, low-severity issues with an obvious fix are welcome as public PRs).

1. GET /v1/system/env-dump (server/endpoints/api/system/index.js) had no [validApiKey] middleware, even though its own swagger doc declares a 403 InvalidAPIKey response and every sibling route in the file is gated.
2. GET /env-dump (server/endpoints/system.js) had no middleware at all.

Both call dumpENV(), which in production rewrites server/.env to the frozen protectedKeys subset - an unauthenticated, repeatable config-integrity action that can silently drop hand-added env keys on restart. The console route now requires validatedRequest + admin/manager role, matching other privileged system routes in the same file.

Verify: default docker deployment, curl -i http://localhost:3001/api/env-dump returns 200 before and 401/403 after; curl -i http://localhost:3001/api/v1/system/env-dump without an API key returns 403 after.

Two-line change, no behavior change for authorized callers.