### PR TITLE
fix: prevent dropped terminal SSE frame in DMR/Lemonade model-download streams

### DIFF
--- a/frontend/src/models/utils/dmrUtils.js
+++ b/frontend/src/models/utils/dmrUtils.js
@@ -26,39 +26,48 @@ const DMRUtils = {
         if (!response.ok)
           throw new Error("Error downloading model: " + response.statusText);
         const reader = response.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = "";
         let done = false;
 
         while (!done) {
           const { value, done: readerDone } = await reader.read();
+          // Decode incrementally so a multi-byte character split across two
+          // network chunks is not corrupted, and retain any trailing partial
+          // line in `buffer` until the next chunk (or the end of the stream)
+          // completes it. Without this, a terminal `success`/`error` frame
+          // that straddles a chunk boundary is silently dropped.
+          buffer += value
+            ? decoder.decode(value, { stream: true })
+            : decoder.decode();
+          const lines = buffer.split("\n");
+          buffer = readerDone ? "" : (lines.pop() ?? "");
+          for (const line of lines) {
+            if (line.startsWith("data:")) {
+              const data = safeJsonParse(line.slice(5));
+              switch (data?.type) {
+                case "success":
+                  done = true;
+                  resolve({ success: true });
+                  break;
+                case "error":
+                  done = true;
+                  resolve({
+                    success: false,
+                    error: data?.error || data?.message,
+                  });
+                  break;
+                case "progress":
+                  progressCallback(data?.percentage);
+                  break;
+                default:
+                  break;
+              }
+            }
+          }
           if (readerDone) {
             done = true;
             resolve({ success: true });
-          } else {
-            const chunk = new TextDecoder("utf-8").decode(value);
-            const lines = chunk.split("\n");
-            for (const line of lines) {
-              if (line.startsWith("data:")) {
-                const data = safeJsonParse(line.slice(5));
-                switch (data?.type) {
-                  case "success":
-                    done = true;
-                    resolve({ success: true });
-                    break;
-                  case "error":
-                    done = true;
-                    resolve({
-                      success: false,
-                      error: data?.error || data?.message,
-                    });
-                    break;
-                  case "progress":
-                    progressCallback(data?.percentage);
-                    break;
-                  default:
-                    break;
-                }
-              }
-            }
           }
         }
       } catch (error) {

--- a/frontend/src/models/utils/lemonadeUtils.js
+++ b/frontend/src/models/utils/lemonadeUtils.js
@@ -29,39 +29,48 @@ const LemonadeUtils = {
         if (!response.ok)
           throw new Error("Error downloading model: " + response.statusText);
         const reader = response.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = "";
         let done = false;
 
         while (!done) {
           const { value, done: readerDone } = await reader.read();
+          // Decode incrementally so a multi-byte character split across two
+          // network chunks is not corrupted, and retain any trailing partial
+          // line in `buffer` until the next chunk (or the end of the stream)
+          // completes it. Without this, a terminal `success`/`error` frame
+          // that straddles a chunk boundary is silently dropped.
+          buffer += value
+            ? decoder.decode(value, { stream: true })
+            : decoder.decode();
+          const lines = buffer.split("\n");
+          buffer = readerDone ? "" : (lines.pop() ?? "");
+          for (const line of lines) {
+            if (line.startsWith("data:")) {
+              const data = safeJsonParse(line.slice(5));
+              switch (data?.type) {
+                case "success":
+                  done = true;
+                  resolve({ success: true });
+                  break;
+                case "error":
+                  done = true;
+                  resolve({
+                    success: false,
+                    error: data?.error || data?.message,
+                  });
+                  break;
+                case "progress":
+                  progressCallback(data?.percentage);
+                  break;
+                default:
+                  break;
+              }
+            }
+          }
           if (readerDone) {
             done = true;
             resolve({ success: true });
-          } else {
-            const chunk = new TextDecoder("utf-8").decode(value);
-            const lines = chunk.split("\n");
-            for (const line of lines) {
-              if (line.startsWith("data:")) {
-                const data = safeJsonParse(line.slice(5));
-                switch (data?.type) {
-                  case "success":
-                    done = true;
-                    resolve({ success: true });
-                    break;
-                  case "error":
-                    done = true;
-                    resolve({
-                      success: false,
-                      error: data?.error || data?.message,
-                    });
-                    break;
-                  case "progress":
-                    progressCallback(data?.percentage);
-                    break;
-                  default:
-                    break;
-                }
-              }
-            }
           }
         }
       } catch (error) {

--- a/server/__tests__/endpoints/utils/dockerModelRunnerUtils.test.js
+++ b/server/__tests__/endpoints/utils/dockerModelRunnerUtils.test.js
@@ -1,0 +1,142 @@
+/* eslint-env jest, node */
+
+/**
+ * Regression test for the DMR model-download SSE re-framing.
+ *
+ * The endpoint reads a newline-delimited event stream from the Docker Model
+ * Runner and forwards `progress`/`success`/`error` frames to the browser.
+ * The bytes arrive in arbitrary network chunks, so a single logical frame can
+ * straddle a chunk boundary. Decoding each chunk in isolation
+ * (`new TextDecoder("utf-8").decode(value)`) and splitting on "\n" with no
+ * cross-chunk buffer drops any frame whose bytes are split across two reads —
+ * including the terminal `success` frame, which then never reaches the UI.
+ *
+ * These tests feed a stream whose terminal `success` frame (and a multi-byte
+ * `progress` message) are deliberately split at a UTF-8 continuation byte,
+ * mid-line, and assert the endpoint still forwards them intact.
+ */
+
+jest.mock("../../../utils/middleware/validatedRequest", () => ({
+  validatedRequest: (_req, _res, next) => next(),
+}));
+jest.mock("../../../utils/middleware/multiUserProtected", () => ({
+  flexUserRoleValid: () => (_req, _res, next) => next(),
+  ROLES: { admin: "admin" },
+}));
+jest.mock("../../../utils/AiProviders/dockerModelRunner", () => ({
+  parseDockerModelRunnerEndpoint: () => "http://127.0.0.1:12434",
+}));
+
+const {
+  dockerModelRunnerUtilsEndpoints,
+} = require("../../../endpoints/utils/dockerModelRunnerUtils");
+
+/** Minimal Express-like app that records the POST handler. */
+function makeApp() {
+  const routes = {};
+  return {
+    routes,
+    post(path, _middleware, handler) {
+      routes[path] = handler;
+    },
+  };
+}
+
+/** A reader that yields the given Uint8Array chunks, like body.getReader(). */
+function readerFrom(chunks) {
+  let i = 0;
+  return {
+    read: async () =>
+      i < chunks.length
+        ? { value: chunks[i++], done: false }
+        : { value: undefined, done: true },
+  };
+}
+
+/** Split a UTF-8 payload into two chunks at the given byte offset. */
+function splitAt(str, byteOffset) {
+  const full = new TextEncoder().encode(str);
+  return [
+    new Uint8Array(full.subarray(0, byteOffset)),
+    new Uint8Array(full.subarray(byteOffset)),
+  ];
+}
+
+function makeResponse() {
+  return {
+    headers: null,
+    chunks: [],
+    ended: false,
+    writeHead(_status, headers) {
+      this.headers = headers;
+    },
+    write(chunk) {
+      this.chunks.push(chunk);
+    },
+    end() {
+      this.ended = true;
+    },
+    get output() {
+      return this.chunks.join("");
+    },
+  };
+}
+
+async function runDownload(streamText, byteSplit) {
+  const app = makeApp();
+  dockerModelRunnerUtilsEndpoints(app);
+  const handler = app.routes["/utils/dmr/download-model"];
+
+  const chunks = splitAt(streamText, byteSplit);
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    statusText: "OK",
+    body: { getReader: () => readerFrom(chunks) },
+  });
+
+  const request = { body: { modelId: "ai/smollm2", basePath: "" } };
+  const response = makeResponse();
+  await handler(request, response);
+  return response;
+}
+
+describe("dockerModelRunnerUtilsEndpoints - SSE frame reassembly", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  test("forwards the terminal success frame even when it straddles a chunk boundary", async () => {
+    const stream =
+      `${JSON.stringify({ type: "progress", pulled: 50, total: 100 })}\n` +
+      `${JSON.stringify({ type: "success" })}\n`;
+
+    // Split inside the token `"success"` -> the terminal frame spans two reads.
+    const byteSplit = new TextEncoder().encode(stream).indexOf(
+      // first byte of `success` value
+      new TextEncoder().encode("success")[0],
+      stream.indexOf('"success"')
+    );
+
+    const response = await runDownload(stream, byteSplit);
+
+    expect(response.ended).toBe(true);
+    // The success control frame must be forwarded to the browser.
+    expect(response.output).toContain('"type":"success"');
+    expect(response.output).toContain('"percentage":100');
+  });
+
+  test("does not corrupt a multi-byte progress message split across chunks", async () => {
+    const message = "Descargando ✅";
+    const stream =
+      `${JSON.stringify({ type: "progress", pulled: 25, total: 100, message })}\n` +
+      `${JSON.stringify({ type: "success" })}\n`;
+
+    // Split inside the 3-byte "✅" of the progress line.
+    const bytes = new TextEncoder().encode(stream);
+    const emojiStart = bytes.indexOf(0xe2); // ✅ = E2 9C 85
+    const response = await runDownload(stream, emojiStart + 1);
+
+    // The multi-byte character must survive re-framing, uncorrupted.
+    expect(response.output).toContain(message);
+    expect(response.output).not.toContain("�"); // no replacement chars
+    expect(response.output).toContain('"type":"success"');
+  });
+});

