### PR TITLE
fix: keep workspace prompt and temperature when an embed sends no override

### DIFF
--- a/server/__tests__/utils/chats/embed.test.js
+++ b/server/__tests__/utils/chats/embed.test.js
@@ -1,0 +1,82 @@
+// `utils/http` reaches the auth stack on require; this suite exercises none of it.
+jest.mock("jsonwebtoken", () => ({}));
+
+// Force resolveLLMConnectorForEmbed into its catch branch so the function returns
+// right after applying the overrides, which is the behavior under test.
+jest.mock("../../../models/embedChats", () => ({
+  EmbedChats: {
+    forEmbedByUser: jest.fn().mockRejectedValue(new Error("no router in test")),
+    count: jest.fn().mockResolvedValue(0),
+  },
+}));
+
+// Modules in this import chain resolve storage paths at require time.
+process.env.STORAGE_DIR = process.env.STORAGE_DIR || require("os").tmpdir();
+
+const { streamChatWithForEmbed } = require("../../../utils/chats/embed");
+
+function embedConfig(overrides = {}) {
+  return {
+    id: 1,
+    chat_mode: "chat",
+    allow_prompt_override: true,
+    allow_temperature_override: true,
+    workspace: { slug: "ws", openAiPrompt: "Configured prompt.", openAiTemp: 0.3 },
+    ...overrides,
+  };
+}
+
+const fakeResponse = () => ({ write: jest.fn() });
+
+describe("streamChatWithForEmbed overrides", () => {
+  it("keeps the workspace prompt and temperature when the request sends none", async () => {
+    const embed = embedConfig();
+
+    await streamChatWithForEmbed(fakeResponse(), embed, "hello", "session", {
+      promptOverride: null,
+      temperatureOverride: null,
+    });
+
+    expect(embed.workspace.openAiPrompt).toBe("Configured prompt.");
+    expect(embed.workspace.openAiTemp).toBe(0.3);
+  });
+
+  it("applies the overrides the request does send", async () => {
+    const embed = embedConfig();
+
+    await streamChatWithForEmbed(fakeResponse(), embed, "hello", "session", {
+      promptOverride: "Overridden prompt.",
+      temperatureOverride: "0.9",
+    });
+
+    expect(embed.workspace.openAiPrompt).toBe("Overridden prompt.");
+    expect(embed.workspace.openAiTemp).toBe(0.9);
+  });
+
+  it("applies an empty prompt override and a zero temperature", async () => {
+    const embed = embedConfig();
+
+    await streamChatWithForEmbed(fakeResponse(), embed, "hello", "session", {
+      promptOverride: "",
+      temperatureOverride: "0",
+    });
+
+    expect(embed.workspace.openAiPrompt).toBe("");
+    expect(embed.workspace.openAiTemp).toBe(0);
+  });
+
+  it("ignores overrides the embed is not permitted to accept", async () => {
+    const embed = embedConfig({
+      allow_prompt_override: false,
+      allow_temperature_override: false,
+    });
+
+    await streamChatWithForEmbed(fakeResponse(), embed, "hello", "session", {
+      promptOverride: "Overridden prompt.",
+      temperatureOverride: "0.9",
+    });
+
+    expect(embed.workspace.openAiPrompt).toBe("Configured prompt.");
+    expect(embed.workspace.openAiTemp).toBe(0.3);
+  });
+});

--- a/server/utils/chats/embed.js
+++ b/server/utils/chats/embed.js
@@ -27,10 +27,11 @@ async function streamChatWithForEmbed(
   const chatModel = embed.allow_model_override ? modelOverride : null;
 
   // If there are overrides in request & they are permitted, override the default workspace ref information.
-  if (embed.allow_prompt_override)
+  if (embed.allow_prompt_override && typeof promptOverride === "string")
     embed.workspace.openAiPrompt = promptOverride;
-  if (embed.allow_temperature_override)
-    embed.workspace.openAiTemp = parseFloat(temperatureOverride);
+  const temperatureValue = parseFloat(temperatureOverride);
+  if (embed.allow_temperature_override && !Number.isNaN(temperatureValue))
+    embed.workspace.openAiTemp = temperatureValue;
 
   const uuid = uuidv4();
   const {


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

resolves #6229

### Description

Enabling an embed override permission changed behavior on its own, even when the widget never sent an override.

The embed stream endpoint defaults `prompt` and `temperature` to `null`, so a request that omits them still reaches `streamChatWithForEmbed` with both overrides null. The assignments were gated only on the permission flag:

```js
if (embed.allow_prompt_override)
  embed.workspace.openAiPrompt = promptOverride;
if (embed.allow_temperature_override)
  embed.workspace.openAiTemp = parseFloat(temperatureOverride);
```

So turning the permission on discarded the workspace configuration:

- `openAiPrompt` became `null`, and `chatPrompt`'s `??` fallback then served `saneDefaultSystemPrompt` instead of the workspace's own prompt. The embed answered as the stock assistant.
- `parseFloat(null)` is `NaN`, which is not nullish, so `embed.workspace?.openAiTemp ?? LLMConnector.defaultTemp` could not recover. The connector received `NaN`, which serializes as `null` in the outbound JSON.

Nothing errors, so an admin who enables the permission and sends no override just gets the wrong behavior.

The model override on the line directly above already does this correctly, by leaving the value null and letting the later `??` fall through. This applies the same rule to the other two: override only when the request actually carried a value.

### Additional Information

Four tests in `server/__tests__/utils/chats/embed.test.js` covering: no override sent, override sent, an empty prompt with temperature zero, and overrides sent without permission.

The third of those is deliberate. An empty string and a temperature of `0` are legitimate overrides, so a truthiness guard would be the wrong fix here, and that test fails against it.

The tests force `resolveLLMConnectorForEmbed` into its catch branch so the function returns just after the lines under test, and assert on the real function's effect rather than on a mock. The suite also mocks `jsonwebtoken`, which is unrelated to the change and only there because `utils/http` reaches the auth stack at require time.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

I ran eslint over `server/`, which is the only package this touches, rather than the full root lint. I did not run a Docker build for a change of this size, so I have left that box unchecked rather than tick it untested.
