### PR TITLE
Identify AnythingLLM Perplexity requests

### DIFF
--- a/server/utils/AiProviders/perplexity/index.js
+++ b/server/utils/AiProviders/perplexity/index.js
@@ -25,7 +25,10 @@ class PerplexityLLM {
     this.openai = new OpenAIApi({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
-      defaultHeaders: { "User-Agent": getAnythingLLMUserAgent() },
+      defaultHeaders: {
+        "User-Agent": getAnythingLLMUserAgent(),
+        "X-Pplx-Integration": "anythingllm",
+      },
     });
     this.model =
       modelPreference ||

--- a/server/utils/AiProviders/perplexity/index.js
+++ b/server/utils/AiProviders/perplexity/index.js
@@ -24,6 +24,7 @@ class PerplexityLLM {
     this.openai = new OpenAIApi({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
+      defaultHeaders: { "X-Pplx-Integration": "anythingllm" },
     });
     this.model =
       modelPreference ||

--- a/server/utils/AiProviders/perplexity/index.js
+++ b/server/utils/AiProviders/perplexity/index.js
@@ -26,8 +26,7 @@ class PerplexityLLM {
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
       defaultHeaders: {
-        "User-Agent": getAnythingLLMUserAgent(),
-        "X-Pplx-Integration": "anythingllm",
+        "X-Pplx-Integration": getAnythingLLMUserAgent(),
       },
     });
     this.model =

--- a/server/utils/AiProviders/perplexity/index.js
+++ b/server/utils/AiProviders/perplexity/index.js
@@ -8,6 +8,7 @@ const {
 const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
+const { getAnythingLLMUserAgent } = require("../../../endpoints/utils");
 
 function perplexityModels() {
   const { MODELS } = require("./models.js");
@@ -24,7 +25,7 @@ class PerplexityLLM {
     this.openai = new OpenAIApi({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
-      defaultHeaders: { "X-Pplx-Integration": "anythingllm" },
+      defaultHeaders: { "User-Agent": getAnythingLLMUserAgent() },
     });
     this.model =
       modelPreference ||

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1126,6 +1126,7 @@ const webBrowsing = {
                   "Content-Type": "application/json",
                   Authorization: `Bearer ${process.env.AGENT_PERPLEXITY_API_KEY}`,
                   "User-Agent": getAnythingLLMUserAgent(),
+                  "X-Pplx-Integration": "anythingllm",
                 },
                 body: JSON.stringify({
                   query: query,

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1,5 +1,6 @@
 const { SystemSettings } = require("../../../../models/systemSettings");
 const { TokenManager } = require("../../../helpers/tiktoken");
+const { getAnythingLLMUserAgent } = require("../../../../endpoints/utils");
 const tiktoken = new TokenManager();
 
 const webBrowsing = {
@@ -1124,7 +1125,7 @@ const webBrowsing = {
                 headers: {
                   "Content-Type": "application/json",
                   Authorization: `Bearer ${process.env.AGENT_PERPLEXITY_API_KEY}`,
-                  "X-Pplx-Integration": "anythingllm",
+                  "User-Agent": getAnythingLLMUserAgent(),
                 },
                 body: JSON.stringify({
                   query: query,

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1125,8 +1125,7 @@ const webBrowsing = {
                 headers: {
                   "Content-Type": "application/json",
                   Authorization: `Bearer ${process.env.AGENT_PERPLEXITY_API_KEY}`,
-                  "User-Agent": getAnythingLLMUserAgent(),
-                  "X-Pplx-Integration": "anythingllm",
+                  "X-Pplx-Integration": getAnythingLLMUserAgent(),
                 },
                 body: JSON.stringify({
                   query: query,

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1124,6 +1124,7 @@ const webBrowsing = {
                 headers: {
                   "Content-Type": "application/json",
                   Authorization: `Bearer ${process.env.AGENT_PERPLEXITY_API_KEY}`,
+                  "X-Pplx-Integration": "anythingllm",
                 },
                 body: JSON.stringify({
                   query: query,

--- a/server/utils/agents/aibitat/providers/perplexity.js
+++ b/server/utils/agents/aibitat/providers/perplexity.js
@@ -15,6 +15,7 @@ class PerplexityProvider extends InheritMultiple([Provider, UnTooled]) {
     const client = new OpenAI({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
+      defaultHeaders: { "X-Pplx-Integration": "anythingllm" },
     });
 
     this.providerTag = "perplexity";

--- a/server/utils/agents/aibitat/providers/perplexity.js
+++ b/server/utils/agents/aibitat/providers/perplexity.js
@@ -16,7 +16,10 @@ class PerplexityProvider extends InheritMultiple([Provider, UnTooled]) {
     const client = new OpenAI({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
-      defaultHeaders: { "User-Agent": getAnythingLLMUserAgent() },
+      defaultHeaders: {
+        "User-Agent": getAnythingLLMUserAgent(),
+        "X-Pplx-Integration": "anythingllm",
+      },
     });
 
     this.providerTag = "perplexity";

--- a/server/utils/agents/aibitat/providers/perplexity.js
+++ b/server/utils/agents/aibitat/providers/perplexity.js
@@ -2,6 +2,7 @@ const OpenAI = require("openai");
 const Provider = require("./ai-provider.js");
 const InheritMultiple = require("./helpers/classes.js");
 const UnTooled = require("./helpers/untooled.js");
+const { getAnythingLLMUserAgent } = require("../../../../endpoints/utils");
 
 /**
  * The agent provider for the Perplexity provider.
@@ -15,7 +16,7 @@ class PerplexityProvider extends InheritMultiple([Provider, UnTooled]) {
     const client = new OpenAI({
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
-      defaultHeaders: { "X-Pplx-Integration": "anythingllm" },
+      defaultHeaders: { "User-Agent": getAnythingLLMUserAgent() },
     });
 
     this.providerTag = "perplexity";

--- a/server/utils/agents/aibitat/providers/perplexity.js
+++ b/server/utils/agents/aibitat/providers/perplexity.js
@@ -17,8 +17,7 @@ class PerplexityProvider extends InheritMultiple([Provider, UnTooled]) {
       baseURL: "https://api.perplexity.ai",
       apiKey: process.env.PERPLEXITY_API_KEY ?? null,
       defaultHeaders: {
-        "User-Agent": getAnythingLLMUserAgent(),
-        "X-Pplx-Integration": "anythingllm",
+        "X-Pplx-Integration": getAnythingLLMUserAgent(),
       },
     });
 


### PR DESCRIPTION
## Summary

Perplexity would like to identify AnythingLLM requests in API attribution data.

- Send `X-Pplx-Integration: anythingllm` from the native chat client, agent provider, and direct Search request.
- Send the existing versioned `AnythingLLM/<deployment-version>` user agent from the same paths.
- Leave authentication, request payloads, and responses unchanged.

Closes #6203
