### PR TITLE
fix: pass workspace temperature to agent sessions

### DIFF
--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -1461,7 +1461,7 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
       case "mistral":
         return new Providers.MistralProvider({ model: config.model });
       case "generic-openai":
-        return new Providers.GenericOpenAiProvider({ model: config.model });
+        return new Providers.GenericOpenAiProvider({ model: config.model, temperature: config.temperature });
       case "perplexity":
         return new Providers.PerplexityProvider({ model: config.model });
       case "textgenwebui":

--- a/server/utils/agents/aibitat/providers/cohere.js
+++ b/server/utils/agents/aibitat/providers/cohere.js
@@ -16,7 +16,7 @@ class CohereProvider extends InheritMultiple([Provider, UnTooled]) {
 
   constructor(config = {}) {
     super();
-    const { model = process.env.COHERE_MODEL_PREF || "command-r-08-2024" } =
+    const { model = process.env.COHERE_MODEL_PREF || "command-r-08-2024", temperature = null } =
       config;
     const client = new OpenAI({
       baseURL: "https://api.cohere.ai/compatibility/v1",
@@ -26,6 +26,7 @@ class CohereProvider extends InheritMultiple([Provider, UnTooled]) {
     this.providerTag = "cohere";
     this._client = client;
     this.model = model;
+    this.temperature = temperature;
     this.verbose = true;
     this._supportsToolCalling = null;
   }
@@ -56,7 +57,7 @@ class CohereProvider extends InheritMultiple([Provider, UnTooled]) {
     return await this.client.chat.completions
       .create({
         model: this.model,
-        temperature: 0,
+        temperature: this.temperature ?? 0,
         messages,
       })
       .then((result) => {

--- a/server/utils/agents/aibitat/providers/genericOpenAi.js
+++ b/server/utils/agents/aibitat/providers/genericOpenAi.js
@@ -21,7 +21,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
   constructor(config = {}) {
     super();
     this.providerTag = "generic-openai";
-    const { model = "gpt-4.1-nano" } = config;
+    const { model = "gpt-4.1-nano", temperature = null } = config;
     const client = new OpenAI({
       baseURL: process.env.GENERIC_OPEN_AI_BASE_PATH,
       apiKey: process.env.GENERIC_OPEN_AI_API_KEY ?? null,
@@ -33,6 +33,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
 
     this._client = client;
     this.model = model;
+    this.temperature = temperature;
     this.verbose = true;
     this._supportsToolCalling = null;
     this.maxTokens = process.env.GENERIC_OPEN_AI_MAX_TOKENS
@@ -75,7 +76,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
     return await this.client.chat.completions
       .create({
         model: this.model,
-        temperature: 0,
+        temperature: this.temperature ?? 0,
         messages,
         max_tokens: this.maxTokens,
       })

--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -514,6 +514,7 @@ class EphemeralAgentHandler extends AgentHandler {
     this.aibitat = new AIbitat({
       provider: this.provider ?? "openai",
       model: this.model ?? "gpt-4.1-nano",
+      temperature: this.#workspace?.openAiTemp ?? null,
       chats: await this.#chatHistory(20),
       handlerProps: {
         invocation: {


### PR DESCRIPTION
## markdown
    Pull Request Type
    
    - [ ] ✨ feat (New feature)
    - [x] 🐛 fix (Bug fix)
    - [ ] ♻️ refactor (Code refactoring without changing behavior)
    - [ ] 💄 style (UI style changes)
    - [ ] 🧹 chore (Build, CI, maintenance)
    - [ ] 📝 docs (Documentation updates)
    
  
## Description
    
    Agent sessions hardcoded temperature: 0 in the GenericOpenAI and Cohere
    provider completions, ignoring the workspace openAiTemp setting entirely.
    This caused temperature-sensitive models (e.g. Gemma 4 E4B) to intermittently
    produce empty textResponse after successful tool calls — the model samples
    an immediate end-of-turn token at temperature 0, but lowering the workspace
    temperature had no effect on agent runs.
    
    Root cause: The workspace openAiTemp was used for normal chat
    (apiChatHandler.js:427, stream.js:292, etc.) but never passed through
    to the agent provider system. EphemeralAgentHandler.createAIbitat() created
    the AIbitat instance without a temperature prop, and
    #buildProviderForConfig() passed only { model } to provider constructors.
## Changes (4 files, +8/-5):
    
    1. server/utils/agents/ephemeral.js — Pass workspace.openAiTemp as
       temperature to the AIbitat constructor
    2. server/utils/agents/aibitat/index.js — Forward config.temperature
       to GenericOpenAiProvider constructor in #buildProviderForConfig()
    3. server/utils/agents/aibitat/providers/genericOpenAi.js — Accept
       temperature in constructor, use this.temperature ?? 0 in
       #handleFunctionCallChat()
    4. server/utils/agents/aibitat/providers/cohere.js — Same pattern:
       accept temperature in constructor, use it in #handleFunctionCallChat()
    
    Behavior:
    - When workspace openAiTemp is set → agent sessions use that temperature
    - When openAiTemp is null/undefined → falls back to 0 (preserving current default)
    - Normal chat behavior is unchanged
## Visuals (if applicable)
    
    N/A  backend-only change
    
 ## Additional Information
    
    The fix is minimal and backwards-compatible. The temperature prop flows
    through the existing rest spread in the AIbitat constructor, so no
    schema or type changes are needed. Other providers (OpenAI, Anthropic, etc.)
    are unaffected — they manage their own temperature internally.
    
##  Developer Validations
    
    - [ ] I ran yarn lint from the root of the repo & committed changes
    - [ ] Relevant documentation has been updated (if applicable)
    - [x] I have tested my code functionality
    - [ ] Docker build succeeds locally

  Relevant Issues
    resolves #6091 