### PR TITLE
Route Bedrock cross-region inference profiles via bedrock-runtime

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -110,6 +110,11 @@ GID='1000'
 # AWS_BEDROCK_LLM_MODEL_PREFERENCE=global.anthropic.claude-haiku-4-5-20251001-v1:0
 # AWS_BEDROCK_LLM_MODEL_TOKEN_LIMIT='128000'
 # AWS_BEDROCK_STREAMING_DISABLED=1
+# Optional endpoint host overrides for air-gapped/specialized AWS partitions
+# (eg: ISO/C2S) whose domains do not follow the commercial naming scheme.
+# AWS_BEDROCK_LLM_MANTLE_ENDPOINT='https://bedrock-mantle.us-west-2.api.aws'
+# AWS_BEDROCK_LLM_RUNTIME_ENDPOINT='https://bedrock-runtime.us-west-2.amazonaws.com'
+# AWS_BEDROCK_LLM_CONTROL_ENDPOINT='https://bedrock.us-west-2.amazonaws.com'
 
 # LLM_PROVIDER='fireworksai'
 # FIREWORKS_AI_LLM_API_KEY='my-fireworks-ai-key'

--- a/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
@@ -3,10 +3,19 @@ import { AWS_REGIONS } from "./regions";
 import { useState, useEffect } from "react";
 import System from "@/models/system";
 
