### PR TITLE
feat: Entra ID / managed identity auth for Azure OpenAI (Azure AI Foundry)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -20,7 +20,9 @@ GID='1000'
 
 # LLM_PROVIDER='azure'
 # AZURE_OPENAI_ENDPOINT=
-# AZURE_OPENAI_KEY=
+# AZURE_OPENAI_CONNECTION_METHOD='api_key' # 'api_key' (default) or 'managed_identity' to authenticate with Microsoft Entra ID.
+# AZURE_OPENAI_KEY= # Not needed when using 'managed_identity'.
+# AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID= # Only for a user-assigned managed identity - leave empty for the system-assigned one.
 # AZURE_OPENAI_MODEL_PREF='my-gpt35-deployment' # This is the "deployment" on Azure you want to use. Not the base model.
 # EMBEDDING_MODEL_PREF='embedder-model' # This is the "deployment" on Azure you want to use for embeddings. Not the base model. Valid base model is text-embedding-ada-002
 
@@ -194,7 +196,9 @@ GID='1000'
 
 # EMBEDDING_ENGINE='azure'
 # AZURE_OPENAI_ENDPOINT=
-# AZURE_OPENAI_KEY=
+# AZURE_OPENAI_CONNECTION_METHOD='api_key' # 'api_key' (default) or 'managed_identity' to authenticate with Microsoft Entra ID.
+# AZURE_OPENAI_KEY= # Not needed when using 'managed_identity'.
+# AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID= # Only for a user-assigned managed identity - leave empty for the system-assigned one.
 # EMBEDDING_MODEL_PREF='my-embedder-model' # This is the "deployment" on Azure you want to use for embeddings. Not the base model. Valid base model is text-embedding-ada-002
 
 # EMBEDDING_ENGINE='localai'

