### PR TITLE
feat: identify AnythingLLM Perplexity requests

### DIFF
--- a/server/__tests__/utils/AiProviders/perplexity/index.test.js
+++ b/server/__tests__/utils/AiProviders/perplexity/index.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+
+jest.mock("openai", () => {
+  const OpenAI = jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: jest.fn() } },
+  }));
+  OpenAI.OpenAI = OpenAI;
+  return OpenAI;
+});
+jest.mock("../../../../utils/helpers/modelPricing", () => ({
+  MODEL_PRICING: {},
+}));
+
+const OpenAI = require("openai");
+const {
+  PerplexityLLM,
+} = require("../../../../utils/AiProviders/perplexity");
+const PerplexityProvider = require("../../../../utils/agents/aibitat/providers/perplexity");
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV, PERPLEXITY_API_KEY: "test-api-key" };
+  OpenAI.mockClear();
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("Perplexity integration attribution", () => {
+  test("adds the integration header to native chat requests", () => {
+    new PerplexityLLM({});
+
+    expect(OpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: { "X-Pplx-Integration": "anythingllm" },
+      })
+    );
+  });
+
+  test("adds the integration header to agent requests", () => {
+    new PerplexityProvider();
+
+    expect(OpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: { "X-Pplx-Integration": "anythingllm" },
+      })
+    );
+  });
+});

--- a/server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js
+++ b/server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+
+jest.mock("../../../../../models/systemSettings", () => ({
+  SystemSettings: { get: jest.fn() },
+}));
+jest.mock("../../../../../utils/helpers/tiktoken", () => ({
+  TokenManager: jest.fn().mockImplementation(() => ({
+    countFromString: jest.fn().mockReturnValue(0),
+  })),
+}));
+
+const {
+  webBrowsing,
+} = require("../../../../../utils/agents/aibitat/plugins/web-browsing");
+
+const ORIGINAL_ENV = process.env;
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    AGENT_PERPLEXITY_API_KEY: "test-api-key",
+  };
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue({ results: [] }),
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+test("adds the integration header to direct Perplexity Search requests", async () => {
+  let searchTool;
+  const aibitat = {
+    function: jest.fn().mockImplementation((tool) => {
+      searchTool = tool;
+    }),
+    handlerProps: { log: jest.fn() },
+    introspect: jest.fn(),
+  };
+
+  webBrowsing.plugin().setup(aibitat);
+  await searchTool._perplexitySearch.call(searchTool, "latest news");
+
+  expect(global.fetch).toHaveBeenCalledWith(
+    "https://api.perplexity.ai/search",
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        "X-Pplx-Integration": "anythingllm",
+      }),
+    })
+  );
+});

--- a/server/utils/AiProviders/perplexity/constants.js
+++ b/server/utils/AiProviders/perplexity/constants.js
@@ -1,0 +1,5 @@
+const PERPLEXITY_INTEGRATION_HEADERS = {
+  "X-Pplx-Integration": "anythingllm",
+};
+
+module.exports = { PERPLEXITY_INTEGRATION_HEADERS };

--- a/server/utils/AiProviders/perplexity/index.js
+++ b/server/utils/AiProviders/perplexity/index.js
@@ -8,6 +8,7 @@ const {
 const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
+const { PERPLEXITY_INTEGRATION_HEADERS } = require("./constants");
 
 function perplexityModels() {
   const { MODELS } = require("./models.js");
@@ -24,6 +25,7 @@ class PerplexityLLM {
     this.openai = new OpenAIApi({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
+      defaultHeaders: PERPLEXITY_INTEGRATION_HEADERS,
     });
     this.model =
       modelPreference ||

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1,5 +1,8 @@
 const { SystemSettings } = require("../../../../models/systemSettings");
 const { TokenManager } = require("../../../helpers/tiktoken");
+const {
+  PERPLEXITY_INTEGRATION_HEADERS,
+} = require("../../../AiProviders/perplexity/constants");
 const tiktoken = new TokenManager();
 
 const webBrowsing = {
@@ -1124,6 +1127,7 @@ const webBrowsing = {
                 headers: {
                   "Content-Type": "application/json",
                   Authorization: `Bearer ${process.env.AGENT_PERPLEXITY_API_KEY}`,
+                  ...PERPLEXITY_INTEGRATION_HEADERS,
                 },
                 body: JSON.stringify({
                   query: query,

--- a/server/utils/agents/aibitat/providers/perplexity.js
+++ b/server/utils/agents/aibitat/providers/perplexity.js
@@ -2,6 +2,9 @@ const OpenAI = require("openai");
 const Provider = require("./ai-provider.js");
 const InheritMultiple = require("./helpers/classes.js");
 const UnTooled = require("./helpers/untooled.js");
+const {
+  PERPLEXITY_INTEGRATION_HEADERS,
+} = require("../../../AiProviders/perplexity/constants.js");
 
 /**
  * The agent provider for the Perplexity provider.
@@ -15,6 +18,7 @@ class PerplexityProvider extends InheritMultiple([Provider, UnTooled]) {
     const client = new OpenAI({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
+      defaultHeaders: PERPLEXITY_INTEGRATION_HEADERS,
     });
 
     this.providerTag = "perplexity";


### PR DESCRIPTION
## Summary

- send `X-Pplx-Integration: anythingllm` from the native Perplexity chat client
- reuse the same attribution header for the agent provider and direct Search transport
- add focused request-boundary coverage for all three paths

## Testing

- `npx jest@29.7.0 server/__tests__/utils/AiProviders/perplexity/index.test.js server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js --runInBand`
- `cd server && yarn lint:check`

Closes #6203