--- a/server/endpoints/utils/dockerModelRunnerUtils.js
+++ b/server/endpoints/utils/dockerModelRunnerUtils.js
@@ -44,13 +44,21 @@ function dockerModelRunnerUtilsEndpoints(app) {
               "An error occurred while downloading the model"
           );
         const reader = dmrResponse.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = "";
         let done = false;
         while (!done) {
           const { value, done: readerDone } = await reader.read();
           if (readerDone) done = true;
 
-          const chunk = new TextDecoder("utf-8").decode(value);
-          const lines = chunk.split("\n");
+          // Decode incrementally and retain any trailing partial line across
+          // reads; otherwise a terminal `success`/`error` frame that straddles
+          // a network chunk boundary is dropped and never forwarded to the UI.
+          buffer += value
+            ? decoder.decode(value, { stream: true })
+            : decoder.decode();
+          const lines = buffer.split("\n");
+          buffer = done ? "" : (lines.pop() ?? "");
           for (const line of lines) {
             if (!line.trim()) continue;
             const decodedLine = decodeHtmlEntities(line);

--- a/server/endpoints/utils/lemonadeUtilsEndpoints.js
+++ b/server/endpoints/utils/lemonadeUtilsEndpoints.js
@@ -50,6 +50,8 @@ function lemonadeUtilsEndpoints(app) {
               "An error occurred while downloading the model"
           );
         const reader = lemonadeResponse.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = "";
         let done = false;
         let currentEvent = null;
 
@@ -57,8 +59,14 @@ function lemonadeUtilsEndpoints(app) {
           const { value, done: readerDone } = await reader.read();
           if (readerDone) done = true;
 
-          const chunk = new TextDecoder("utf-8").decode(value);
-          const lines = chunk.split("\n");
+          // Decode incrementally and retain any trailing partial line across
+          // reads; otherwise a terminal `complete`/`error` frame that straddles
+          // a network chunk boundary is dropped and never forwarded to the UI.
+          buffer += value
+            ? decoder.decode(value, { stream: true })
+            : decoder.decode();
+          const lines = buffer.split("\n");
+          buffer = done ? "" : (lines.pop() ?? "");
           for (const line of lines) {
             if (!line.trim()) continue;
 


### PR DESCRIPTION
Closes #6219

### What & why

The DMR (Docker Model Runner) and Lemonade model-download paths read a Server-Sent-Events stream and act on `progress` / `success` / `error` frames. Both the server re-emit endpoints and the browser readers decoded each network chunk in isolation:

```js
const chunk = new TextDecoder("utf-8").decode(value); // no { stream: true }
const lines = chunk.split("\n");                      // no cross-chunk buffer
```

Network chunk boundaries are arbitrary and do not respect frame or UTF-8 character boundaries. When the terminal `success` (or `error`) frame straddles a chunk boundary — or a multi-byte character is split across two reads — the partial trailing line is discarded and the bytes are mis-decoded, so the frame fails to parse and is silently dropped.

Effect: the server never forwards the terminal `success` frame, so the browser never receives the completion event — the download progress bar stalls at the last forwarded percentage until the socket closes. The same drop applies to a terminal `error` frame, so a **failed pull is reported as if it completed**.

### Fix

Use a single persistent `TextDecoder` decoding with `{ stream: true }` (with a final `decoder.decode()` flush), and keep a cross-read line buffer so a partial trailing line is only processed once its newline arrives. Applied identically to all four affected files:

- `frontend/src/models/utils/dmrUtils.js`
- `frontend/src/models/utils/lemonadeUtils.js`
- `server/endpoints/utils/dockerModelRunnerUtils.js`
- `server/endpoints/utils/lemonadeUtilsEndpoints.js`

### Testing

Added `server/__tests__/endpoints/utils/dockerModelRunnerUtils.test.js`, which drives the real endpoint with an upstream stream whose terminal `success` frame and a multi-byte progress message are split at a UTF-8 continuation byte, and asserts both are forwarded intact. The test fails on the previous code and passes on this change.