--- a/frontend/src/components/EmbeddingSelection/AzureAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/AzureAiOptions/index.jsx
@@ -1,4 +1,11 @@
+import { useState } from "react";
+
 export default function AzureAiOptions({ settings }) {
+  const [connectionMethod, setConnectionMethod] = useState(
+    settings?.AzureOpenAiConnectionMethod || "api_key"
+  );
+  const usesManagedIdentity = connectionMethod === "managed_identity";
+
   return (
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
@@ -20,20 +27,56 @@ export default function AzureAiOptions({ settings }) {
 
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
-            API Key
+            Connection Method
           </label>
-          <input
-            type="password"
-            name="AzureOpenAiKey"
+          <select
+            name="AzureOpenAiConnectionMethod"
+            value={connectionMethod}
+            onChange={(e) => setConnectionMethod(e.target.value)}
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-            placeholder="Azure OpenAI API Key"
-            defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
             required={true}
-            autoComplete="off"
-            spellCheck={false}
-          />
+          >
+            <option value="api_key">API Key</option>
+            <option value="managed_identity">Managed Identity</option>
+          </select>
         </div>
 
+        {usesManagedIdentity ? (
+          <div className="flex flex-col w-60">
+            <label className="text-white text-sm font-semibold block mb-3">
+              Managed Identity Client ID
+            </label>
+            <input
+              type="text"
+              name="AzureOpenAiManagedIdentityClientId"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder="Optional - only for a user-assigned identity"
+              defaultValue={settings?.AzureOpenAiManagedIdentityClientId}
+              required={false}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col w-60">
+            <label className="text-white text-sm font-semibold block mb-3">
+              API Key
+            </label>
+            <input
+              type="password"
+              name="AzureOpenAiKey"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder="Azure OpenAI API Key"
+              defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
+              required={true}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
             Embedding Deployment Name

--- a/frontend/src/components/LLMSelection/AzureAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AzureAiOptions/index.jsx
@@ -1,9 +1,14 @@
 import { Info } from "@phosphor-icons/react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Tooltip } from "react-tooltip";
 
 export default function AzureAiOptions({ settings }) {
   const { t } = useTranslation();
+  const [connectionMethod, setConnectionMethod] = useState(
+    settings?.AzureOpenAiConnectionMethod || "api_key"
+  );
+  const usesManagedIdentity = connectionMethod === "managed_identity";
 
   return (
     <div className="w-full flex flex-col gap-y-7 mt-1.5">
@@ -25,21 +30,111 @@ export default function AzureAiOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
-            {t("llm.providers.azure_openai.api_key")}
-          </label>
-          <input
-            type="password"
-            name="AzureOpenAiKey"
+          <div className="flex items-center gap-1 mb-3">
+            <label className="text-white text-sm font-semibold block">
+              {t("llm.providers.azure_openai.connection_method")}
+            </label>
+            <Tooltip
+              id="azure-openai-connection-method"
+              place="top"
+              delayShow={300}
+              className="tooltip !text-xs !opacity-100"
+              style={{
+                maxWidth: "250px",
+                whiteSpace: "normal",
+                wordWrap: "break-word",
+              }}
+            />
+            <div
+              type="button"
+              className="text-theme-text-secondary cursor-pointer hover:bg-theme-bg-primary flex items-center justify-center rounded-full"
+              data-tooltip-id="azure-openai-connection-method"
+              data-tooltip-place="top"
+              data-tooltip-content={t(
+                "llm.providers.azure_openai.connection_method_tooltip"
+              )}
+            >
+              <Info size={18} className="text-theme-text-secondary" />
+            </div>
+          </div>
+          <select
+            name="AzureOpenAiConnectionMethod"
+            value={connectionMethod}
+            onChange={(e) => setConnectionMethod(e.target.value)}
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-            placeholder="Azure OpenAI API Key"
-            defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
             required={true}
-            autoComplete="off"
-            spellCheck={false}
-          />
+          >
+            <option value="api_key">
+              {t("llm.providers.azure_openai.api_key")}
+            </option>
+            <option value="managed_identity">
+              {t("llm.providers.azure_openai.managed_identity")}
+            </option>
+          </select>
         </div>
 
+        {usesManagedIdentity ? (
+          <div className="flex flex-col w-60">
+            <div className="flex items-center gap-1 mb-3">
+              <label className="text-white text-sm font-semibold block">
+                {t("llm.providers.azure_openai.managed_identity_client_id")}
+              </label>
+              <Tooltip
+                id="azure-openai-managed-identity-client-id"
+                place="top"
+                delayShow={300}
+                className="tooltip !text-xs !opacity-100"
+                style={{
+                  maxWidth: "250px",
+                  whiteSpace: "normal",
+                  wordWrap: "break-word",
+                }}
+              />
+              <div
+                type="button"
+                className="text-theme-text-secondary cursor-pointer hover:bg-theme-bg-primary flex items-center justify-center rounded-full"
+                data-tooltip-id="azure-openai-managed-identity-client-id"
+                data-tooltip-place="top"
+                data-tooltip-content={t(
+                  "llm.providers.azure_openai.managed_identity_client_id_tooltip"
+                )}
+              >
+                <Info size={18} className="text-theme-text-secondary" />
+              </div>
+            </div>
+            <input
+              type="text"
+              name="AzureOpenAiManagedIdentityClientId"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder={t(
+                "llm.providers.azure_openai.managed_identity_client_id_placeholder"
+              )}
+              defaultValue={settings?.AzureOpenAiManagedIdentityClientId}
+              required={false}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col w-60">
+            <label className="text-white text-sm font-semibold block mb-3">
+              {t("llm.providers.azure_openai.api_key")}
+            </label>
+            <input
+              type="password"
+              name="AzureOpenAiKey"
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              placeholder="Azure OpenAI API Key"
+              defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
+              required={true}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.chat_deployment_name")}
@@ -55,9 +150,7 @@ export default function AzureAiOptions({ settings }) {
             spellCheck={false}
           />
         </div>
-      </div>
 
-      <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.chat_model_token_limit")}

--- a/frontend/src/components/LLMSelection/AzureAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AzureAiOptions/index.jsx
@@ -1,7 +1,8 @@
 import { Info } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Tooltip } from "react-tooltip";
+import System from "@/models/system";
 
 export default function AzureAiOptions({ settings }) {
   const { t } = useTranslation();
@@ -9,6 +10,15 @@ export default function AzureAiOptions({ settings }) {
     settings?.AzureOpenAiConnectionMethod || "api_key"
   );
   const usesManagedIdentity = connectionMethod === "managed_identity";
+
+  // Listing deployments needs the endpoint and credentials, which may still be
+  // mid-edit. These update on blur rather than on change so that typing an
+  // endpoint does not fire a request per keystroke.
+  const [endpoint, setEndpoint] = useState(settings?.AzureOpenAiEndpoint);
+  const [apiKey, setApiKey] = useState(settings?.AzureOpenAiKey);
+  const [clientId, setClientId] = useState(
+    settings?.AzureOpenAiManagedIdentityClientId
+  );
 
   return (
     <div className="w-full flex flex-col gap-y-7 mt-1.5">
@@ -23,6 +33,7 @@ export default function AzureAiOptions({ settings }) {
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="https://my-azure.openai.azure.com"
             defaultValue={settings?.AzureOpenAiEndpoint}
+            onBlur={(e) => setEndpoint(e.target.value)}
             required={true}
             autoComplete="off"
             spellCheck={false}
@@ -110,6 +121,7 @@ export default function AzureAiOptions({ settings }) {
                 "llm.providers.azure_openai.managed_identity_client_id_placeholder"
               )}
               defaultValue={settings?.AzureOpenAiManagedIdentityClientId}
+              onBlur={(e) => setClientId(e.target.value)}
               required={false}
               autoComplete="off"
               spellCheck={false}
@@ -126,6 +138,7 @@ export default function AzureAiOptions({ settings }) {
               className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="Azure OpenAI API Key"
               defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
+              onBlur={(e) => setApiKey(e.target.value)}
               required={true}
               autoComplete="off"
               spellCheck={false}
@@ -135,21 +148,13 @@ export default function AzureAiOptions({ settings }) {
       </div>
 
       <div className="w-full flex items-center gap-[36px]">
-        <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
-            {t("llm.providers.azure_openai.chat_deployment_name")}
-          </label>
-          <input
-            type="text"
-            name="AzureOpenAiModelPref"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-            placeholder="Azure OpenAI chat model deployment name"
-            defaultValue={settings?.AzureOpenAiModelPref}
-            required={true}
-            autoComplete="off"
-            spellCheck={false}
-          />
-        </div>
+        <AzureDeploymentSelection
+          settings={settings}
+          endpoint={endpoint}
+          apiKey={apiKey}
+          connectionMethod={connectionMethod}
+          clientId={clientId}
+        />
 
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
@@ -216,6 +221,144 @@ export default function AzureAiOptions({ settings }) {
           </select>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Azure addresses models by deployment name, chosen by whoever created the
+ * deployment, so the list has to come from the resource itself. A deployment can
+ * always be typed in instead: listing needs read access to the resource, and a
+ * deployment created in the last few minutes may not be listed yet.
+ */
+function AzureDeploymentSelection({
+  settings,
+  endpoint,
+  apiKey,
+  connectionMethod,
+  clientId,
+}) {
+  const { t } = useTranslation();
+  const [deployments, setDeployments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [manualEntry, setManualEntry] = useState(false);
+
+  useEffect(() => {
+    async function findDeployments() {
+      if (!endpoint) {
+        setDeployments([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      const { models, error } = await System.customModels(
+        "azure",
+        typeof apiKey === "boolean" ? null : apiKey,
+        endpoint,
+        null,
+        { connectionMethod, managedIdentityClientId: clientId }
+      );
+      // Embedding deployments cannot serve chat, so they are left out of this
+      // dropdown. "unknown" is kept: the capability catalog does not cover every
+      // model a resource can serve, and those deployments still work.
+      setDeployments(
+        (models || []).filter((deployment) => deployment.type !== "embedding")
+      );
+      setError(error);
+      setLoading(false);
+    }
+    findDeployments();
+  }, [endpoint, apiKey, connectionMethod, clientId]);
+
+  const label = t("llm.providers.azure_openai.chat_deployment_name");
+
+  if (manualEntry || (!loading && !!endpoint && deployments.length === 0)) {
+    return (
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          {label}
+        </label>
+        <input
+          type="text"
+          name="AzureOpenAiModelPref"
+          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          placeholder="Azure OpenAI chat model deployment name"
+          defaultValue={settings?.AzureOpenAiModelPref}
+          required={true}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className="text-theme-text-secondary text-xs mt-2">
+          {error ?? t("llm.providers.azure_openai.deployments_none_found")}
+        </p>
+      </div>
+    );
+  }
+
+  if (loading || !endpoint) {
+    return (
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          {label}
+        </label>
+        <select
+          name="AzureOpenAiModelPref"
+          disabled={true}
+          defaultValue=""
+          className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg block w-full p-2.5"
+        >
+          <option value="" disabled={true}>
+            {endpoint
+              ? t("llm.providers.azure_openai.deployments_loading")
+              : t("llm.providers.azure_openai.deployments_waiting")}
+          </option>
+        </select>
+      </div>
+    );
+  }
+
+  const chatDeployments = deployments.filter((d) => d.type === "chat");
+  const otherDeployments = deployments.filter((d) => d.type !== "chat");
+
+  return (
+    <div className="flex flex-col w-60">
+      <label className="text-white text-sm font-semibold block mb-3">
+        {label}
+      </label>
+      <select
+        name="AzureOpenAiModelPref"
+        required={true}
+        defaultValue={settings?.AzureOpenAiModelPref}
+        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg block w-full p-2.5"
+      >
+        {chatDeployments.length > 0 && (
+          <optgroup label={t("llm.providers.azure_openai.deployments_chat")}>
+            {chatDeployments.map((deployment) => (
+              <option key={deployment.id} value={deployment.id}>
+                {deployment.id}
+              </option>
+            ))}
+          </optgroup>
+        )}
+        {otherDeployments.length > 0 && (
+          <optgroup label={t("llm.providers.azure_openai.deployments_unknown")}>
+            {otherDeployments.map((deployment) => (
+              <option key={deployment.id} value={deployment.id}>
+                {deployment.id}
+              </option>
+            ))}
+          </optgroup>
+        )}
+      </select>
+      <button
+        type="button"
+        onClick={() => setManualEntry(true)}
+        className="text-theme-text-secondary hover:text-white text-xs mt-2 text-left underline w-fit"
+      >
+        {t("llm.providers.azure_openai.deployments_enter_manually")}
+      </button>
     </div>
   );
 }

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -925,6 +925,15 @@ const TRANSLATIONS = {
         api_key: "API Key",
         chat_deployment_name: "Chat Deployment Name",
         chat_model_token_limit: "Chat Model Token Limit",
+        connection_method: "Connection Method",
+        connection_method_tooltip:
+          "Use “API Key” to authenticate with the key from your Azure resource, or “Managed Identity” to authenticate with a Microsoft Entra ID token from the identity assigned to this host. Managed Identity is required when the resource has local authentication disabled.",
+        managed_identity: "Managed Identity",
+        managed_identity_client_id: "Managed Identity Client ID",
+        managed_identity_client_id_placeholder:
+          "Optional - only for a user-assigned identity",
+        managed_identity_client_id_tooltip:
+          "Leave empty to use the system-assigned managed identity of this host. Set this to the client ID of a user-assigned managed identity to select it explicitly.",
         model_type: "Model Type",
         model_type_tooltip:
           "If your deployment uses a reasoning model (o1, o1-mini, o3-mini, etc.), set this to “Reasoning”. Otherwise, your chat requests may fail.",

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -925,6 +925,13 @@ const TRANSLATIONS = {
         api_key: "API Key",
         chat_deployment_name: "Chat Deployment Name",
         chat_model_token_limit: "Chat Model Token Limit",
+        deployments_chat: "Chat deployments",
+        deployments_enter_manually: "Enter a deployment name manually",
+        deployments_loading: "-- loading your deployments --",
+        deployments_none_found:
+          "No deployments could be listed for this endpoint. Enter the deployment name from your Azure resource.",
+        deployments_unknown: "Capability not reported by Azure",
+        deployments_waiting: "-- waiting for endpoint --",
         connection_method: "Connection Method",
         connection_method_tooltip:
           "Use “API Key” to authenticate with the key from your Azure resource, or “Managed Identity” to authenticate with a Microsoft Entra ID token from the identity assigned to this host. Managed Identity is required when the resource has local authentication disabled.",

--- a/server/__tests__/utils/AiProviders/azureOpenAi/credentials.test.js
+++ b/server/__tests__/utils/AiProviders/azureOpenAi/credentials.test.js
@@ -1,0 +1,183 @@
+/* eslint-env jest */
+
+/**
+ * Tests for Azure OpenAI (Azure AI Foundry) credential handling - the API key
+ * default and the Microsoft Entra ID / managed identity path.
+ *
+ * Related issue: https://github.com/Mintplex-Labs/anything-llm/issues/6172
+ */
+
+let mockTokenCounter = 0;
+const mockCredentialOptions = [];
+
+jest.mock(
+  "@azure/identity",
+  () => ({
+    DefaultAzureCredential: class {
+      constructor(options = {}) {
+        mockCredentialOptions.push(options);
+        this.options = options;
+      }
+    },
+    getBearerTokenProvider: (credential, scope) => async () =>
+      `token-${++mockTokenCounter}|${scope}|${credential.options.managedIdentityClientId ?? "system-assigned"}`,
+  }),
+  { virtual: true }
+);
+
+describe("Azure OpenAI credentials", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockTokenCounter = 0;
+    mockCredentialOptions.length = 0;
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.AZURE_OPENAI_CONNECTION_METHOD;
+    delete process.env.AZURE_OPENAI_KEY;
+    delete process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function loadCredentials() {
+    return require("../../../../utils/AiProviders/azureOpenAi/credentials");
+  }
+
+  describe("api key (default)", () => {
+    test("is the connection method when nothing is configured", () => {
+      const { azureConnectionMethod, usesManagedIdentity } = loadCredentials();
+      expect(azureConnectionMethod()).toBe("api_key");
+      expect(usesManagedIdentity()).toBe(false);
+    });
+
+    test("an unrecognized connection method falls back to the api key", () => {
+      process.env.AZURE_OPENAI_CONNECTION_METHOD = "something-else";
+      const { azureConnectionMethod } = loadCredentials();
+      expect(azureConnectionMethod()).toBe("api_key");
+    });
+
+    test("passes the key to both client shapes", () => {
+      process.env.AZURE_OPENAI_KEY = "static-key";
+      const { azureClientOptions, azureOpenAiClientOptions } =
+        loadCredentials();
+      expect(azureClientOptions()).toEqual({ apiKey: "static-key" });
+      expect(azureOpenAiClientOptions()).toEqual({ apiKey: "static-key" });
+    });
+
+    test("still requires a key to be set", () => {
+      const { validateAzureCredentials } = loadCredentials();
+      expect(() => validateAzureCredentials()).toThrow(
+        "No Azure API key was set."
+      );
+    });
+  });
+
+  describe("managed identity", () => {
+    beforeEach(() => {
+      process.env.AZURE_OPENAI_CONNECTION_METHOD = "managed_identity";
+    });
+
+    test("needs no API key", () => {
+      const { usesManagedIdentity, validateAzureCredentials } =
+        loadCredentials();
+      expect(usesManagedIdentity()).toBe(true);
+      expect(() => validateAzureCredentials()).not.toThrow();
+    });
+
+    test("hands the SDK's AzureOpenAI client a token provider instead of a key", async () => {
+      const { azureOpenAiClientOptions } = loadCredentials();
+      const options = azureOpenAiClientOptions();
+      expect(options.apiKey).toBeUndefined();
+      expect(typeof options.azureADTokenProvider).toBe("function");
+      await expect(options.azureADTokenProvider()).resolves.toContain(
+        "https://cognitiveservices.azure.com/.default"
+      );
+    });
+
+    test("sets a bearer token on every request the plain client makes", async () => {
+      const { azureClientOptions } = loadCredentials();
+      const { apiKey, fetch: wrappedFetch } = azureClientOptions();
+
+      // The SDK and LangChain both refuse to build a client without an apiKey,
+      // but the header built from it is replaced below.
+      expect(apiKey).toBeTruthy();
+
+      const authHeaders = [];
+      global.fetch = jest.fn(async (_url, init) => {
+        authHeaders.push(new Headers(init.headers).get("authorization"));
+        return { ok: true };
+      });
+
+      await wrappedFetch("https://x.openai.azure.com/openai/v1/models", {
+        headers: { "content-type": "application/json" },
+      });
+      await wrappedFetch("https://x.openai.azure.com/openai/v1/models", {});
+
+      expect(authHeaders[0]).toMatch(/^Bearer token-/);
+      expect(authHeaders[1]).toMatch(/^Bearer token-/);
+      expect(authHeaders[0]).toContain("system-assigned");
+    });
+
+    test("preserves the headers and request options the caller passed", async () => {
+      const { azureClientOptions } = loadCredentials();
+      const { fetch: wrappedFetch } = azureClientOptions();
+
+      let captured = null;
+      global.fetch = jest.fn(async (_url, init) => {
+        captured = init;
+        return { ok: true };
+      });
+
+      const controller = new AbortController();
+      await wrappedFetch("https://x.openai.azure.com/openai/v1/models", {
+        method: "POST",
+        body: "{}",
+        signal: controller.signal,
+        headers: { "content-type": "application/json" },
+      });
+
+      expect(captured.method).toBe("POST");
+      expect(captured.body).toBe("{}");
+      expect(captured.signal).toBe(controller.signal);
+      expect(new Headers(captured.headers).get("content-type")).toBe(
+        "application/json"
+      );
+    });
+
+    test("selects a user-assigned identity by client ID", async () => {
+      process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID = "client-id-123";
+      const { azureOpenAiClientOptions } = loadCredentials();
+      await expect(
+        azureOpenAiClientOptions().azureADTokenProvider()
+      ).resolves.toContain("client-id-123");
+      expect(mockCredentialOptions[0]).toEqual({
+        managedIdentityClientId: "client-id-123",
+      });
+    });
+
+    test("omits the client ID entirely for a system-assigned identity", () => {
+      const { azureOpenAiClientOptions } = loadCredentials();
+      azureOpenAiClientOptions();
+      expect(mockCredentialOptions[0]).toEqual({});
+    });
+
+    test("rebuilds the credential when the configured identity changes", async () => {
+      const { azureOpenAiClientOptions } = loadCredentials();
+      await azureOpenAiClientOptions().azureADTokenProvider();
+      expect(mockCredentialOptions).toHaveLength(1);
+
+      // Same identity - the cached provider is reused.
+      await azureOpenAiClientOptions().azureADTokenProvider();
+      expect(mockCredentialOptions).toHaveLength(1);
+
+      process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID = "client-id-123";
+      await expect(
+        azureOpenAiClientOptions().azureADTokenProvider()
+      ).resolves.toContain("client-id-123");
+      expect(mockCredentialOptions).toHaveLength(2);
+    });
+  });
+});

--- a/server/__tests__/utils/AiProviders/azureOpenAi/models.test.js
+++ b/server/__tests__/utils/AiProviders/azureOpenAi/models.test.js
@@ -1,0 +1,204 @@
+/* eslint-env jest */
+
+/**
+ * Tests for listing the deployments on an Azure OpenAI (Azure AI Foundry)
+ * resource, which is what backs the deployment dropdown in the LLM settings.
+ *
+ * Related issue: https://github.com/Mintplex-Labs/anything-llm/issues/6172
+ */
+
+const mockCredentialOptions = [];
+
+jest.mock(
+  "@azure/identity",
+  () => ({
+    DefaultAzureCredential: class {
+      constructor(options = {}) {
+        mockCredentialOptions.push(options);
+      }
+      async getToken(scope) {
+        return { token: `token|${scope}` };
+      }
+    },
+    getBearerTokenProvider: (credential, scope) => async () => `token|${scope}`,
+  }),
+  { virtual: true }
+);
+
+const HOST = "https://my-resource.services.ai.azure.com";
+
+/** Every deployment shape the route can return, including ones to drop. */
+const DEPLOYMENTS = {
+  data: [
+    { id: "gpt-4o", model: "gpt-4o", status: "succeeded" },
+    { id: "ada", model: "text-embedding-ada-002", status: "succeeded" },
+    { id: "partner", model: "Kimi-K2.6", status: "succeeded" },
+    { id: "half-built", model: "gpt-4o", status: "creating" },
+  ],
+};
+
+const CATALOG = {
+  data: [
+    { id: "gpt-4o", capabilities: { chat_completion: true } },
+    { id: "text-embedding-ada-002", capabilities: { embeddings: true } },
+  ],
+};
+
+describe("Azure OpenAI deployment listing", () => {
+  const ORIGINAL_ENV = process.env;
+  let requests;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockCredentialOptions.length = 0;
+    requests = [];
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.AZURE_OPENAI_ENDPOINT;
+    delete process.env.AZURE_OPENAI_KEY;
+    delete process.env.AZURE_OPENAI_CONNECTION_METHOD;
+    delete process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID;
+
+    global.fetch = jest.fn(async (url, init) => {
+      requests.push({ url, headers: init.headers });
+      const body = url.includes("/deployments") ? DEPLOYMENTS : CATALOG;
+      return { ok: true, json: async () => body };
+    });
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function subject() {
+    return require("../../../../utils/AiProviders/azureOpenAi/models");
+  }
+
+  it("returns an error rather than throwing when no endpoint is configured", async () => {
+    const { listAzureDeployments } = subject();
+    const { models, error } = await listAzureDeployments({});
+    expect(models).toEqual([]);
+    expect(error).toMatch(/endpoint/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the saved endpoint", async () => {
+    process.env.AZURE_OPENAI_ENDPOINT = HOST;
+    process.env.AZURE_OPENAI_KEY = "secret";
+    const { listAzureDeployments } = subject();
+    const { error } = await listAzureDeployments({});
+    expect(error).toBeNull();
+    expect(requests[0].url).toContain(HOST);
+  });
+
+  it("drops a project path from the endpoint", async () => {
+    const { listAzureDeployments } = subject();
+    await listAzureDeployments({
+      endpoint: `${HOST}/api/projects/my-project`,
+      apiKey: "secret",
+    });
+    expect(requests[0].url).toBe(
+      `${HOST}/openai/deployments?api-version=2023-03-15-preview`
+    );
+  });
+
+  it("only returns deployments that finished provisioning", async () => {
+    const { listAzureDeployments } = subject();
+    const { models } = await listAzureDeployments({
+      endpoint: HOST,
+      apiKey: "secret",
+    });
+    expect(models.map((m) => m.id)).not.toContain("half-built");
+  });
+
+  it("classifies deployments by the capability of their model", async () => {
+    const { listAzureDeployments } = subject();
+    const { models } = await listAzureDeployments({
+      endpoint: HOST,
+      apiKey: "secret",
+    });
+    expect(models).toEqual([
+      { id: "gpt-4o", model: "gpt-4o", type: "chat" },
+      { id: "ada", model: "text-embedding-ada-002", type: "embedding" },
+      { id: "partner", model: "Kimi-K2.6", type: "unknown" },
+    ]);
+  });
+
+  it("keeps a deployment whose model the catalog does not list", async () => {
+    const { listAzureDeployments } = subject();
+    const { models } = await listAzureDeployments({
+      endpoint: HOST,
+      apiKey: "secret",
+    });
+    // A resource can serve models absent from the catalog, so an unrecognized
+    // one must stay selectable rather than be hidden as unusable.
+    expect(models.find((m) => m.id === "partner").type).toBe("unknown");
+  });
+
+  it("sends the API key in Azure's own header", async () => {
+    const { listAzureDeployments } = subject();
+    await listAzureDeployments({
+      endpoint: HOST,
+      apiKey: "secret",
+      connectionMethod: "api_key",
+    });
+    expect(requests[0].headers).toEqual({ "api-key": "secret" });
+  });
+
+  it("sends a bearer token for managed identity and never the key header", async () => {
+    const { listAzureDeployments } = subject();
+    await listAzureDeployments({
+      endpoint: HOST,
+      connectionMethod: "managed_identity",
+    });
+    expect(requests[0].headers.Authorization).toBe(
+      "Bearer token|https://cognitiveservices.azure.com/.default"
+    );
+    expect(requests[0].headers["api-key"]).toBeUndefined();
+  });
+
+  it("selects a user-assigned identity by client ID", async () => {
+    const { listAzureDeployments } = subject();
+    await listAzureDeployments({
+      endpoint: HOST,
+      connectionMethod: "managed_identity",
+      managedIdentityClientId: "client-id",
+    });
+    expect(mockCredentialOptions[0]).toEqual({
+      managedIdentityClientId: "client-id",
+    });
+  });
+
+  it("omits the client ID for a system-assigned identity", async () => {
+    const { listAzureDeployments } = subject();
+    await listAzureDeployments({
+      endpoint: HOST,
+      connectionMethod: "managed_identity",
+    });
+    expect(mockCredentialOptions[0]).toEqual({});
+  });
+
+  it("reports a failed listing instead of returning an empty dropdown", async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, json: async () => ({}) }));
+    const { listAzureDeployments } = subject();
+    const { models, error } = await listAzureDeployments({
+      endpoint: HOST,
+      apiKey: "secret",
+    });
+    expect(models).toEqual([]);
+    expect(error).toMatch(/could not list deployments/i);
+  });
+
+  it("still lists deployments when the capability catalog is unavailable", async () => {
+    global.fetch = jest.fn(async (url) => ({
+      ok: url.includes("/deployments"),
+      json: async () => DEPLOYMENTS,
+    }));
+    const { listAzureDeployments } = subject();
+    const { models, error } = await listAzureDeployments({
+      endpoint: HOST,
+      apiKey: "secret",
+    });
+    expect(error).toBeNull();
+    expect(models.every((m) => m.type === "unknown")).toBe(true);
+  });
+});

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -883,6 +883,10 @@ const SystemSettings = {
       AzureOpenAiEmbeddingModelPref: process.env.EMBEDDING_MODEL_PREF,
       AzureOpenAiTokenLimit: process.env.AZURE_OPENAI_TOKEN_LIMIT || 4096,
       AzureOpenAiModelType: process.env.AZURE_OPENAI_MODEL_TYPE || "default",
+      AzureOpenAiConnectionMethod:
+        process.env.AZURE_OPENAI_CONNECTION_METHOD || "api_key",
+      AzureOpenAiManagedIdentityClientId:
+        process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID,
 
       // Anthropic Keys
       AnthropicApiKey: !!process.env.ANTHROPIC_API_KEY,

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@azure/identity": "^4.13.2",
     "@breejs/later": "4.2.0",
     "@datastax/astra-db-ts": "^0.1.3",
     "@ladjs/graceful": "^3.2.2",

--- a/server/utils/AiProviders/azureOpenAi/credentials.js
+++ b/server/utils/AiProviders/azureOpenAi/credentials.js
@@ -1,0 +1,125 @@
+/**
+ * Credential handling for the Azure OpenAI (Azure AI Foundry) provider.
+ *
+ * Azure resources can authenticate two ways and both are supported here:
+ *  - `api_key` (default): the static key from the resource, in AZURE_OPENAI_KEY.
+ *  - `managed_identity`: a Microsoft Entra ID token fetched at request time from
+ *    the ambient Azure credential chain, so no secret is ever stored. This is the
+ *    only option when the resource sets `disableLocalAuth: true`.
+ */
+
+/** Scope every Azure AI Foundry / Azure OpenAI data-plane token is issued for. */
+const AZURE_COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default";
+
+/**
+ * The OpenAI SDK and LangChain both refuse to build a client without an API key,
+ * but for managed identity the Authorization header is replaced per-request, so
+ * the value they are handed is never sent anywhere.
+ * @type {string}
+ */
+const MANAGED_IDENTITY_PLACEHOLDER = "managed-identity";
+
+/** @type {{provider: (function(): Promise<string>), clientId: string|null}|null} */
+let cachedTokenProvider = null;
+
+/**
+ * How this instance authenticates against Azure. Anything other than an explicit
+ * "managed_identity" keeps the historical API key behavior.
+ * @returns {"api_key"|"managed_identity"}
+ */
+function azureConnectionMethod() {
+  return process.env.AZURE_OPENAI_CONNECTION_METHOD === "managed_identity"
+    ? "managed_identity"
+    : "api_key";
+}
+
+/**
+ * @returns {boolean} Whether Entra ID / managed identity auth is in use.
+ */
+function usesManagedIdentity() {
+  return azureConnectionMethod() === "managed_identity";
+}
+
+/**
+ * A cached token provider for the configured identity. `DefaultAzureCredential`
+ * covers the managed identity assigned to the host (Container Apps, App Service,
+ * AKS workload identity, VMs) and falls back to the environment or a developer's
+ * `az login` session, so the same setting works in production and locally.
+ *
+ * The provider caches the token and refreshes it before it expires, so this is
+ * built once per process rather than per request.
+ * @returns {function(): Promise<string>} Resolves to a bearer token.
+ */
+function bearerTokenProvider() {
+  const clientId = process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID || null;
+  if (cachedTokenProvider && cachedTokenProvider.clientId === clientId)
+    return cachedTokenProvider.provider;
+
+  const {
+    DefaultAzureCredential,
+    getBearerTokenProvider,
+  } = require("@azure/identity");
+  const credential = new DefaultAzureCredential({
+    // Omitted for a system-assigned identity - only a user-assigned one needs to
+    // be picked out by client ID.
+    ...(clientId ? { managedIdentityClientId: clientId } : {}),
+  });
+  cachedTokenProvider = {
+    clientId,
+    provider: getBearerTokenProvider(credential, AZURE_COGNITIVE_SCOPE),
+  };
+  return cachedTokenProvider.provider;
+}
+
+/**
+ * Throws when the provider cannot authenticate with the current settings. With
+ * managed identity there is nothing to validate up front - the credential chain
+ * is only resolved once a request is actually made.
+ * @returns {void}
+ */
+function validateAzureCredentials() {
+  if (usesManagedIdentity()) return;
+  if (!process.env.AZURE_OPENAI_KEY)
+    throw new Error("No Azure API key was set.");
+}
+
+/**
+ * Auth options for a plain `OpenAI` client (or LangChain's `configuration`)
+ * pointed at an Azure endpoint. Azure's v1 API surface accepts an Entra ID token
+ * in the same `Authorization: Bearer` header the SDK builds from `apiKey`, but a
+ * token expires while `apiKey` is fixed at construction - so the header is set
+ * from the token provider on every request instead.
+ * @returns {{apiKey: string, fetch?: function}}
+ */
+function azureClientOptions() {
+  if (!usesManagedIdentity()) return { apiKey: process.env.AZURE_OPENAI_KEY };
+
+  const getToken = bearerTokenProvider();
+  return {
+    apiKey: MANAGED_IDENTITY_PLACEHOLDER,
+    fetch: async (url, init = {}) => {
+      const headers = new Headers(init.headers);
+      headers.set("Authorization", `Bearer ${await getToken()}`);
+      return fetch(url, { ...init, headers });
+    },
+  };
+}
+
+/**
+ * Auth options for the SDK's `AzureOpenAI` client, which takes a token provider
+ * directly and handles refresh itself.
+ * @returns {{apiKey: string}|{azureADTokenProvider: function(): Promise<string>}}
+ */
+function azureOpenAiClientOptions() {
+  if (!usesManagedIdentity()) return { apiKey: process.env.AZURE_OPENAI_KEY };
+  return { azureADTokenProvider: bearerTokenProvider() };
+}
+
+module.exports = {
+  AZURE_COGNITIVE_SCOPE,
+  azureClientOptions,
+  azureConnectionMethod,
+  azureOpenAiClientOptions,
+  usesManagedIdentity,
+  validateAzureCredentials,
+};

--- a/server/utils/AiProviders/azureOpenAi/index.js
+++ b/server/utils/AiProviders/azureOpenAi/index.js
@@ -6,18 +6,22 @@ const {
 const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
+const {
+  azureClientOptions,
+  azureConnectionMethod,
+  validateAzureCredentials,
+} = require("./credentials");
 
 class AzureOpenAiLLM {
   constructor(embedder = null, modelPreference = null) {
     const { OpenAI } = require("openai");
     if (!process.env.AZURE_OPENAI_ENDPOINT)
       throw new Error("No Azure API endpoint was set.");
-    if (!process.env.AZURE_OPENAI_KEY)
-      throw new Error("No Azure API key was set.");
+    validateAzureCredentials();
 
     this.className = "AzureOpenAiLLM";
     this.openai = new OpenAI({
-      apiKey: process.env.AZURE_OPENAI_KEY,
+      ...azureClientOptions(),
       baseURL: AzureOpenAiLLM.formatBaseUrl(process.env.AZURE_OPENAI_ENDPOINT),
     });
     this.model =
@@ -41,7 +45,7 @@ class AzureOpenAiLLM {
     this.embedder = embedder ?? new NativeEmbedder();
     this.defaultTemp = 0.7;
     this.#log(
-      `Initialized. Model "${this.model}" @ ${this.promptWindowLimit()} tokens.\nAPI-Version: ${this.apiVersion}.\nModel Type: ${this.isOTypeModel ? "reasoning" : "default"}`
+      `Initialized. Model "${this.model}" @ ${this.promptWindowLimit()} tokens.\nAPI-Version: ${this.apiVersion}.\nModel Type: ${this.isOTypeModel ? "reasoning" : "default"}\nAuth: ${azureConnectionMethod()}`
     );
   }
 

--- a/server/utils/AiProviders/azureOpenAi/models.js
+++ b/server/utils/AiProviders/azureOpenAi/models.js
@@ -1,0 +1,165 @@
+const { AZURE_COGNITIVE_SCOPE } = require("./credentials");
+
+/**
+ * Listing what is actually deployed needs the data-plane `deployments` route,
+ * which only exists on this api-version - the current ones (2024-10-21 and
+ * later) dropped it and return 404. The `models` route is not a substitute: it
+ * advertises the region's entire catalog (hundreds of entries), almost none of
+ * which the resource can serve.
+ */
+const DEPLOYMENTS_API_VERSION = "2023-03-15-preview";
+
+/** The catalog is only consulted for capability metadata, so it can use a current version. */
+const CATALOG_API_VERSION = "2024-10-21";
+
+/** Deployment listing backs a settings dropdown, so it should fail fast rather than hang the UI. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Azure takes the static key in its own header rather than as a bearer token,
+ * so the two connection methods produce different headers entirely.
+ *
+ * This deliberately does not reuse the cached token provider from
+ * `credentials.js`: the values here come from a settings form that may not be
+ * saved yet, and a one-off listing call should not replace the cached provider
+ * the live LLM clients are using.
+ * @param {{connectionMethod: string, apiKey: string|null, managedIdentityClientId: string|null}} auth
+ * @returns {Promise<Object>} Headers to send with the request.
+ */
+async function authHeaders({
+  connectionMethod,
+  apiKey,
+  managedIdentityClientId,
+}) {
+  if (connectionMethod !== "managed_identity")
+    return { "api-key": apiKey || process.env.AZURE_OPENAI_KEY };
+
+  const { DefaultAzureCredential } = require("@azure/identity");
+  const clientId =
+    managedIdentityClientId ||
+    process.env.AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID ||
+    null;
+  const credential = new DefaultAzureCredential({
+    ...(clientId ? { managedIdentityClientId: clientId } : {}),
+  });
+  const { token } = await credential.getToken(AZURE_COGNITIVE_SCOPE);
+  return { Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Both routes hang off the resource host - the endpoint a user pastes in may
+ * carry a project path (`/api/projects/...`) that has to be dropped first.
+ * @param {string} endpoint
+ * @returns {string} The origin of the endpoint.
+ */
+function resourceOrigin(endpoint) {
+  const url = new URL(endpoint);
+  url.protocol = "https";
+  return url.origin;
+}
+
+/**
+ * @param {string} url
+ * @param {Object} headers
+ * @returns {Promise<Object|null>} Parsed body, or null when the request fails.
+ */
+async function getJson(url, headers) {
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) return null;
+  return await response.json();
+}
+
+/**
+ * Capabilities per underlying model name, so a deployment can be sorted into
+ * the chat or the embedding dropdown. Best-effort: a resource can serve models
+ * that are absent from this catalog (partner models published through AI
+ * Foundry, for instance), and those still work, so a miss must never be treated
+ * as "unusable".
+ * @param {string} origin
+ * @param {Object} headers
+ * @returns {Promise<Map<string, string>>} Model name to "chat"|"embedding"|"other".
+ */
+async function modelCapabilities(origin, headers) {
+  const capabilities = new Map();
+  const catalog = await getJson(
+    `${origin}/openai/models?api-version=${CATALOG_API_VERSION}`,
+    headers
+  ).catch(() => null);
+
+  for (const model of catalog?.data ?? []) {
+    if (model?.capabilities?.chat_completion)
+      capabilities.set(model.id, "chat");
+    else if (model?.capabilities?.embeddings)
+      capabilities.set(model.id, "embedding");
+    else capabilities.set(model.id, "other");
+  }
+  return capabilities;
+}
+
+/**
+ * The deployments on an Azure OpenAI / AI Foundry resource, which is what the
+ * provider addresses models by. Only successful deployments are returned - one
+ * still provisioning or failed cannot serve a request.
+ * @param {Object} args
+ * @param {string|null} args.endpoint - Defaults to the saved endpoint.
+ * @param {string|null} args.apiKey
+ * @param {string|null} args.connectionMethod - "api_key" or "managed_identity".
+ * @param {string|null} args.managedIdentityClientId
+ * @returns {Promise<{models: Array<{id: string, model: string, type: string}>, error: string|null}>}
+ */
+async function listAzureDeployments({
+  endpoint = null,
+  apiKey = null,
+  connectionMethod = null,
+  managedIdentityClientId = null,
+} = {}) {
+  const azureEndpoint = endpoint || process.env.AZURE_OPENAI_ENDPOINT;
+  if (!azureEndpoint)
+    return { models: [], error: "No Azure OpenAI endpoint was set." };
+
+  try {
+    const origin = resourceOrigin(azureEndpoint);
+    const headers = await authHeaders({
+      connectionMethod:
+        connectionMethod || process.env.AZURE_OPENAI_CONNECTION_METHOD,
+      apiKey,
+      managedIdentityClientId,
+    });
+
+    const deployments = await getJson(
+      `${origin}/openai/deployments?api-version=${DEPLOYMENTS_API_VERSION}`,
+      headers
+    );
+    if (!deployments)
+      return {
+        models: [],
+        error:
+          "Could not list deployments. Check the endpoint and that these credentials can read the Azure resource.",
+      };
+
+    const capabilities = await modelCapabilities(origin, headers);
+    const models = (deployments.data ?? [])
+      .filter((deployment) => deployment.status === "succeeded")
+      .map((deployment) => ({
+        id: deployment.id,
+        model: deployment.model,
+        // "unknown" keeps a deployment selectable when the catalog has never
+        // heard of its model - it is very likely still usable.
+        type: capabilities.get(deployment.model) ?? "unknown",
+      }));
+
+    return { models, error: null };
+  } catch (e) {
+    console.error(`AzureOpenAi:listAzureDeployments`, e.message);
+    return { models: [], error: e.message };
+  }
+}
+
+module.exports = {
+  DEPLOYMENTS_API_VERSION,
+  listAzureDeployments,
+};

--- a/server/utils/EmbeddingEngines/azureOpenAi/index.js
+++ b/server/utils/EmbeddingEngines/azureOpenAi/index.js
@@ -1,17 +1,20 @@
 const { toChunks, reportEmbeddingProgress } = require("../../helpers");
+const {
+  azureOpenAiClientOptions,
+  validateAzureCredentials,
+} = require("../../AiProviders/azureOpenAi/credentials");
 
 class AzureOpenAiEmbedder {
   constructor() {
     const { AzureOpenAI } = require("openai");
     if (!process.env.AZURE_OPENAI_ENDPOINT)
       throw new Error("No Azure API endpoint was set.");
-    if (!process.env.AZURE_OPENAI_KEY)
-      throw new Error("No Azure API key was set.");
+    validateAzureCredentials();
 
     this.className = "AzureOpenAiEmbedder";
     this.apiVersion = "2024-12-01-preview";
     const openai = new AzureOpenAI({
-      apiKey: process.env.AZURE_OPENAI_KEY,
+      ...azureOpenAiClientOptions(),
       endpoint: process.env.AZURE_OPENAI_ENDPOINT,
       apiVersion: this.apiVersion,
     });

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -26,6 +26,9 @@ const { parseFoundryBasePath } = require("../../../AiProviders/foundry");
 const { parseOMLXBasePath } = require("../../../AiProviders/omlx");
 const { AzureOpenAiLLM } = require("../../../AiProviders/azureOpenAi");
 const {
+  azureClientOptions,
+} = require("../../../AiProviders/azureOpenAi/credentials");
+const {
   SystemPromptVariables,
 } = require("../../../../models/systemPromptVariables");
 const { OllamaAILLM } = require("../../../AiProviders/ollama");
@@ -300,16 +303,19 @@ class Provider {
           apiKey: process.env.AWS_BEDROCK_LLM_API_KEY ?? null,
           ...config,
         });
-      case "azure":
+      case "azure": {
+        const { apiKey, ...clientOptions } = azureClientOptions();
         return new ChatOpenAI({
           configuration: {
             baseURL: AzureOpenAiLLM.formatBaseUrl(
               process.env.AZURE_OPENAI_ENDPOINT
             ),
+            ...clientOptions,
           },
-          apiKey: process.env.AZURE_OPENAI_KEY,
+          apiKey,
           ...config,
         });
+      }
       case "fireworksai":
         return new ChatOpenAI({
           apiKey: process.env.FIREWORKS_AI_LLM_API_KEY,

--- a/server/utils/agents/aibitat/providers/azure.js
+++ b/server/utils/agents/aibitat/providers/azure.js
@@ -1,5 +1,8 @@
 const { OpenAI } = require("openai");
 const { AzureOpenAiLLM } = require("../../../AiProviders/azureOpenAi");
+const {
+  azureClientOptions,
+} = require("../../../AiProviders/azureOpenAi/credentials");
 const Provider = require("./ai-provider.js");
 const { tooledStream, tooledComplete } = require("./helpers/tooled.js");
 const { RetryError } = require("../error.js");
@@ -13,7 +16,7 @@ class AzureOpenAiProvider extends Provider {
 
   constructor(config = { model: null }) {
     const client = new OpenAI({
-      apiKey: process.env.AZURE_OPENAI_KEY,
+      ...azureClientOptions(),
       baseURL: AzureOpenAiLLM.formatBaseUrl(process.env.AZURE_OPENAI_ENDPOINT),
     });
     super(client);

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -17,6 +17,9 @@ const ImportedPlugin = require("./imported");
 const { AgentFlows } = require("../agentFlows");
 const MCPCompatibilityLayer = require("../MCP");
 const { getAndClearInvocationAttachments } = require("../chats/agents");
+const {
+  usesManagedIdentity,
+} = require("../AiProviders/azureOpenAi/credentials");
 const { DocumentManager } = require("../DocumentManager");
 
 class AgentHandler {
@@ -152,9 +155,15 @@ class AgentHandler {
           throw new Error("TogetherAI API key must be provided to use agents.");
         break;
       case "azure":
-        if (!process.env.AZURE_OPENAI_ENDPOINT || !process.env.AZURE_OPENAI_KEY)
+        if (!process.env.AZURE_OPENAI_ENDPOINT)
           throw new Error(
-            "Azure OpenAI API endpoint and key must be provided to use agents."
+            "Azure OpenAI API endpoint must be provided to use agents."
+          );
+        // With managed identity there is no key to check - the credential chain
+        // is resolved when the first request is made.
+        if (!usesManagedIdentity() && !process.env.AZURE_OPENAI_KEY)
+          throw new Error(
+            "Azure OpenAI API key must be provided to use agents."
           );
         break;
       case "koboldcpp":

--- a/server/utils/helpers/customModels.js
+++ b/server/utils/helpers/customModels.js
@@ -14,9 +14,11 @@ const { GeminiLLM } = require("../AiProviders/gemini");
 const { fetchCometApiModels } = require("../AiProviders/cometapi");
 const { getDockerModels } = require("../AiProviders/dockerModelRunner");
 const { getAllLemonadeModels } = require("../AiProviders/lemonade");
+const { listAzureDeployments } = require("../AiProviders/azureOpenAi/models");
 
 const SUPPORT_CUSTOM_MODELS = [
   "openai",
+  "azure",
   "anthropic",
   "localai",
   "ollama",
@@ -134,6 +136,8 @@ async function getCustomModels(
       return await getMoonshotAiModels(apiKey);
     case "foundry":
       return await getFoundryModels(basePath);
+    case "azure":
+      return await azureDeployments(basePath, apiKey, options);
     case "cohere":
       return await getCohereModels(apiKey, "chat");
     case "zai":
@@ -945,6 +949,25 @@ async function getMoonshotAiModels(_apiKey = null) {
  * models module for how that is determined and what each one can report.
  * @see {@link ../AiProviders/foundry/models}
  */
+/**
+ * Azure addresses models by deployment name, which is chosen by whoever created
+ * the deployment, so the only way to offer a picker is to ask the resource.
+ * @param {string|null} basePath - The Azure resource endpoint.
+ * @param {string|null} apiKey
+ * @param {{connectionMethod: string|null, managedIdentityClientId: string|null}} options
+ * @returns {Promise<{models: Array, error: string|null}>}
+ */
+async function azureDeployments(basePath = null, apiKey = null, options = {}) {
+  return await listAzureDeployments({
+    endpoint: basePath,
+    // A saved key reaches the frontend as `true` rather than the secret itself,
+    // in which case the stored value is the one to use.
+    apiKey: typeof apiKey === "boolean" ? null : apiKey,
+    connectionMethod: options?.connectionMethod ?? null,
+    managedIdentityClientId: options?.managedIdentityClientId ?? null,
+  });
+}
+
 async function getFoundryModels(basePath = null) {
   try {
     const FoundryModels = require("../AiProviders/foundry/models");

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -33,6 +33,14 @@ const KEY_MAPPING = {
     envKey: "AZURE_OPENAI_KEY",
     checks: [isNotEmpty],
   },
+  AzureOpenAiConnectionMethod: {
+    envKey: "AZURE_OPENAI_CONNECTION_METHOD",
+    checks: [validAzureConnectionMethod],
+  },
+  AzureOpenAiManagedIdentityClientId: {
+    envKey: "AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID",
+    checks: [],
+  },
   AzureOpenAiModelPref: {
     envKey: "AZURE_OPENAI_MODEL_PREF",
     checks: [isNotEmpty],
@@ -1205,6 +1213,12 @@ function validChromaURL(input = "") {
   return input.slice(-1) === "/"
     ? `Chroma Instance URL should not end in a trailing slash.`
     : null;
+}
+
+function validAzureConnectionMethod(input = "") {
+  return ["api_key", "managed_identity"].includes(input)
+    ? null
+    : "Invalid connection method. Must be one of: api_key, managed_identity.";
 }
 
 function validOpenAiTokenLimit(input = "") {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -77,6 +77,22 @@
   dependencies:
     tslib "^2.6.2"
 
+"@azure/abort-controller@^2.0.0", "@azure/abort-controller@^2.1.2":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-2.2.0.tgz#93e0e82b01862e7ea3b5b69958719d3f3fd2c8ac"
+  integrity sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@azure/core-auth@^1.10.0", "@azure/core-auth@^1.9.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.11.0.tgz#1daeffdf62d1a871d22b865f9f3164a63ea1f575"
+  integrity sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-util" "^1.13.0"
+    tslib "^2.6.2"
+
 "@azure/core-auth@^1.3.0", "@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0":
   version "1.7.2"
   resolved "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz"
@@ -97,6 +113,19 @@
     "@azure/core-tracing" "^1.0.0"
     "@azure/core-util" "^1.6.1"
     "@azure/logger" "^1.0.0"
+    tslib "^2.6.2"
+
+"@azure/core-client@^1.9.2":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-client/-/core-client-1.11.0.tgz#e73d09ac7977de5d7b415696b7ed45d3fdeb67b0"
+  integrity sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-rest-pipeline" "^1.22.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@azure/core-util" "^1.13.0"
+    "@azure/logger" "^1.3.0"
     tslib "^2.6.2"
 
 "@azure/core-http-compat@^2.0.1":
@@ -125,6 +154,11 @@
   dependencies:
     tslib "^2.6.2"
 
+"@azure/core-process@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-process/-/core-process-1.0.0.tgz#c3af1c17223d6538e1b36967ddc94cdae532cb83"
+  integrity sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==
+
 "@azure/core-rest-pipeline@^1.1.0", "@azure/core-rest-pipeline@^1.3.0", "@azure/core-rest-pipeline@^1.8.1", "@azure/core-rest-pipeline@^1.9.1":
   version "1.16.0"
   resolved "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz"
@@ -139,10 +173,30 @@
     https-proxy-agent "^7.0.0"
     tslib "^2.6.2"
 
+"@azure/core-rest-pipeline@^1.17.0", "@azure/core-rest-pipeline@^1.22.0":
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz#92ea4912edbb1f7395f4829a300631174aa82f08"
+  integrity sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@azure/core-util" "^1.13.0"
+    "@azure/logger" "^1.3.0"
+    "@typespec/ts-http-runtime" "^0.3.4"
+    tslib "^2.6.2"
+
 "@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.0.1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz"
   integrity sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@azure/core-tracing@^1.0.0", "@azure/core-tracing@^1.3.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.4.0.tgz#d657a700e24d256d195e628a795db6a8cc475eab"
+  integrity sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==
   dependencies:
     tslib "^2.6.2"
 
@@ -152,6 +206,15 @@
   integrity sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==
   dependencies:
     "@azure/abort-controller" "^2.0.0"
+    tslib "^2.6.2"
+
+"@azure/core-util@^1.11.0", "@azure/core-util@^1.13.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.14.0.tgz#7ce9fe57958f132dd422573856e5a45c7232bb04"
+  integrity sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@typespec/ts-http-runtime" "^0.3.0"
     tslib "^2.6.2"
 
 "@azure/identity@^3.4.1":
@@ -172,6 +235,24 @@
     jws "^4.0.0"
     open "^8.0.0"
     stoppable "^1.1.0"
+    tslib "^2.2.0"
+
+"@azure/identity@^4.13.2":
+  version "4.13.2"
+  resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-4.13.2.tgz#cead7e69ff586dc28bebbaea2201b6bb6960b84f"
+  integrity sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==
+  dependencies:
+    "@azure/abort-controller" "^2.0.0"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-client" "^1.9.2"
+    "@azure/core-process" "^1.0.0"
+    "@azure/core-rest-pipeline" "^1.17.0"
+    "@azure/core-tracing" "^1.0.0"
+    "@azure/core-util" "^1.11.0"
+    "@azure/logger" "^1.0.0"
+    "@azure/msal-browser" "^5.5.0"
+    "@azure/msal-node" "^5.1.5"
+    open "^10.1.0"
     tslib "^2.2.0"
 
 "@azure/keyvault-keys@^4.4.0":
@@ -198,6 +279,14 @@
   dependencies:
     tslib "^2.6.2"
 
+"@azure/logger@^1.0.0", "@azure/logger@^1.3.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.4.0.tgz#3d5a627fe59a276ece7487a79dd92ad5c508c339"
+  integrity sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==
+  dependencies:
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
 "@azure/msal-browser@^3.5.0":
   version "3.14.0"
   resolved "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.14.0.tgz"
@@ -205,10 +294,22 @@
   dependencies:
     "@azure/msal-common" "14.10.0"
 
+"@azure/msal-browser@^5.5.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-5.19.0.tgz#704db6388d1b72aad722166f0f17786071fe62df"
+  integrity sha512-DHe9iRcyByGJuLPkl0K31a1JjOdRY2zX38Q07mQpSbR8zOj1EIgsWfTXhSQVyyijUxlcofVy/br7qWJbrMwVXQ==
+  dependencies:
+    "@azure/msal-common" "16.13.0"
+
 "@azure/msal-common@14.10.0":
   version "14.10.0"
   resolved "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.10.0.tgz"
   integrity sha512-Zk6DPDz7e1wPgLoLgAp0349Yay9RvcjPM5We/ehuenDNsz/t9QEFI7tRoHpp/e47I4p20XE3FiDlhKwAo3utDA==
+
+"@azure/msal-common@16.13.0":
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-16.13.0.tgz#62e424c6b21e143e8ef4374a64dbf8772dfe1a07"
+  integrity sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==
 
 "@azure/msal-node@^2.5.1":
   version "2.8.1"
@@ -218,6 +319,14 @@
     "@azure/msal-common" "14.10.0"
     jsonwebtoken "^9.0.0"
     uuid "^8.3.0"
+
+"@azure/msal-node@^5.1.5":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-5.6.0.tgz#8cbfeff021b6d2f3d064a3afb82262ad985e8434"
+  integrity sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==
+  dependencies:
+    "@azure/msal-common" "16.13.0"
+    jsonwebtoken "^9.0.0"
 
 "@babel/runtime@^7.10.5":
   version "7.24.7"
@@ -1161,6 +1270,15 @@
   resolved "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz"
   integrity sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==
 
+"@typespec/ts-http-runtime@^0.3.0", "@typespec/ts-http-runtime@^0.3.4":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz#b4dee5a5e7971aedc70953bb7d2dbf5783f42d38"
+  integrity sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==
+  dependencies:
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.0"
+    tslib "^2.6.2"
+
 "@vscode/ripgrep@1.17.1":
   version "1.17.1"
   resolved "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz"
@@ -1247,6 +1365,11 @@ agent-base@^7.0.2, agent-base@^7.1.0:
   integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
   dependencies:
     debug "^4.3.4"
+
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 agent-base@^7.1.2:
   version "7.1.4"
@@ -1817,6 +1940,11 @@ buffer-equal-constant-time@1.0.1:
   resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
@@ -1847,6 +1975,13 @@ buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==
+
+bundle-name@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-4.1.0.tgz#f3b96b34160d6431a19d7688135af7cfb8797889"
+  integrity sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==
+  dependencies:
+    run-applescript "^7.0.0"
 
 busboy@^1.0.0:
   version "1.6.0"
@@ -2458,6 +2593,13 @@ debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+debug@4, debug@^4.3.4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
@@ -2504,6 +2646,19 @@ deepmerge@^4.2.2:
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
+default-browser-id@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-5.0.1.tgz#f7a7ccb8f5104bf8e0f71ba3b1ccfa5eafdb21e8"
+  integrity sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==
+
+default-browser@^5.2.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-5.5.1.tgz#1790affc52680fbb11e17cab2752d69aa2a37d2c"
+  integrity sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==
+  dependencies:
+    bundle-name "^4.1.0"
+    default-browser-id "^5.0.0"
+
 default-shell@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/default-shell/-/default-shell-2.2.0.tgz"
@@ -2522,6 +2677,11 @@ define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
@@ -3927,6 +4087,14 @@ http-errors@^2.0.0, http-errors@~2.0.0, http-errors@~2.0.1:
     statuses "~2.0.2"
     toidentifier "~1.0.1"
 
+http-proxy-agent@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
@@ -4220,6 +4388,11 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
+
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
@@ -4269,6 +4442,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
 
 is-invalid-path@^0.1.0:
   version "0.1.0"
@@ -4466,6 +4646,13 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+is-wsl@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.1.tgz#327897b26832a3eb117da6c27492d04ca132594f"
+  integrity sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==
+  dependencies:
+    is-inside-container "^1.0.0"
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -4713,6 +4900,15 @@ jwa@^2.0.0:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
 jws@^3.2.2:
   version "3.2.2"
   resolved "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz"
@@ -4727,6 +4923,14 @@ jws@^4.0.0:
   integrity sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==
   dependencies:
     jwa "^2.0.0"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+  dependencies:
+    jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
 keyv@^4.5.4:
@@ -5238,6 +5442,11 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 mssql@^10.0.2:
   version "10.0.2"
   resolved "https://registry.npmjs.org/mssql/-/mssql-10.0.2.tgz"
@@ -5607,6 +5816,16 @@ onnxruntime-web@1.14.0:
     onnx-proto "^4.0.4"
     onnxruntime-common "~1.14.0"
     platform "^1.3.6"
+
+open@^10.1.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-10.2.0.tgz#b9d855be007620e80b6fb05fac98141fe62db73c"
+  integrity sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==
+  dependencies:
+    default-browser "^5.2.1"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    wsl-utils "^0.1.0"
 
 open@^8.0.0:
   version "8.4.2"
@@ -6422,6 +6641,11 @@ rrweb-cssom@^0.8.0:
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
   integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
 
+run-applescript@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.1.0.tgz#2e9e54c4664ec3106c5b5630e249d3d6595c4911"
+  integrity sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==
+
 rusha@^0.8.14:
   version "0.8.14"
   resolved "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz"
@@ -6451,6 +6675,11 @@ safe-array-concat@^1.1.3:
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
@@ -6534,6 +6763,11 @@ semver@^7.3.5, semver@^7.5.4:
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.5.4:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 semver@~7.0.0:
   version "7.0.0"
@@ -7833,6 +8067,13 @@ ws@^8.18.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+
+wsl-utils@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/wsl-utils/-/wsl-utils-0.1.0.tgz#8783d4df671d4d50365be2ee4c71917a0557baab"
+  integrity sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==
+  dependencies:
+    is-wsl "^3.1.0"
 
 xml-js@^1.6.8:
   version "1.6.11"


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #6172

### Description

The Azure OpenAI (Azure AI Foundry) provider can only authenticate with a static API key today. That forces a long-lived secret onto installs running on Azure, and it makes the provider **unusable entirely** against a resource configured with `disableLocalAuth: true`, which a lot of organizations require.

This adds Microsoft Entra ID / managed identity as an alternative — the Azure counterpart to the IAM-role option #2632 once added for Bedrock.

**New settings**

| Env var | Values | Notes |
| --- | --- | --- |
| `AZURE_OPENAI_CONNECTION_METHOD` | `api_key` (default) \| `managed_identity` | The default preserves today's behavior exactly |
| `AZURE_OPENAI_MANAGED_IDENTITY_CLIENT_ID` | optional | Client ID of a user-assigned managed identity; leave empty for the system-assigned one |

With `managed_identity`, `AZURE_OPENAI_KEY` is no longer required and every Azure client authenticates with a token for the `https://cognitiveservices.azure.com/.default` scope from `DefaultAzureCredential`.

**How the token gets onto the request**

`server/utils/AiProviders/azureOpenAi/credentials.js` is a small shared module that all four Azure client construction sites now go through:

- The LLM, the agent provider and the LangChain client use the plain `OpenAI` client against Azure's v1 surface, which already sends `Authorization: Bearer <apiKey>` — the exact header Entra needs. But an Entra token expires while `apiKey` is fixed at construction, so these get a `fetch` wrapper that sets the header from the token provider on every request. `getBearerTokenProvider` caches the token and refreshes it ahead of expiry, and the credential itself is built once per process (rebuilt only if the configured client ID changes).
- The embedder uses the SDK's `AzureOpenAI` class, which accepts `azureADTokenProvider` directly and handles refresh itself.

`DefaultAzureCredential` also resolves environment credentials, AKS workload identity and a developer's `az login` session, so the one setting works in production and locally without a second code path.

**Backwards compatibility**

`AZURE_OPENAI_CONNECTION_METHOD` defaults to `api_key`. Existing installs are untouched — the key stays required, and the "No Azure API key was set." error is unchanged in that mode.

**Files touched**

- new `server/utils/AiProviders/azureOpenAi/credentials.js` — the shared credential logic
- `server/utils/AiProviders/azureOpenAi/index.js`, `server/utils/EmbeddingEngines/azureOpenAi/index.js`, `server/utils/agents/aibitat/providers/azure.js`, `server/utils/agents/aibitat/providers/ai-provider.js` — build clients through it
- `server/utils/agents/index.js` — agent preflight no longer demands a key under managed identity
- `server/utils/helpers/updateENV.js`, `server/models/systemSettings.js` — register and expose the two new settings
- both `AzureAiOptions` components — a Connection Method selector that swaps the API Key field for an optional Managed Identity Client ID field
- `frontend/src/locales/en/common.js`, `docker/.env.example` — labels and documentation
- `server/package.json` / `server/yarn.lock` — adds `@azure/identity`

### Visuals (if applicable)

The LLM and embedder settings panes gain a **Connection Method** dropdown (`API Key` / `Managed Identity`) next to the Azure Service Endpoint. Selecting `Managed Identity` replaces the API Key input with an optional **Managed Identity Client ID** input; selecting `API Key` restores the original form unchanged.

### Additional Information

Two design questions from the issue that I resolved one way to keep the PR concrete — happy to change either:

1. **One `managed_identity` value backed by `DefaultAzureCredential`**, rather than separate `managed_identity` / `default_credential` values. It keeps the UI to a single choice and makes local development work without a second setting. Easy to split if you would rather be explicit.
2. **The embedder is included**, since it shares `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_KEY` with the LLM and would otherwise still demand a key against a resource that has none.

Also worth flagging: #2632's `AWS_BEDROCK_LLM_CONNECTION_METHOD` no longer exists — Bedrock was since refactored onto the Mantle API with a plain key. I cited it as the design precedent, not as live code to match.

`@azure/identity` is a new server dependency (~4.13.2). `server/yarn.lock` is updated with its subtree; the diff is additions only.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally

On the last two, so you know exactly what has and has not been exercised:

- I added `server/__tests__/utils/AiProviders/azureOpenAi/credentials.test.js` (11 tests, passing) covering both connection methods, the bearer header being set per request, caller headers/`signal`/body surviving the fetch wrapper, system- vs user-assigned identity selection, and credential rebuild when the client ID changes. The pre-existing `azureOpenAiModelPref` suite still passes.
- **I have not tested this end to end against a live Azure resource with a managed identity**, and I have not run a Docker build. If that verification is a merge requirement, tell me and I will run it against a real deployment before you spend review time on this.
- On lint: I verified Prettier formatting over every changed file rather than running the full `yarn lint`, which needs a complete workspace install.