+const MANUAL_REGION_ENTRY = "-- Enter region manually --";
+
 export default function AwsBedrockLLMOptions({ settings }) {
   const [inputValue, setInputValue] = useState(settings?.AwsBedrockLLMApiKey);
   const [apiKey, setApiKey] = useState(settings?.AwsBedrockLLMApiKey);
   const [region, setRegion] = useState(settings?.AwsBedrockLLMRegion);
+  // A saved region outside the known list (eg: GovCloud or other specialized
+  // regions set via ENV/Helm) can only render via manual entry - a select
+  // with no matching option would silently fall back to the first region.
+  const [manualRegion, setManualRegion] = useState(
+    !!settings?.AwsBedrockLLMRegion &&
+      !AWS_REGIONS.some((r) => r.code === settings.AwsBedrockLLMRegion)
+  );
 
   return (
     <div className="w-full flex flex-col">
@@ -53,22 +62,54 @@ export default function AwsBedrockLLMOptions({ settings }) {
           <label className="text-white text-sm font-semibold block mb-3">
             AWS Region
           </label>
-          <select
-            name="AwsBedrockLLMRegion"
-            value={region}
-            required={true}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-            onChange={(e) => setRegion(e.target.value)}
-            onBlur={() => setRegion(region)}
-          >
-            {AWS_REGIONS.map((region) => {
-              return (
-                <option key={region.code} value={region.code}>
-                  {region.name} ({region.code})
-                </option>
-              );
-            })}
-          </select>
+          {manualRegion ? (
+            <>
+              <input
+                type="text"
+                name="AwsBedrockLLMRegion"
+                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                placeholder="us-gov-west-1"
+                defaultValue={region}
+                required={true}
+                autoComplete="off"
+                spellCheck={false}
+                onChange={(e) => setRegion(e.target.value)}
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  if (!AWS_REGIONS.some((r) => r.code === region))
+                    setRegion(AWS_REGIONS[0].code);
+                  setManualRegion(false);
+                }}
+                className="text-white/60 hover:text-white text-xs text-left mt-1.5 underline w-fit"
+              >
+                Select from available regions
+              </button>
+            </>
+          ) : (
+            <select
+              name="AwsBedrockLLMRegion"
+              value={region}
+              required={true}
+              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              onChange={(e) => {
+                if (e.target.value === MANUAL_REGION_ENTRY)
+                  return setManualRegion(true);
+                setRegion(e.target.value);
+              }}
+            >
+              {AWS_REGIONS.map((region) => {
+                return (
+                  <option key={region.code} value={region.code}>
+                    {region.name} ({region.code})
+                  </option>
+                );
+              })}
+              <option disabled={true}>──────────</option>
+              <option value={MANUAL_REGION_ENTRY}>{MANUAL_REGION_ENTRY}</option>
+            </select>
+          )}
         </div>
       </div>
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -116,6 +116,11 @@ SIG_SALT='salt' # Please generate random string at least 32 chars long.
 # AWS_BEDROCK_LLM_MODEL_PREFERENCE=global.anthropic.claude-haiku-4-5-20251001-v1:0
 # AWS_BEDROCK_LLM_MODEL_TOKEN_LIMIT='128000'
 # AWS_BEDROCK_STREAMING_DISABLED=1
+# Optional endpoint host overrides for air-gapped/specialized AWS partitions
+# (eg: ISO/C2S) whose domains do not follow the commercial naming scheme.
+# AWS_BEDROCK_LLM_MANTLE_ENDPOINT='https://bedrock-mantle.us-west-2.api.aws'
+# AWS_BEDROCK_LLM_RUNTIME_ENDPOINT='https://bedrock-runtime.us-west-2.amazonaws.com'
+# AWS_BEDROCK_LLM_CONTROL_ENDPOINT='https://bedrock.us-west-2.amazonaws.com'
 
 # LLM_PROVIDER='apipie'
 # APIPIE_LLM_API_KEY='sk-123abc'

--- a/server/utils/AiProviders/bedrock/endpoints.js
+++ b/server/utils/AiProviders/bedrock/endpoints.js
@@ -1,0 +1,117 @@
+/**
+ * AWS Bedrock exposes two HTTP endpoint surfaces that both accept Bedrock API
+ * key (bearer) auth, but with disjoint model ID support:
+ *
+ * - `bedrock-mantle.{region}.api.aws` - the Mantle catalog. Accepts plain
+ *   catalog IDs (eg: `anthropic.claude-haiku-4-5`, `minimax.minimax-m2.1`)
+ *   but rejects cross-region inference profile IDs. Only exists in a subset
+ *   of regions.
+ * - `bedrock-runtime.{region}.amazonaws.com` - the primary runtime. Its
+ *   `/anthropic` route accepts cross-region inference profile IDs
+ *   (eg: `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`) but rejects plain
+ *   catalog IDs for models without on-demand throughput. Exists in every
+ *   region where Bedrock is offered, including GovCloud.
+ *
+ * In many regions (eg: EU) Claude is ONLY available via cross-region
+ * inference profiles, so we route by model ID shape: geo-prefixed profile
+ * IDs go to bedrock-runtime, everything else keeps the Mantle path.
+ *
+ * The `bedrock.{region}.amazonaws.com` control plane also accepts bearer
+ * auth and is used to list inference profiles the Mantle catalog omits.
+ *
+ * Each host can be overridden via env for air-gapped partitions (ISO/C2S)
+ * whose domains do not follow the commercial naming scheme.
+ */
+
+// Geography prefixes AWS uses for system-defined cross-region inference
+// profiles. Vendor prefixes (anthropic., meta., mistral., ...) never collide.
+const INFERENCE_PROFILE_PREFIXES = [
+  "us.",
+  "eu.",
+  "apac.",
+  "global.",
+  "us-gov.",
+  "jp.",
+  "au.",
+  "ca.",
+];
+
+/**
+ * Whether a model ID is a cross-region inference profile ID.
+ * @param {string|null} modelId
+ * @returns {boolean}
+ */
+function isInferenceProfileId(modelId = "") {
+  if (!modelId) return false;
+  return INFERENCE_PROFILE_PREFIXES.some((prefix) =>
+    modelId.startsWith(prefix)
+  );
+}
+
+/**
+ * Base host for the Mantle (OpenAI-compatible catalog) endpoint.
+ * @param {string} region
+ * @returns {string}
+ */
+function mantleHost(region) {
+  return (
+    process.env.AWS_BEDROCK_LLM_MANTLE_ENDPOINT ||
+    `https://bedrock-mantle.${region}.api.aws`
+  );
+}
+
+/**
+ * Base host for the bedrock-runtime endpoint.
+ * @param {string} region
+ * @returns {string}
+ */
+function runtimeHost(region) {
+  return (
+    process.env.AWS_BEDROCK_LLM_RUNTIME_ENDPOINT ||
+    `https://bedrock-runtime.${region}.amazonaws.com`
+  );
+}
+
+/**
+ * Base host for the Bedrock control plane (model/profile listing).
+ * @param {string} region
+ * @returns {string}
+ */
+function controlPlaneHost(region) {
+  return (
+    process.env.AWS_BEDROCK_LLM_CONTROL_ENDPOINT ||
+    `https://bedrock.${region}.amazonaws.com`
+  );
+}
+
+/**
+ * OpenAI-compatible base URL for chat completions.
+ * @param {string} region
+ * @returns {string}
+ */
+function openaiBaseURL(region) {
+  return `${mantleHost(region)}/v1`;
+}
+
+/**
+ * Anthropic Messages API base URL for the given model. Cross-region
+ * inference profile IDs are only served by bedrock-runtime; plain catalog
+ * IDs are only served by Mantle.
+ * @param {string} region
+ * @param {string|null} modelId
+ * @returns {string}
+ */
+function anthropicBaseURL(region, modelId = "") {
+  return isInferenceProfileId(modelId)
+    ? `${runtimeHost(region)}/anthropic`
+    : `${mantleHost(region)}/anthropic`;
+}
+
+module.exports = {
+  isInferenceProfileId,
+  mantleHost,
+  runtimeHost,
+  controlPlaneHost,
+  openaiBaseURL,
+  anthropicBaseURL,
+};

--- a/server/utils/AiProviders/bedrock/index.js
+++ b/server/utils/AiProviders/bedrock/index.js
@@ -10,6 +10,7 @@ const {
   buildAnthropicParams,
   handleAnthropicChatStream,
 } = require("./anthropicChat");
+const { openaiBaseURL, anthropicBaseURL } = require("./endpoints");
 
 class AWSBedrockLLM {
   noSystemPromptModels = [
@@ -46,14 +47,14 @@ class AWSBedrockLLM {
 
     this.openai = new OpenAIApi({
       apiKey: process.env.AWS_BEDROCK_LLM_API_KEY,
-      baseURL: `https://bedrock-mantle.${this.region}.api.aws/v1`,
+      baseURL: openaiBaseURL(this.region),
     });
 
     if (this.model?.includes("anthropic")) {
       const AnthropicAI = require("@anthropic-ai/sdk");
       this.anthropic = new AnthropicAI({
         apiKey: process.env.AWS_BEDROCK_LLM_API_KEY,
-        baseURL: `https://bedrock-mantle.${this.region}.api.aws/anthropic`,
+        baseURL: anthropicBaseURL(this.region, this.model),
         defaultHeaders: { "anthropic-version": "2023-06-01" },
       });
     }

--- a/server/utils/AiProviders/bedrock/index.js
+++ b/server/utils/AiProviders/bedrock/index.js
@@ -12,6 +12,37 @@ const {
 } = require("./anthropicChat");
 const { openaiBaseURL, anthropicBaseURL } = require("./endpoints");
 
+/**
+ * Bedrock's OpenAI-compatible stream reports usage in a final chunk that
+ * arrives AFTER the `finish_reason` chunk, but the default stream handler
+ * stops reading at the first `finish_reason` and would never see it -
+ * leaving metrics to be estimated at one token per visible chunk, which
+ * wildly undercounts reasoning models. This holds back only the
+ * `finish_reason` chunk and merges the trailing usage chunk into it before
+ * yielding, so real usage reaches the handler. Normal token chunks pass
+ * through without delay.
+ * @param {AsyncIterable<object>} stream
+ */
+async function* mergeTrailingUsageChunk(stream) {
+  let held = null;
+  for await (const chunk of stream) {
+    if (held) {
+      const usageOnly =
+        (!chunk?.choices || chunk.choices.length === 0) && !!chunk?.usage;
+      if (usageOnly) held.usage = chunk.usage;
+      yield held;
+      held = null;
+      if (usageOnly) continue;
+    }
+    if (!!chunk?.choices?.[0]?.finish_reason && !chunk?.usage) {
+      held = chunk;
+      continue;
+    }
+    yield chunk;
+  }
+  if (held) yield held;
+}
+
 class AWSBedrockLLM {
   noSystemPromptModels = [
     "amazon.titan-text-express-v1",
@@ -244,9 +275,10 @@ class AWSBedrockLLM {
       messages,
       temperature: this.temperatureParam(temperature),
       stream: true,
+      stream_options: { include_usage: true },
     });
     return await LLMPerformanceMonitor.measureStream({
-      func: stream,
+      func: mergeTrailingUsageChunk(stream),
       messages,
       modelTag: this.model,
       provider: this.className,

--- a/server/utils/agents/aibitat/providers/bedrock.js
+++ b/server/utils/agents/aibitat/providers/bedrock.js
@@ -9,6 +9,10 @@ const {
   anthropicTooledComplete,
 } = require("./helpers/anthropicTooled.js");
 const { RetryError } = require("../error.js");
+const {
+  openaiBaseURL,
+  anthropicBaseURL,
+} = require("../../../AiProviders/bedrock/endpoints.js");
 
 /**
  * The agent provider for the AWS Bedrock provider.
@@ -24,7 +28,7 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
       config.model || process.env.AWS_BEDROCK_LLM_MODEL_PREFERENCE || null;
     const region = process.env.AWS_BEDROCK_LLM_REGION;
     const client = new OpenAI({
-      baseURL: `https://bedrock-mantle.${region}.api.aws/v1`,
+      baseURL: openaiBaseURL(region),
       apiKey: process.env.AWS_BEDROCK_LLM_API_KEY,
     });
 
@@ -37,7 +41,7 @@ class AWSBedrockProvider extends InheritMultiple([Provider, UnTooled]) {
     if (this.model?.includes("anthropic")) {
       this._anthropic = new Anthropic({
         apiKey: process.env.AWS_BEDROCK_LLM_API_KEY,
-        baseURL: `https://bedrock-mantle.${region}.api.aws/anthropic`,
+        baseURL: anthropicBaseURL(region, this.model),
         defaultHeaders: { "anthropic-version": "2023-06-01" },
       });
     }

--- a/server/utils/helpers/customModels.js
+++ b/server/utils/helpers/customModels.js
@@ -1365,26 +1365,62 @@ async function getBedrockModels(_apiKey = null, options = {}) {
       options?.region || process.env.AWS_BEDROCK_LLM_REGION || "us-west-2";
 
     const { OpenAI: OpenAIApi } = require("openai");
+    const {
+      openaiBaseURL,
+      controlPlaneHost,
+    } = require("../AiProviders/bedrock/endpoints");
     const openai = new OpenAIApi({
       apiKey,
-      baseURL: `https://bedrock-mantle.${region}.api.aws/v1`,
+      baseURL: openaiBaseURL(region),
     });
-    const models = await openai.models
+
+    // The Mantle catalog listing omits cross-region inference profiles
+    // (eg: `eu.anthropic.*`), which are the only way to run Claude in many
+    // regions, and does not exist at all in some regions (eg: GovCloud East).
+    // The control plane accepts the same bearer key and lists them, so both
+    // sources are merged. Only Anthropic profiles are listed since profile
+    // IDs are only routable through the bedrock-runtime `/anthropic` path.
+    const catalogModels = await openai.models
       .list()
       .then((results) => results.data)
       .then((models) =>
-        models
-          .map((model) => ({
-            id: model.id,
-            name: model.id,
-            organization: model.owned_by ?? "AWS Bedrock",
-          }))
-          .sort((a, b) => a.name.localeCompare(b.name))
+        models.map((model) => ({
+          id: model.id,
+          name: model.id,
+          organization: model.owned_by ?? "AWS Bedrock",
+        }))
       )
       .catch((e) => {
         console.error(`AWSBedrock:listModels`, e.message);
         return [];
       });
+
+    const profileModels = await fetch(
+      `${controlPlaneHost(region)}/inference-profiles?maxResults=1000`,
+      { headers: { Authorization: `Bearer ${apiKey}` } }
+    )
+      .then((res) => (res.ok ? res.json() : { inferenceProfileSummaries: [] }))
+      .then((data) =>
+        (data.inferenceProfileSummaries ?? [])
+          .filter(
+            (profile) =>
+              profile.status === "ACTIVE" &&
+              profile.inferenceProfileId.includes("anthropic.")
+          )
+          .map((profile) => ({
+            id: profile.inferenceProfileId,
+            name: profile.inferenceProfileId,
+            organization: "Cross-Region Inference Profiles",
+          }))
+      )
+      .catch((e) => {
+        console.error(`AWSBedrock:listInferenceProfiles`, e.message);
+        return [];
+      });
+
+    const models = [...catalogModels, ...profileModels].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
 
     if (models.length > 0 && !!apiKey)
       process.env.AWS_BEDROCK_LLM_API_KEY = apiKey;


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [x] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #6179

### Description

Mantle rejects cross-region inference profile IDs (eu./us./global.*), which are the only way to run Claude in many regions (all of EU). The bedrock-runtime endpoint serves the same Anthropic Messages API with the same bearer API key and accepts profile IDs, so Claude models are now routed by ID shape: geo-prefixed profile IDs go to bedrock-runtime, plain catalog IDs keep the Mantle path unchanged.

Model listing now merges the Mantle catalog with Anthropic inference profiles from the Bedrock control plane (same bearer auth), so profile IDs appear in the model dropdown even though Mantle's listing omits them.

The region selector gains a manual-entry fallback so regions outside the hardcoded list (GovCloud, specialized partitions set via ENV/Helm) no longer render an empty select that clobbers the saved region on save. Optional endpoint host override ENVs added for air-gapped partitions whose domains don't follow commercial naming.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
