### PR TITLE
fix(vdb): better error logging for VDB namespace deletion failures

### DIFF
--- a/server/endpoints/admin.js
+++ b/server/endpoints/admin.js
@@ -316,7 +316,7 @@ function adminEndpoints(app) {
         try {
           await VectorDb["delete-namespace"]({ namespace: workspace.slug });
         } catch (e) {
-          console.error(e.message);
+          console.error(`Failed to delete VDB namespace for workspace ${workspace.slug}:`, e);
         }
 
         response.status(200).json({ success: true, error: null });

--- a/server/endpoints/api/workspace/index.js
+++ b/server/endpoints/api/workspace/index.js
@@ -266,7 +266,7 @@ function apiWorkspaceEndpoints(app) {
         try {
           await VectorDb["delete-namespace"]({ namespace: slug });
         } catch (e) {
-          console.error(e.message);
+          console.error(`Failed to delete VDB namespace for workspace ${slug}:`, e);
         }
         response.sendStatus(200).end();
       } catch (e) {

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -322,7 +322,7 @@ function workspaceEndpoints(app) {
         try {
           await VectorDb["delete-namespace"]({ namespace: slug });
         } catch (e) {
-          console.error(e.message);
+          console.error(`Failed to delete VDB namespace for workspace ${slug}:`, e);
         }
         response.sendStatus(200).end();
       } catch (e) {
@@ -363,7 +363,7 @@ function workspaceEndpoints(app) {
         try {
           await VectorDb["delete-namespace"]({ namespace: slug });
         } catch (e) {
-          console.error(e.message);
+          console.error(`Failed to delete VDB namespace for workspace ${slug}:`, e);
         }
         response.sendStatus(200).end();
       } catch (e) {


### PR DESCRIPTION
corresponds to issue #6212 

When a workspace is deleted, the system attempts to delete the namespace from the Vector DB. If this fails, only console.error(e.message) was logged — losing the stack trace and workspace context.

What Changed
Log the full error object (including stack trace) instead of just e.message
Include the workspace slug in the error message for identification
Apply to all 4 VectorDb["delete-namespace"] try-catch blocks

Files Modified

server/endpoints/workspaces.js (2 locations: workspace delete, reset vectors)
server/endpoints/admin.js (1 location: admin workspace delete)
server/endpoints/api/workspace/index.js (1 location: API workspace delete)


**Full error object logged** — `console.error(..., e)` instead of `console.error(e.message)` — includes stack trace
**Workspace slug included** — each message now reads `Failed to delete VDB namespace for workspace ${slug}:`
**All 4 locations updated** — `server/endpoints/workspaces.js` (2), `server/endpoints/admin.js` (1), `server/endpoints/api/workspace/index.js` (1)