### PR TITLE
fix: stop $ sequences corrupting restored Telegram code blocks

### DIFF
--- a/server/__tests__/utils/telegramBot/format.test.js
+++ b/server/__tests__/utils/telegramBot/format.test.js
@@ -1,26 +1,259 @@
 /* eslint-env jest */
 const {
   markdownToTelegram,
+  escapeHTML,
 } = require("../../../utils/telegramBot/utils/format");
 
-describe("markdownToTelegram code blocks containing $ sequences", () => {
-  test("keeps $& from consuming the restored block", () => {
-    const result = markdownToTelegram('```bash\nsed -E "s/foo/[$&]/" file\n```');
+describe("markdownToTelegram", () => {
+  describe("empty and null input", () => {
+    test("returns empty string for empty input", () => {
+      expect(markdownToTelegram("")).toBe("");
+    });
 
-    expect(result).toBe('<pre>sed -E "s/foo/[$&amp;]/" file</pre>');
-    expect(result).not.toContain("CODEBLOCK");
+    test("returns empty string for null/undefined input", () => {
+      expect(markdownToTelegram(null)).toBe("");
+      expect(markdownToTelegram(undefined)).toBe("");
+    });
   });
 
-  test("keeps a literal $$ in a code block", () => {
-    const result = markdownToTelegram("```make\nall:\n\techo $$HOME\n```");
+  describe("basic markdown conversion", () => {
+    test("converts **bold** and __bold__ to <b>", () => {
+      expect(markdownToTelegram("this is **bold** text")).toBe(
+        "this is <b>bold</b> text"
+      );
+      expect(markdownToTelegram("this is __bold__ text")).toBe(
+        "this is <b>bold</b> text"
+      );
+    });
 
-    expect(result).toContain("echo $$HOME");
+    test("converts *italic* and _italic_ to <i>", () => {
+      expect(markdownToTelegram("this is *italic* text")).toBe(
+        "this is <i>italic</i> text"
+      );
+      expect(markdownToTelegram("this is _italic_ text")).toBe(
+        "this is <i>italic</i> text"
+      );
+    });
+
+    test("converts ~~strikethrough~~ to <s>", () => {
+      expect(markdownToTelegram("this is ~~gone~~ text")).toBe(
+        "this is <s>gone</s> text"
+      );
+    });
+
+    test("converts markdown links to <a href>", () => {
+      expect(markdownToTelegram("see [docs](https://example.com) here")).toBe(
+        'see <a href="https://example.com">docs</a> here'
+      );
+    });
+
+    test("converts headings to <b>", () => {
+      expect(markdownToTelegram("# Title\nbody")).toBe("<b>Title</b>\nbody");
+      expect(markdownToTelegram("### Subsection")).toBe("<b>Subsection</b>");
+    });
+
+    test("converts list markers to bullets", () => {
+      expect(markdownToTelegram("- one\n- two\n* three")).toBe(
+        "• one\n• two\n• three"
+      );
+    });
+
+    test("converts blockquotes to <i>", () => {
+      expect(markdownToTelegram("> quoted line")).toBe("<i>quoted line</i>");
+    });
+
+    test("converts horizontal rules to a divider line", () => {
+      expect(markdownToTelegram("above\n---\nbelow")).toBe(
+        "above\n————————————\nbelow"
+      );
+    });
+
+    test("supports italic nested inside bold", () => {
+      expect(markdownToTelegram("**bold and *nested* here**")).toBe(
+        "<b>bold and <i>nested</i> here</b>"
+      );
+    });
+
+    test("does not italicize underscores inside identifiers", () => {
+      expect(markdownToTelegram("the var user_name_here stays")).toBe(
+        "the var user_name_here stays"
+      );
+    });
   });
 
-  test("keeps $& literal in inline code", () => {
-    const result = markdownToTelegram("run `echo [$&]` first");
+  describe("HTML escaping", () => {
+    test("escapes HTML in plain text", () => {
+      expect(markdownToTelegram("a <script>alert(1)</script> & b")).toBe(
+        "a &lt;script&gt;alert(1)&lt;/script&gt; &amp; b"
+      );
+    });
 
-    expect(result).toBe("run <code>echo [$&amp;]</code> first");
-    expect(result).not.toContain("INLINECODE");
+    test("preserves HTML when escapeHtml is false", () => {
+      expect(
+        markdownToTelegram("a <b>kept</b> & thing", { escapeHtml: false })
+      ).toBe("a <b>kept</b> & thing");
+    });
+  });
+
+  describe("code blocks", () => {
+    test("converts fenced code blocks to <pre> and escapes HTML inside", () => {
+      expect(markdownToTelegram("```js\nconst a = 1 < 2 && 3 > 2;\n```")).toBe(
+        "<pre>const a = 1 &lt; 2 &amp;&amp; 3 &gt; 2;</pre>"
+      );
+    });
+
+    test("does not apply markdown formatting inside code blocks", () => {
+      expect(markdownToTelegram("```\n**not bold** _not italic_\n```")).toBe(
+        "<pre>**not bold** _not italic_</pre>"
+      );
+    });
+
+    test("restores multiple code blocks in order", () => {
+      expect(
+        markdownToTelegram("```\nfirst\n```\ntext\n```\nsecond\n```")
+      ).toBe("<pre>first</pre>\ntext\n<pre>second</pre>");
+    });
+
+    test("converts inline code to <code> and escapes HTML inside", () => {
+      expect(markdownToTelegram("use `<div>` tag")).toBe(
+        "use <code>&lt;div&gt;</code> tag"
+      );
+    });
+
+    test("does not apply markdown formatting inside inline code", () => {
+      expect(markdownToTelegram("run `a ** b` now")).toBe(
+        "run <code>a ** b</code> now"
+      );
+    });
+
+    test("restores multiple inline code spans on one line", () => {
+      expect(markdownToTelegram("`a` and `b`")).toBe(
+        "<code>a</code> and <code>b</code>"
+      );
+    });
+  });
+
+  describe("code blocks containing $ sequences", () => {
+    test("keeps $& from consuming the restored block", () => {
+      const result = markdownToTelegram(
+        '```bash\nsed -E "s/foo/[$&]/" file\n```'
+      );
+
+      expect(result).toBe('<pre>sed -E "s/foo/[$&amp;]/" file</pre>');
+      expect(result).not.toContain("CODEBLOCK");
+      expect(result).not.toContain("\x00");
+    });
+
+    test("keeps a literal $$ in a code block", () => {
+      const result = markdownToTelegram("```make\nall:\n\techo $$HOME\n```");
+
+      expect(result).toContain("echo $$HOME");
+    });
+
+    test("keeps $& literal in inline code", () => {
+      const result = markdownToTelegram("run `echo [$&]` first");
+
+      expect(result).toBe("run <code>echo [$&amp;]</code> first");
+      expect(result).not.toContain("INLINECODE");
+    });
+
+    test("keeps $` and $' literal in code blocks", () => {
+      const result = markdownToTelegram(
+        '```awk\nBEGIN { print "$` before, $\' after" }\n```'
+      );
+
+      expect(result).toContain("$` before, $' after");
+      expect(result).not.toContain("CODEBLOCK");
+    });
+
+    test("keeps $ sequences literal in think blocks", () => {
+      const result = markdownToTelegram(
+        "<think>cost is $$ and $& applies</think>done"
+      );
+
+      expect(result).toContain("cost is $$ and $&amp; applies");
+      expect(result).not.toContain("THINKBLOCK");
+    });
+
+    test("keeps $ sequences in plain text outside code", () => {
+      expect(markdownToTelegram("price is $5 and $$ or $& fine")).toBe(
+        "price is $5 and $$ or $&amp; fine"
+      );
+    });
+  });
+
+  describe("think blocks", () => {
+    test("converts a complete <think> block to a blockquote", () => {
+      expect(markdownToTelegram("<think>pondering</think>answer")).toBe(
+        "<blockquote>💭 <b>Thinking:</b>\npondering</blockquote>answer"
+      );
+    });
+
+    test("handles an unclosed <think> tag from a split message", () => {
+      expect(markdownToTelegram("<think>still pondering")).toBe(
+        "<blockquote>💭 <b>Thinking:</b>\nstill pondering</blockquote>"
+      );
+    });
+
+    test("handles a closing </think> without an opener from a split message", () => {
+      expect(markdownToTelegram("end of thought</think>final answer")).toBe(
+        "<blockquote>💭 <b>Thinking continued:</b>\nend of thought</blockquote>final answer"
+      );
+    });
+
+    test("uses an expandable blockquote for long thinking content", () => {
+      const result = markdownToTelegram(`<think>${"x".repeat(250)}</think>ok`);
+
+      expect(result).toContain("<blockquote expandable>");
+    });
+  });
+
+  describe("tables", () => {
+    test("converts markdown tables to aligned preformatted text", () => {
+      const result = markdownToTelegram(
+        "| Name | Age |\n| --- | --- |\n| Bob | 42 |"
+      );
+
+      expect(result).toContain("<pre>");
+      expect(result).toContain("Name │ Age");
+      expect(result).toContain("Bob");
+      expect(result).not.toContain("| --- |");
+    });
+  });
+
+  describe("unclosed tag handling for streaming", () => {
+    test("closes unclosed HTML tags by default", () => {
+      expect(markdownToTelegram("<b>hello", { escapeHtml: false })).toBe(
+        "<b>hello</b>"
+      );
+    });
+
+    test("leaves unclosed tags alone when closeUnclosedTags is false", () => {
+      expect(
+        markdownToTelegram("<b>hello", {
+          escapeHtml: false,
+          closeUnclosedTags: false,
+        })
+      ).toBe("<b>hello");
+    });
+
+    test("leaves incomplete markdown untouched mid-stream", () => {
+      expect(markdownToTelegram("streaming **bold text that got cut")).toBe(
+        "streaming **bold text that got cut"
+      );
+      expect(markdownToTelegram("```js\nconst a = 1;")).toBe(
+        "```js\nconst a = 1;"
+      );
+    });
+  });
+});
+
+describe("escapeHTML", () => {
+  test("escapes ampersands and angle brackets", () => {
+    expect(escapeHTML("<a> & </a>")).toBe("&lt;a&gt; &amp; &lt;/a&gt;");
+  });
+
+  test("leaves text without special characters unchanged", () => {
+    expect(escapeHTML("plain text")).toBe("plain text");
   });
 });

--- a/server/__tests__/utils/telegramBot/format.test.js
+++ b/server/__tests__/utils/telegramBot/format.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+const {
+  markdownToTelegram,
+} = require("../../../utils/telegramBot/utils/format");
+
+describe("markdownToTelegram code blocks containing $ sequences", () => {
+  test("keeps $& from consuming the restored block", () => {
+    const result = markdownToTelegram('```bash\nsed -E "s/foo/[$&]/" file\n```');
+
+    expect(result).toBe('<pre>sed -E "s/foo/[$&amp;]/" file</pre>');
+    expect(result).not.toContain("CODEBLOCK");
+  });
+
+  test("keeps a literal $$ in a code block", () => {
+    const result = markdownToTelegram("```make\nall:\n\techo $$HOME\n```");
+
+    expect(result).toContain("echo $$HOME");
+  });
+
+  test("keeps $& literal in inline code", () => {
+    const result = markdownToTelegram("run `echo [$&]` first");
+
+    expect(result).toBe("run <code>echo [$&amp;]</code> first");
+    expect(result).not.toContain("INLINECODE");
+  });
+});

--- a/server/utils/telegramBot/utils/format.js
+++ b/server/utils/telegramBot/utils/format.js
@@ -108,13 +108,13 @@ function markdownToTelegram(
 
   // Restore preserved blocks
   thinkBlocks.forEach((block, i) => {
-    result = result.replace(`\x00THINKBLOCK${i}\x00`, block);
+    result = result.replace(`\x00THINKBLOCK${i}\x00`, () => block);
   });
   codeBlocks.forEach((block, i) => {
-    result = result.replace(`\x00CODEBLOCK${i}\x00`, block);
+    result = result.replace(`\x00CODEBLOCK${i}\x00`, () => block);
   });
   inlineCode.forEach((code, i) => {
-    result = result.replace(`\x00INLINECODE${i}\x00`, code);
+    result = result.replace(`\x00INLINECODE${i}\x00`, () => code);
   });
 
   // Close any unclosed HTML tags to prevent Telegram API errors during streaming


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

resolves #6233

### Description

`markdownToTelegram` extracts code blocks to placeholders, formats the surrounding markdown, then restores them with `String.prototype.replace`. The second argument there is a replacement pattern, so `$$`, `$&`, `` $` `` and `$'` are expanded rather than inserted literally, and code blocks are exactly where those sequences appear.

Running the shipped function:

```
in : ```bash
     sed -E "s/foo/[$&]/" file
     ```
out: <pre>sed -E "s/foo/[ <NUL>CODEBLOCK0<NUL> amp;]/" file</pre>

in : ```make
     all:
     	echo $$HOME
     ```
out: <pre>all:
     	echo $HOME</pre>
```

The first case is the bad one: `$&` expands to the matched text, which is the placeholder itself, so an internal marker and a null byte land inside the user's code block. The second silently drops a `$`.

This is on the live send path for every bot reply, through both `editMessage` and `sendFormattedMessage`, so any shell, Makefile, sed or awk answer can come back wrong.

The fix passes a function replacer, which inserts the captured text verbatim. Applied to all three restore loops (think blocks, code blocks, inline code) since they share the defect. The repo already uses function replacers for this reason in `server/utils/chats/index.js`.

### Additional Information

Three tests in `server/__tests__/utils/telegramBot/format.test.js`. The function is pure with no requires, so they call it directly with no mocks.

All three fail against the current code and pass with the fix. I checked that deliberately rather than assuming: my first draft of the third case passed both before and after, so I replaced it with one that actually discriminates.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

I ran eslint over `server/`, the only package this touches, rather than the full root lint. I did not run a Docker build for a three line change, so I left that unchecked rather than tick it untested.
