### PR TITLE
fix: keep thread and user on the query-mode refusal row

### DIFF
--- a/server/__tests__/utils/chats/apiChatHandler.test.js
+++ b/server/__tests__/utils/chats/apiChatHandler.test.js
@@ -92,6 +92,10 @@ jest.mock("../../../utils/agents/ephemeral", () => {
 const { ApiChatHandler } = require("../../../utils/chats/apiChatHandler");
 const { WorkspaceChats } = require("../../../models/workspaceChats");
 const {
+  getVectorDbClass,
+  resolveProviderConnector,
+} = require("../../../utils/helpers");
+const {
   writeResponseChunk,
 } = require("../../../utils/helpers/chat/responses");
 const {
@@ -251,6 +255,44 @@ describe("ApiChatHandler @agent persistence", () => {
         })
       );
     });
+  });
+
+  describe("query-mode refusal, no embeddings", () => {
+    // Same contract as the agent saves above: a refusal row is still a turn,
+    // and must carry the scoping triple it was invoked with or it is orphaned.
+    test.each(REAL_WORLD_CASES)(
+      "chatSync keeps the scoping triple on the refusal row ($name)",
+      async ({ user, thread, sessionId }) => {
+        EphemeralAgentHandler.isAgentInvocation.mockResolvedValue(false);
+        resolveProviderConnector.mockResolvedValue({
+          connector: { promptWindowLimit: () => 8000 },
+          routingMetadata: null,
+        });
+        getVectorDbClass.mockReturnValue({
+          hasNamespace: jest.fn().mockResolvedValue(false),
+          namespaceCount: jest.fn().mockResolvedValue(0),
+        });
+
+        await ApiChatHandler.chatSync({
+          workspace,
+          message: "anything",
+          mode: "query",
+          user,
+          thread,
+          sessionId,
+        });
+
+        expect(WorkspaceChats.new).toHaveBeenCalledWith(
+          expect.objectContaining({
+            workspaceId: workspace.id,
+            include: false,
+            threadId: thread?.id || null,
+            apiSessionId: sessionId,
+            user,
+          })
+        );
+      }
+    );
   });
 
   describe("cross-cutting rules", () => {

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -259,8 +259,10 @@ async function chatSync({
         type: chatMode,
         metrics: {},
       },
+      threadId: thread?.id || null,
       include: false,
       apiSessionId: sessionId,
+      user,
     });
 
     return {


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

resolves #6234

### Description

`chatSync`'s query-mode refusal writes its chat row without `threadId` or `user`, so the turn is stored with `user_id: null` and `thread_id: null`.

Every other `WorkspaceChats.new` in this file passes the scoping triple it was invoked with. The streaming twin of this exact branch saves the same refusal text with `threadId: thread?.id || null` and `user`, and so does the other early exit inside `chatSync` itself. Both values are `chatSync` parameters and already in scope, so this is two lines.

Consequences beyond tidiness: the row is unattributed in admin Workspace Chats and in exports, and because `workspace_chats.thread_id` has no foreign key while `WorkspaceThread.delete` removes chats by `thread_id`, a refusal saved with a null `thread_id` outlives the thread it belonged to instead of being cleaned up with it. The same user action against `/chat` and `/stream-chat` currently persists differently.

### Additional Information

The contract this restores is already written down in the repo. The header of `server/__tests__/utils/chats/apiChatHandler.test.js` says the save "MUST persist the same triple it was invoked with, exactly like the non-agent saves in the same file, or the turn is invisible everywhere". This is one of those non-agent saves.

The new cases reuse that file's existing `REAL_WORLD_CASES` table, so they cover all four parameter combinations the v1 endpoints can produce: workspace chat with and without a sessionId, and thread chat with and without an attributed user.

Reverting the two production lines fails exactly those four cases and leaves the other eleven passing.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

I ran eslint over `server/`, the only package this touches, rather than the full root lint. I did not run a Docker build for a two line change, so I left that unchecked rather than tick it untested.
