### PR TITLE
fix(pdf): clearer error message for password-protected PDFs

### DIFF
--- a/collector/processSingleFile/convert/asPDF/PDFLoader/index.js
+++ b/collector/processSingleFile/convert/asPDF/PDFLoader/index.js
@@ -10,12 +10,22 @@ class PDFLoader {
     const buffer = await fs.readFile(this.filePath);
     const { getDocument, version } = await this.getPdfJS();
 
-    const pdf = await getDocument({
-      data: new Uint8Array(buffer),
-      useWorkerFetch: false,
-      isEvalSupported: false,
-      useSystemFonts: true,
-    }).promise;
+    let pdf;
+    try {
+      pdf = await getDocument({
+        data: new Uint8Array(buffer),
+        useWorkerFetch: false,
+        isEvalSupported: false,
+        useSystemFonts: true,
+      }).promise;
+    } catch (e) {
+      if (e?.name === "PasswordException") {
+        throw new Error(
+          `PDF file "${this.filePath}" is password protected. Please provide an unencrypted version.`
+        );
+      }
+      throw e;
+    }
 
     const meta = await pdf.getMetadata().catch(() => null);
     const documents = [];


### PR DESCRIPTION
corresponds to issue #6211 

When a password-protected PDF is uploaded for ingestion, PDF.js throws a PasswordException that propagates as a cryptic error to the user with no context about password protection.

What Changed

Catch PasswordException specifically — match on e?.name === "PasswordException" from PDF.js during document loading
Throw a clear, actionable error message — PDF file "${this.filePath}" is password protected. Please provide an unencrypted version.
Pass through all other errors unchanged — non-password errors propagate normally with full stack trace
No new dependencies or behavioral changes for non-encrypted PDFs


Files Modified

collector/processSingleFile/convert/asPDF/PDFLoader/index.js


The implementation matches the proposed fix exactly:

1. **Catches the specific `PasswordException`** — `e?.name === "PasswordException"` (line 22)
2. **Throws a clear, actionable error message** — `PDF file "${this.filePath}" is password protected. Please provide an unencrypted version.` (lines 23-25)
3. **Passes through all other errors unchanged** — `throw e` (line 27)
4. **No new dependencies or behavioral changes** — the try/catch only intercepts `PasswordException`; normal PDFs are unaffected since `getDocument().promise` succeeds and the existing code continues as before.