### PR TITLE
Prevent unload if under inference workload

### DIFF
--- a/frontend/src/components/Modals/NewWorkspace.jsx
+++ b/frontend/src/components/Modals/NewWorkspace.jsx
@@ -1,7 +1,9 @@
 import React, { useRef, useState } from "react";
 import Workspace from "@/models/workspace";
 import paths from "@/utils/paths";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { REFETCH_WORKSPACES_EVENT } from "@/components/Sidebar/ActiveWorkspaces";
 import Modal, {
   ModalHeader,
   ModalBody,
@@ -12,6 +14,7 @@ import Modal, {
 
 const noop = () => false;
 export default function NewWorkspaceModal({ hideModal = noop }) {
+  const navigate = useNavigate();
   const formEl = useRef(null);
   const [error, setError] = useState(null);
   const { t } = useTranslation();
@@ -23,7 +26,14 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
     for (var [key, value] of form.entries()) data[key] = value;
     const { workspace, message } = await Workspace.new(data);
     if (!!workspace) {
-      window.location.href = paths.workspace.chat(workspace.slug);
+      // Refresh the sidebar list and navigate via the router so
+      // ActiveGenerationGuard can intercept if a response is generating.
+      // If the user cancels the navigation, the workspace still exists and
+      // shows in the sidebar - so close this modal either way.
+      window.dispatchEvent(new CustomEvent(REFETCH_WORKSPACES_EVENT));
+      hideModal();
+      navigate(paths.workspace.chat(workspace.slug));
+      return;
     }
     setError(message);
   };

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
@@ -10,7 +10,7 @@ import {
   X,
 } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
 const THREAD_CALLOUT_DETAIL_WIDTH = 26;
 export default function ThreadItem({
@@ -171,6 +171,7 @@ function OptionsMenu({
   close,
   currentThreadSlug,
 }) {
+  const navigate = useNavigate();
   const menuRef = useRef(null);
 
   // Ref menu options
@@ -246,9 +247,10 @@ function OptionsMenu({
     if (success) {
       showToast("Thread deleted successfully!", "success", { clear: true });
       onRemove(thread.id);
-      // Redirect if deleting the active thread
+      // Redirect if deleting the active thread. Use router navigation so
+      // ActiveGenerationGuard can intercept if a response is generating.
       if (currentThreadSlug === thread.slug) {
-        window.location.href = paths.workspace.chat(workspace.slug);
+        navigate(paths.workspace.chat(workspace.slug));
       }
       return;
     }

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
@@ -7,6 +7,7 @@ import ThreadItem from "./ThreadItem";
 import { useNavigate, useParams } from "react-router-dom";
 import useHoverMetaKey from "./hooks";
 export const THREAD_RENAME_EVENT = "renameThread";
+export const THREAD_FORK_EVENT = "forkToThread";
 
 export default function ThreadContainer({
   workspace,
@@ -38,6 +39,24 @@ export default function ThreadContainer({
       window.removeEventListener(THREAD_RENAME_EVENT, chatHandler);
     };
   }, []);
+
+  // Handle new fork events from chat actions. Forking navigates via the router
+  // now, so a blocked/cancelled navigation would otherwise leave the new thread
+  // missing from this list until the next refetch.
+  useEffect(() => {
+    const forkHandler = () => {
+      if (!workspace?.slug) return;
+      Workspace.threads
+        .all(workspace.slug)
+        .then(({ threads }) => setThreads(threads))
+        .catch((e) => console.error(e));
+    };
+
+    window.addEventListener(THREAD_FORK_EVENT, forkHandler);
+    return () => {
+      window.removeEventListener(THREAD_FORK_EVENT, forkHandler);
+    };
+  }, [workspace?.slug]);
 
   useEffect(() => {
     async function fetchThreads() {

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
@@ -4,7 +4,7 @@ import showToast from "@/utils/toast";
 import { Plus, CircleNotch, Trash } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import ThreadItem from "./ThreadItem";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import useHoverMetaKey from "./hooks";
 export const THREAD_RENAME_EVENT = "renameThread";
 
@@ -12,6 +12,7 @@ export default function ThreadContainer({
   workspace,
   isVirtualThread = false,
 }) {
+  const navigate = useNavigate();
   const { threadSlug = null } = useParams();
   const [threads, setThreads] = useState([]);
   const [defaultThreadHasChats, setDefaultThreadHasChats] = useState(false);
@@ -65,9 +66,10 @@ export default function ThreadContainer({
     await Workspace.threads.deleteBulk(workspace.slug, slugs);
     setThreads((prev) => prev.filter((t) => !t.deleted));
 
-    // Only redirect if current thread is being deleted
+    // Only redirect if current thread is being deleted. Use router navigation
+    // so ActiveGenerationGuard can intercept if a response is generating.
     if (slugs.includes(threadSlug)) {
-      window.location.href = paths.workspace.chat(workspace.slug);
+      navigate(paths.workspace.chat(workspace.slug));
     }
   };
 
@@ -159,12 +161,16 @@ export default function ThreadContainer({
         threads={threads}
         onDelete={handleDeleteAll}
       />
-      <NewThreadButton workspace={workspace} />
+      <NewThreadButton
+        workspace={workspace}
+        onNewThread={(thread) => setThreads((prev) => [...prev, thread])}
+      />
     </div>
   );
 }
 
-function NewThreadButton({ workspace }) {
+function NewThreadButton({ workspace, onNewThread }) {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const onClick = async () => {
     setLoading(true);
@@ -174,9 +180,15 @@ function NewThreadButton({ workspace }) {
       setLoading(false);
       return;
     }
-    window.location.replace(
-      paths.workspace.thread(workspace.slug, thread.slug)
-    );
+    // Show the new thread in the sidebar immediately - if the navigation below
+    // gets blocked (ActiveGenerationGuard) and cancelled, the thread still
+    // exists and remains reachable. Router navigation also ensures the guard
+    // can intercept and the button never wedges in its loading state.
+    onNewThread?.(thread);
+    navigate(paths.workspace.thread(workspace.slug, thread.slug), {
+      replace: true,
+    });
+    setLoading(false);
   };
 
   return (

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
@@ -15,6 +15,8 @@ import showToast from "@/utils/toast";
 import { LAST_VISITED_WORKSPACE } from "@/utils/constants";
 import { safeJsonParse } from "@/utils/request";
 
+export const REFETCH_WORKSPACES_EVENT = "refetchWorkspaces";
+
 export default function ActiveWorkspaces() {
   const navigate = useNavigate();
   const { slug } = useParams();
@@ -33,6 +35,13 @@ export default function ActiveWorkspaces() {
       setWorkspaces(Workspace.orderWorkspaces(workspaces));
     }
     getWorkspaces();
+
+    // Refetch when a workspace is created elsewhere in the app (eg: the
+    // NewWorkspace modal) since those flows navigate via the router and no
+    // longer trigger a full page reload.
+    window.addEventListener(REFETCH_WORKSPACES_EVENT, getWorkspaces);
+    return () =>
+      window.removeEventListener(REFETCH_WORKSPACES_EVENT, getWorkspaces);
   }, []);
 
   if (loading) {

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ActiveGenerationGuard/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ActiveGenerationGuard/index.jsx
@@ -1,4 +1,5 @@
 import { useBlocker } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { ABORT_STREAM_EVENT } from "@/utils/chat";
 import Modal, {
   ModalHeader,
@@ -38,6 +39,7 @@ import Modal, {
  * @param {boolean} props.isGenerating - Whether a response is actively generating (mirrors the Send/Stop button state)
  */
 export default function ActiveGenerationGuard({ isGenerating = false }) {
+  const { t } = useTranslation();
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
       isGenerating && currentLocation.pathname !== nextLocation.pathname
@@ -55,19 +57,21 @@ export default function ActiveGenerationGuard({ isGenerating = false }) {
   if (blocker.state !== "blocked") return null;
   return (
     <Modal isOpen={true} onClose={blocker.reset} size="md">
-      <ModalHeader title="Stop generating response?" onClose={blocker.reset} />
+      <ModalHeader
+        title={t("chat_window.leave_generating.title")}
+        onClose={blocker.reset}
+      />
       <ModalBody>
         <p className="text-sm text-zinc-400 light:text-slate-600">
-          You are about to leave this chat, this will stop the model from
-          generating the response and it cannot be recovered.
+          {t("chat_window.leave_generating.description")}
         </p>
       </ModalBody>
       <ModalFooter>
         <ModalSecondaryButton type="button" onClick={blocker.reset}>
-          Cancel
+          {t("chat_window.leave_generating.cancel")}
         </ModalSecondaryButton>
         <ModalPrimaryButton type="button" onClick={stopGenerationAndLeave}>
-          Continue
+          {t("chat_window.leave_generating.confirm")}
         </ModalPrimaryButton>
       </ModalFooter>
     </Modal>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ActiveGenerationGuard/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ActiveGenerationGuard/index.jsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useBlocker } from "react-router-dom";
+import { ABORT_STREAM_EVENT } from "@/utils/chat";
+import Modal, {
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalPrimaryButton,
+  ModalSecondaryButton,
+} from "@/components/lib/Modal";
+
+/**
+ * Guards against accidentally leaving a chat while a response is actively
+ * generating (eg: the Stop button is showing). Internal route changes are
+ * intercepted via react-router's `useBlocker` and confirmed through a modal.
+ * Closing/refreshing the app entirely is intentionally not guarded - only
+ * in-app navigation. All navigation must go through the router (`navigate`/
+ * `<Link>`) for this guard to intercept it - `window.location` bypasses it.
+ *
+ * The guard is non-blocking: the stream keeps flowing in the background while
+ * the modal is open. Generation is only aborted if the user confirms leaving.
+ *
+ * @note `useBlocker` requires a data router (`createBrowserRouter`/
+ * `createHashRouter`) - plain `<HashRouter>` will throw. See main.jsx.
+ *
+ * @param {Object} props - Component props
+ * @param {boolean} props.isGenerating - Whether a response is actively generating (mirrors the Send/Stop button state)
+ */
+export default function ActiveGenerationGuard({ isGenerating = false }) {
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      isGenerating && currentLocation.pathname !== nextLocation.pathname
+  );
+
+  // If the response finishes while the modal is open there is nothing left
+  // to protect - resume the navigation the user already asked for.
+  useEffect(() => {
+    if (blocker.state === "blocked" && !isGenerating) blocker.proceed();
+  }, [blocker, isGenerating]);
+
+  function stopGenerationAndLeave() {
+    window.dispatchEvent(new CustomEvent(ABORT_STREAM_EVENT));
+    blocker.proceed();
+  }
+
+  if (blocker.state !== "blocked") return null;
+  return (
+    <Modal isOpen={true} onClose={blocker.reset} size="md">
+      <ModalHeader title="Stop generating response?" onClose={blocker.reset} />
+      <ModalBody>
+        <p className="text-sm text-zinc-400 light:text-slate-600">
+          You are about to leave this chat, this will stop the model from
+          generating the response and it cannot be recovered.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <ModalSecondaryButton type="button" onClick={blocker.reset}>
+          Cancel
+        </ModalSecondaryButton>
+        <ModalPrimaryButton type="button" onClick={stopGenerationAndLeave}>
+          Continue
+        </ModalPrimaryButton>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ActiveGenerationGuard/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ActiveGenerationGuard/index.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useBlocker } from "react-router-dom";
 import { ABORT_STREAM_EVENT } from "@/utils/chat";
 import Modal, {
@@ -20,8 +19,20 @@ import Modal, {
  * The guard is non-blocking: the stream keeps flowing in the background while
  * the modal is open. Generation is only aborted if the user confirms leaving.
  *
- * @note `useBlocker` requires a data router (`createBrowserRouter`/
- * `createHashRouter`) - plain `<HashRouter>` will throw. See main.jsx.
+ * @note `useBlocker` constraints - do not lose these as this evolves:
+ * - It requires a data router (`createBrowserRouter`/`createHashRouter`) and
+ *   will THROW at mount inside a plain `<BrowserRouter>`/`<HashRouter>`. See
+ *   main.jsx. The desktop app must use `createHashRouter` for this to work.
+ * - React-router supports only ONE active blocker at a time app-wide. This is
+ *   currently safe because a single ChatContainer mounts this guard - if
+ *   another `useBlocker` is ever added elsewhere (eg: unsaved-form guards),
+ *   they will silently conflict when co-mounted.
+ * - It only intercepts router-driven navigation (`navigate`/`<Link>`),
+ *   including browser back/forward. `window.location.*` navigations and
+ *   reloads bypass it entirely - reloads killing generation is accepted
+ *   behavior, but new in-app navigation must go through the router.
+ * - The `shouldBlock` callback compares pathnames, so same-path query/hash
+ *   changes are deliberately not blocked.
  *
  * @param {Object} props - Component props
  * @param {boolean} props.isGenerating - Whether a response is actively generating (mirrors the Send/Stop button state)
@@ -32,14 +43,12 @@ export default function ActiveGenerationGuard({ isGenerating = false }) {
       isGenerating && currentLocation.pathname !== nextLocation.pathname
   );
 
-  // If the response finishes while the modal is open there is nothing left
-  // to protect - resume the navigation the user already asked for.
-  useEffect(() => {
-    if (blocker.state === "blocked" && !isGenerating) blocker.proceed();
-  }, [blocker, isGenerating]);
-
+  // The modal stays open even if the response finishes while it is showing -
+  // auto-resuming the navigation underneath the user is jarring. They decide
+  // via Cancel/Continue either way, so only emit the abort if a response is
+  // actually still generating.
   function stopGenerationAndLeave() {
-    window.dispatchEvent(new CustomEvent(ABORT_STREAM_EVENT));
+    if (isGenerating) window.dispatchEvent(new CustomEvent(ABORT_STREAM_EVENT));
     blocker.proceed();
   }
 

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -13,8 +13,9 @@ import { ArrowDown } from "@phosphor-icons/react";
 import Chartable from "./Chartable";
 import ModelRouteNotification from "./ModelRouteNotification";
 import Workspace from "@/models/workspace";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import paths from "@/utils/paths";
+import { THREAD_FORK_EVENT } from "@/components/Sidebar/ActiveWorkspaces/ThreadContainer";
 import Appearance from "@/models/appearance";
 import useTextSize from "@/hooks/useTextSize";
 import useAutoScroll from "@/hooks/useAutoScroll";
@@ -39,6 +40,7 @@ export default forwardRef(function (
 ) {
   const { chatHistoryRef, isAtBottom, scrollToBottom, scrollHandlers } =
     useAutoScroll(history, ref);
+  const navigate = useNavigate();
   const { threadSlug = null } = useParams();
   const { showing, hideModal } = useManageWorkspaceModal();
   const { showScrollbar } = Appearance.getSettings();
@@ -113,12 +115,18 @@ export default forwardRef(function (
         threadSlug,
         chatId
       );
-      window.location.href = paths.workspace.thread(
-        workspace.slug,
-        newThreadSlug
+      // Surface the fork in the sidebar first - if the navigation below gets
+      // blocked (ActiveGenerationGuard) and cancelled, the new thread still
+      // exists and stays reachable. Router navigation so the guard can
+      // intercept while a response is generating.
+      window.dispatchEvent(
+        new CustomEvent(THREAD_FORK_EVENT, {
+          detail: { threadSlug: newThreadSlug },
+        })
       );
+      navigate(paths.workspace.thread(workspace.slug, newThreadSlug));
     },
-    [workspace.slug, threadSlug]
+    [workspace.slug, threadSlug, navigate]
   );
 
   const compiledHistory = useMemo(

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -38,6 +38,7 @@ import WorkspaceModelPicker from "./WorkspaceModelPicker";
 import { ChatSidebarProvider } from "./ChatSidebar";
 import SourcesSidebar from "./SourcesSidebar";
 import MemoriesSidebar from "./MemoriesSidebar";
+import ActiveGenerationGuard from "./ActiveGenerationGuard";
 
 export default function ChatContainer({
   workspace,
@@ -514,6 +515,7 @@ export default function ChatContainer({
 
   return (
     <ChatSidebarProvider>
+      <ActiveGenerationGuard isGenerating={loadingResponse} />
       <div
         style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
         className="relative flex md:ml-[2px] md:mr-[16px] md:my-[16px] w-full h-full z-[2]"

--- a/frontend/src/locales/ar/common.js
+++ b/frontend/src/locales/ar/common.js
@@ -1283,6 +1283,13 @@ const TRANSLATIONS = {
     response_failed_reason: "السبب: {{reason}}",
     thought_in_progress: "النموذج يفكر...",
     thoughts: "أفكار",
+    leave_generating: {
+      title: "هل تريد التوقف عن إنشاء ردود؟",
+      description:
+        "أنت على وشك الخروج من هذا المحادثة، وهذا سيمنع النموذج من إنشاء الرد، ولا يمكن استعادته.",
+      cancel: "إلغاء",
+      confirm: "استمر",
+    },
   },
   profile_settings: {
     edit_account: "تحرير الحساب",

--- a/frontend/src/locales/ca/common.js
+++ b/frontend/src/locales/ca/common.js
@@ -1516,6 +1516,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Motiu: {{reason}}",
     thought_in_progress: "L'entrenament continua...",
     thoughts: "Pensaments",
+    leave_generating: {
+      title: "Deu deixar de generar respostes?",
+      description:
+        "Estàs a punt de tancar aquesta conversa; això farà que el model deixi d'elaborar la resposta i no es podrà recuperar.",
+      cancel: "Cancelar",
+      confirm: "Segueix",
+    },
   },
   profile_settings: {
     edit_account: "Edita el compte",

--- a/frontend/src/locales/cs/common.js
+++ b/frontend/src/locales/cs/common.js
@@ -1423,6 +1423,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Důvod: {{reason}}",
     thought_in_progress: "Systém přemýšlí…",
     thoughts: "Myšlenky",
+    leave_generating: {
+      title: "Zastavte generování odpovědi?",
+      description:
+        "Chystáte se tuto konverzaci ukončit. To způsobí zastavení generování odpovědí modelem a není možné ji obnovit.",
+      cancel: "Zrušit",
+      confirm: "Pokračujte",
+    },
   },
   profile_settings: {
     edit_account: "Upravit účet",

--- a/frontend/src/locales/da/common.js
+++ b/frontend/src/locales/da/common.js
@@ -1298,6 +1298,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Årsag: {{reason}}",
     thought_in_progress: "Modellen tænker…",
     thoughts: "Tanker",
+    leave_generating: {
+      title: "Hvilket svar skal jeg ikke generere?",
+      description:
+        "Du er ved at forlade denne samtale. Dette vil stoppe modellen fra at generere et svar, og det kan ikke gendannes.",
+      cancel: "Annullér",
+      confirm: "Fortsæt",
+    },
   },
   profile_settings: {
     edit_account: "Rediger konto",

--- a/frontend/src/locales/de/common.js
+++ b/frontend/src/locales/de/common.js
@@ -1422,6 +1422,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Grund: {{reason}}",
     thought_in_progress: "Das Modell denkt…",
     thoughts: "Gedanken",
+    leave_generating: {
+      title: "Stoppen der Antwortgenerierung?",
+      description:
+        "Sie werden diesen Chat jetzt verlassen. Dadurch wird verhindert, dass das Modell eine Antwort generiert, und dies kann nicht rückgängig gemacht werden.",
+      cancel: "Abbrechen",
+      confirm: "Weiter",
+    },
   },
   profile_settings: {
     edit_account: "Account bearbeiten",

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1666,6 +1666,13 @@ const TRANSLATIONS = {
         cancel: "Cancel",
       },
     },
+    leave_generating: {
+      title: "Stop generating response?",
+      description:
+        "You are about to leave this chat, this will stop the model from generating the response and it cannot be recovered.",
+      cancel: "Cancel",
+      confirm: "Continue",
+    },
   },
   profile_settings: {
     edit_account: "Edit Account",

--- a/frontend/src/locales/es/common.js
+++ b/frontend/src/locales/es/common.js
@@ -1437,6 +1437,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Razón: {{reason}}",
     thought_in_progress: "El modelo está pensando…",
     thoughts: "Ideas, reflexiones",
+    leave_generating: {
+      title: "¿Debe dejar de generar respuestas?",
+      description:
+        "A continuación, finalizará esta conversación, lo que impedirá que el modelo genere una respuesta y no podrá recuperarse.",
+      cancel: "Cancelar",
+      confirm: "Continúa",
+    },
   },
   profile_settings: {
     edit_account: "Editar cuenta",

--- a/frontend/src/locales/et/common.js
+++ b/frontend/src/locales/et/common.js
@@ -1363,6 +1363,13 @@ const TRANSLATIONS = {
     response_failed_reason: "põhjus: {{reason}}",
     thought_in_progress: "Mudel mõtleb…",
     thoughts: "Mõtisklused",
+    leave_generating: {
+      title: "Kas soovite peatada vastuste genereerimise?",
+      description:
+        "Te olete valmis loobuma sellest vestlusest, see peatab mudeli vastuste genereerimise ja seda ei saa enam taastada.",
+      cancel: "Katkuda",
+      confirm: "Jätka",
+    },
   },
   profile_settings: {
     edit_account: "Muuda kontot",

--- a/frontend/src/locales/fa/common.js
+++ b/frontend/src/locales/fa/common.js
@@ -1290,6 +1290,13 @@ const TRANSLATIONS = {
     response_failed_reason: "دلیل: {{reason}}",
     thought_in_progress: "مدل در حال تفکر است...",
     thoughts: "اندیشه‌ها",
+    leave_generating: {
+      title: "چگونه باید پاسخ را متوقف کنم؟",
+      description:
+        "شما در حال خروج از این گفتگو هستید، این کار باعث خواهد شد مدل دیگر پاسخ تولید نکند و امکان بازگشت به حالت قبلی وجود ندارد.",
+      cancel: "لغو کردن",
+      confirm: "ادامه بده",
+    },
   },
   profile_settings: {
     edit_account: "ویرایش حساب",

--- a/frontend/src/locales/fr/common.js
+++ b/frontend/src/locales/fr/common.js
@@ -1327,6 +1327,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Raison : {{reason}}",
     thought_in_progress: "Le modèle réfléchit…",
     thoughts: "Réflexions",
+    leave_generating: {
+      title: "Arrêter de générer une réponse ?",
+      description:
+        "Vous allez bientôt quitter cette conversation. Cela empêchera le modèle de générer une réponse et il ne sera plus possible de récupérer la conversation.",
+      cancel: "Annuler",
+      confirm: "Continuer",
+    },
   },
   profile_settings: {
     edit_account: "Modifier le compte",

--- a/frontend/src/locales/he/common.js
+++ b/frontend/src/locales/he/common.js
@@ -1350,6 +1350,13 @@ const TRANSLATIONS = {
     response_failed_reason: "סיבה: {{reason}}",
     thought_in_progress: "המערכת חושבת…",
     thoughts: "מחשבות",
+    leave_generating: {
+      title: "האם הפסקת לייצר תגובה?",
+      description:
+        "אתם עומדים לצאת מהצ'אט הזה, וזה יגרום למודל להפסיק ליצור את התשובה, ואי אפשר יהיה לשחזר אותה.",
+      cancel: "ביטול",
+      confirm: "המשך",
+    },
   },
   profile_settings: {
     edit_account: "ערוך חשבון",

--- a/frontend/src/locales/hr/common.js
+++ b/frontend/src/locales/hr/common.js
@@ -1670,6 +1670,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Razlog: {{reason}}",
     thought_in_progress: "Model razmišlja...",
     thoughts: "Razmišljanja",
+    leave_generating: {
+      title: "Zaustaviti generiranje odgovora?",
+      description:
+        "O trenutno napuštate ovu razgovornu sesiju. To će zaustaviti generiranje odgovora i ne postoji mogućnost da se to vrati.",
+      cancel: "Otkazati",
+      confirm: "Nastavite",
+    },
   },
   profile_settings: {
     edit_account: "Uredi račun",

--- a/frontend/src/locales/id/common.js
+++ b/frontend/src/locales/id/common.js
@@ -1666,6 +1666,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Alasan: {{reason}}",
     thought_in_progress: "Model sedang berpikir...",
     thoughts: "Pemikiran",
+    leave_generating: {
+      title: "Berhenti menghasilkan respons?",
+      description:
+        "Anda akan segera keluar dari obrolan ini, hal ini akan menghentikan model untuk menghasilkan respons dan tidak dapat dipulihkan.",
+      cancel: "Batalkan",
+      confirm: "Lanjutkan",
+    },
   },
   profile_settings: {
     edit_account: "Edit Akun",

--- a/frontend/src/locales/it/common.js
+++ b/frontend/src/locales/it/common.js
@@ -1329,6 +1329,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Motivo: {{reason}}",
     thought_in_progress: "Il modello sta riflettendo…",
     thoughts: "Pensieri",
+    leave_generating: {
+      title: "Arresto della generazione di risposte?",
+      description:
+        "State per uscire da questa conversazione; questo impedirà al modello di generare una risposta e non sarà più possibile recuperarla.",
+      cancel: "Annulla",
+      confirm: "Continua",
+    },
   },
   profile_settings: {
     edit_account: "Modifica account",

--- a/frontend/src/locales/ja/common.js
+++ b/frontend/src/locales/ja/common.js
@@ -1281,6 +1281,13 @@ const TRANSLATIONS = {
     response_failed_reason: "理由：{{reason}}",
     thought_in_progress: "モデルは思考しています…",
     thoughts: "考え、思索",
+    leave_generating: {
+      title: "応答を停止するには？",
+      description:
+        "あなたは今、このチャットを終了します。これにより、モデルが応答を生成できなくなり、もう回復することはできません。",
+      cancel: "キャンセル",
+      confirm: "続き",
+    },
   },
   profile_settings: {
     edit_account: "アカウントを編集",

--- a/frontend/src/locales/ko/common.js
+++ b/frontend/src/locales/ko/common.js
@@ -1364,6 +1364,13 @@ const TRANSLATIONS = {
     response_failed_reason: "이유: {{reason}}",
     thought_in_progress: "모델은 생각 중입니다…",
     thoughts: "생각들",
+    leave_generating: {
+      title: "응답 생성 중단?",
+      description:
+        "현재 대화를 종료하면 모델이 응답을 생성하는 것을 중단시키고, 이 상태를 되돌릴 수 없습니다.",
+      cancel: "취소",
+      confirm: "계속",
+    },
   },
   profile_settings: {
     edit_account: "계정 정보 수정",

--- a/frontend/src/locales/lo/common.js
+++ b/frontend/src/locales/lo/common.js
@@ -1584,6 +1584,13 @@ const TRANSLATIONS = {
     response_failed_reason: "ສາเหตุ: {{reason}}",
     thought_in_progress: "ແບບนั้น ພາກັນຄິດ",
     thoughts: "ຄວາມຄິດ",
+    leave_generating: {
+      title: "ຢຸດການສ້າງຕອບ?",
+      description:
+        "ເຈົ້າ ກຳ ລັງຈະອອກຈາກການສົນทະນານີ້, ດັ່ງນັ້ນມັນຈະຢຸດ ໂໝດ ໃຫ້ສຳເລັດ ແລະບໍ່ສາມາດຟື້ນຟູໄດ້।",
+      cancel: "ຍົກເລີດ",
+      confirm: "ຊື່ຕໍ່",
+    },
   },
   profile_settings: {
     edit_account: "ແກ້ໄຂບັນຊີ",

--- a/frontend/src/locales/lt/common.js
+++ b/frontend/src/locales/lt/common.js
@@ -1427,6 +1427,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Priežastis: {{reason}}",
     thought_in_progress: "„Modelis mąstė…“",
     thoughts: "Mintys",
+    leave_generating: {
+      title: "Ar sustabdyti atsakymo generavimą?",
+      description:
+        "Jūs šiuo metu pasirenkate išeiti iš šio pokalbio, o tai sustabdys modelį ir jį nebegalės atnaujinti.",
+      cancel: "Anuliu",
+      confirm: "Toliau",
+    },
   },
   profile_settings: {
     edit_account: "Redaguoti paskyrą",

--- a/frontend/src/locales/lv/common.js
+++ b/frontend/src/locales/lv/common.js
@@ -1407,6 +1407,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Iemesls: {{reason}}",
     thought_in_progress: "Modeļim ir domas...",
     thoughts: "Domas",
+    leave_generating: {
+      title: "Kas ir novērst atbildes generēšanu?",
+      description:
+        "Jūs gatavojaties iziet no šīs sarunas, un tas apturēs modeli, kas varētu atbildēt, un šo nevarēs atkāties.",
+      cancel: "Atcelt",
+      confirm: "Turpināt",
+    },
   },
   profile_settings: {
     edit_account: "Rediģēt kontu",

--- a/frontend/src/locales/nl/common.js
+++ b/frontend/src/locales/nl/common.js
@@ -1310,6 +1310,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Reden: {{reason}}",
     thought_in_progress: "Het model denkt...",
     thoughts: "Denken",
+    leave_generating: {
+      title: "Stoppen met het genereren van een antwoord?",
+      description:
+        "U gaat nu deze chat afsluiten. Dit zorgt ervoor dat het model geen antwoord meer genereert en dit kan niet worden teruggedraaid.",
+      cancel: "Annuleren",
+      confirm: "Vervolg",
+    },
   },
   profile_settings: {
     edit_account: "Account bewerken",

--- a/frontend/src/locales/pl/common.js
+++ b/frontend/src/locales/pl/common.js
@@ -1414,6 +1414,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Powód: {{reason}}",
     thought_in_progress: "Model myśli…",
     thoughts: "Myśli",
+    leave_generating: {
+      title: "Przestań generować odpowiedź?",
+      description:
+        "Wkrótce opuścisz tę rozmowę, co spowoduje zatrzymanie działania modelu i uniemożliwi jego odtworzenie.",
+      cancel: "Anuluj",
+      confirm: "Kontynuuj",
+    },
   },
   profile_settings: {
     edit_account: "Edytuj konto",

--- a/frontend/src/locales/pt_BR/common.js
+++ b/frontend/src/locales/pt_BR/common.js
@@ -1397,6 +1397,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Motivo: {{reason}}",
     thought_in_progress: "O modelo está pensando...",
     thoughts: "Pensamentos",
+    leave_generating: {
+      title: "Parar de gerar respostas?",
+      description:
+        "Você está prestes a sair deste bate-papo. Isso impedirá que o modelo gere uma resposta e não poderá ser recuperado.",
+      cancel: "Cancelar",
+      confirm: "Continue",
+    },
   },
   profile_settings: {
     edit_account: "Editar conta",

--- a/frontend/src/locales/ro/common.js
+++ b/frontend/src/locales/ro/common.js
@@ -673,6 +673,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Motiv: {{reason}}",
     thought_in_progress: "Modelul analizează...",
     thoughts: "Gânduri",
+    leave_generating: {
+      title: "Încetați să generați răspunsuri?",
+      description:
+        "În curând veți părăsi această conversație; acest lucru va opri modelul de a genera răspunsul și nu poate fi recuperat.",
+      cancel: "Anula",
+      confirm: "Continuă",
+    },
   },
   profile_settings: {
     edit_account: "Editează contul",

--- a/frontend/src/locales/ru/common.js
+++ b/frontend/src/locales/ru/common.js
@@ -1318,6 +1318,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Причина: {{reason}}",
     thought_in_progress: "Модель размышляет…",
     thoughts: "Мысли",
+    leave_generating: {
+      title: "Прекратить генерацию ответа?",
+      description:
+        "Вы собираетесь выйти из этого чата, это остановит работу модели и предотвратит генерацию ответа. Восстановить эту ситуацию невозможно.",
+      cancel: "Отменить",
+      confirm: "Продолжить",
+    },
   },
   profile_settings: {
     edit_account: "Редактировать учётную запись",

--- a/frontend/src/locales/tr/common.js
+++ b/frontend/src/locales/tr/common.js
@@ -1311,6 +1311,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Nedeni: {{reason}}",
     thought_in_progress: "Model düşünüyor...",
     thoughts: "Düşünceler",
+    leave_generating: {
+      title: "Yanıt üretmeyi durdurun?",
+      description:
+        "Şu anda bu sohbetten çıkıyorsunuz. Bu, modelin yanıt oluşturmasını durduracak ve bu durumun geri alınamayacağını ifade eder.",
+      cancel: "İptal et",
+      confirm: "Devam et",
+    },
   },
   profile_settings: {
     edit_account: "Hesabı Düzenle",

--- a/frontend/src/locales/vn/common.js
+++ b/frontend/src/locales/vn/common.js
@@ -1295,6 +1295,13 @@ const TRANSLATIONS = {
     response_failed_reason: "Lý do: {{reason}}",
     thought_in_progress: "Đang suy nghĩ...",
     thoughts: "Ý tưởng",
+    leave_generating: {
+      title: "Dừng tạo phản hồi?",
+      description:
+        "Bạn sắp rời khỏi cuộc trò chuyện này, điều này sẽ ngăn mô hình tạo ra câu trả lời và không thể khôi phục lại.",
+      cancel: "Hủy",
+      confirm: "Tiếp tục",
+    },
   },
   profile_settings: {
     edit_account: "Chỉnh sửa Tài khoản",

--- a/frontend/src/locales/zh/common.js
+++ b/frontend/src/locales/zh/common.js
@@ -1306,6 +1306,12 @@ const TRANSLATIONS = {
     response_failed_reason: "原因：{{reason}}",
     thought_in_progress: "正在思考…",
     thoughts: "想法、思绪",
+    leave_generating: {
+      title: "停止生成回复吗？",
+      description: "您即将退出此对话，这将阻止模型生成回复，并且无法恢复。",
+      cancel: "取消",
+      confirm: "继续",
+    },
   },
   profile_settings: {
     edit_account: "编辑帐户",

--- a/frontend/src/locales/zh_TW/common.js
+++ b/frontend/src/locales/zh_TW/common.js
@@ -1214,6 +1214,12 @@ const TRANSLATIONS = {
     response_failed_reason: "原因：{{reason}}",
     thought_in_progress: "正在思考…",
     thoughts: "想法、思緒",
+    leave_generating: {
+      title: "停止生成回應？",
+      description: "您即將結束本次對話，這會阻止模型生成回應，而且無法恢復。",
+      cancel: "取消",
+      confirm: "繼續",
+    },
   },
   profile_settings: {
     edit_account: "編輯帳戶",

--- a/frontend/src/utils/keyboardShortcuts.js
+++ b/frontend/src/utils/keyboardShortcuts.js
@@ -1,46 +1,46 @@
 import paths from "./paths";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { userFromStorage } from "./request";
 import { TOGGLE_LLM_SELECTOR_EVENT } from "@/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/action";
 
 export const KEYBOARD_SHORTCUTS_HELP_EVENT = "keyboard-shortcuts-help";
 export const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+
+/**
+ * Keyboard shortcut definitions.
+ *
+ * @note Navigating actions MUST use the injected `navigate` (react-router)
+ * rather than `window.location`. Router navigation is interceptable - it lets
+ * ActiveGenerationGuard warn before a shortcut abandons an in-flight response -
+ * and avoids a full page reload of the whole SPA.
+ *
+ * @type {Record<string, {translationKey: string, action: (ctx: {navigate: import("react-router-dom").NavigateFunction}) => void}>}
+ */
 export const SHORTCUTS = {
   "⌘ + ,": {
     translationKey: "settings",
-    action: () => {
-      window.location.href = paths.settings.interface();
-    },
+    action: ({ navigate }) => navigate(paths.settings.interface()),
   },
   "⌘ + H": {
     translationKey: "home",
-    action: () => {
-      window.location.href = paths.home();
-    },
+    action: ({ navigate }) => navigate(paths.home()),
   },
   "⌘ + I": {
     translationKey: "workspaces",
-    action: () => {
-      window.location.href = paths.settings.workspaces();
-    },
+    action: ({ navigate }) => navigate(paths.settings.workspaces()),
   },
   "⌘ + K": {
     translationKey: "apiKeys",
-    action: () => {
-      window.location.href = paths.settings.apiKeys();
-    },
+    action: ({ navigate }) => navigate(paths.settings.apiKeys()),
   },
   "⌘ + L": {
     translationKey: "llmPreferences",
-    action: () => {
-      window.location.href = paths.settings.llmPreference();
-    },
+    action: ({ navigate }) => navigate(paths.settings.llmPreference()),
   },
   "⌘ + Shift + C": {
     translationKey: "chatSettings",
-    action: () => {
-      window.location.href = paths.settings.chat();
-    },
+    action: ({ navigate }) => navigate(paths.settings.chat()),
   },
   "⌘ + Shift + ?": {
     translationKey: "help",
@@ -99,8 +99,12 @@ function getShortcutKey(event) {
   return key;
 }
 
-// Initialize keyboard shortcuts
-export function initKeyboardShortcuts() {
+/**
+ * Initialize keyboard shortcuts.
+ * @param {{navigate: import("react-router-dom").NavigateFunction}} ctx - Context passed to each shortcut action
+ * @returns {() => void} cleanup function that removes the listener
+ */
+export function initKeyboardShortcuts(ctx = {}) {
   function handleKeyDown(event) {
     const shortcutKey = getShortcutKey(event);
     if (!shortcutKey) return;
@@ -108,7 +112,7 @@ export function initKeyboardShortcuts() {
     const action = LISTENERS[shortcutKey];
     if (action) {
       event.preventDefault();
-      action();
+      action(ctx);
     }
   }
 
@@ -117,15 +121,16 @@ export function initKeyboardShortcuts() {
 }
 
 function useKeyboardShortcuts() {
+  const navigate = useNavigate();
   useEffect(() => {
     // If there is a user and the user is not an admin do not register the event listener
     // since some of the shortcuts are only available in multi-user mode as admin
     const user = userFromStorage();
     if (!!user && user?.role !== "admin") return;
-    const cleanup = initKeyboardShortcuts();
+    const cleanup = initKeyboardShortcuts({ navigate });
 
     return () => cleanup();
-  }, []);
+  }, [navigate]);
   return;
 }
 


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [x] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #6156

### Description

Adds a custom modal to the beforeunload hook as well as updates some components that can inadvertently cause a reload or state change **while inference is underway**.

This alerts the user that navigation from the thread will kill/disconnect the LLM from the task to save on compute instead of letting it run in the background.

This is the **first pass** on this solution. We intended to make this behavior customizable so that you can let threads run in the background without having to be on their tab. This is more involved as it requires a UI alert system and continuous state tracking and is much larger lift.

This PR simply makes the accidental loss of chat data due to cancellation less easy to accomplish for the user.

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->
<img width="1715" height="890" alt="Screenshot 2026-08-26 at 1 23 02 PM" src="https://github.com/user-attachments/assets/d44e4c6e-06b7-4257-b09c-30bde81266d7" />


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
