### PR TITLE
fix: mobile reset-chat also clears API session history

### DIFF
--- a/server/__tests__/endpoints/mobile/utils/index.test.js
+++ b/server/__tests__/endpoints/mobile/utils/index.test.js
@@ -52,6 +52,7 @@ describe("handleMobileCommand: reset-chat", () => {
     expect(WorkspaceChats.markThreadHistoryInvalidV2).toHaveBeenCalledWith({
       workspaceId: 7,
       thread_id: 42,
+      api_session_id: null,
     });
   });
 
@@ -73,6 +74,7 @@ describe("handleMobileCommand: reset-chat", () => {
     expect(WorkspaceChats.markThreadHistoryInvalidV2).toHaveBeenCalledWith({
       workspaceId: 7,
       thread_id: null,
+      api_session_id: null,
     });
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith({ success: true });
@@ -90,9 +92,12 @@ describe("handleMobileCommand: reset-chat", () => {
     );
 
     expect(prisma.workspace_threads.findFirst).not.toHaveBeenCalled();
+    // api_session_id is named because API session chats also live on the
+    // default thread; row-level coverage is in chatHistoryReset.test.js.
     expect(WorkspaceChats.markThreadHistoryInvalidV2).toHaveBeenCalledWith({
       workspaceId: 7,
       thread_id: null,
+      api_session_id: null,
     });
   });
 });

--- a/server/__tests__/utils/chats/chatHistoryReset.test.js
+++ b/server/__tests__/utils/chats/chatHistoryReset.test.js
@@ -131,11 +131,24 @@ jest.mock("../../../utils/router", () => ({
   ModelRouterService: { resetForWorkspace: jest.fn() },
 }));
 
+// The mobile command handler pulls these in; reset-chat reaches none of them.
+jest.mock("../../../models/workspace", () => ({
+  Workspace: { get: jest.fn(), getWithUser: jest.fn() },
+}));
+jest.mock("../../../models/workspaceThread", () => ({ WorkspaceThread: {} }));
+jest.mock("../../../models/mobileDevice", () => ({ MobileDevice: {} }));
+jest.mock("../../../endpoints/utils", () => ({ getModelTag: () => "test" }));
+jest.mock("../../../utils/http", () => ({ reqBody: (request) => request.body }));
+
 const prisma = require("../../../utils/prisma");
 const { WorkspaceChats } = require("../../../models/workspaceChats");
 const { ApiChatHandler } = require("../../../utils/chats/apiChatHandler");
 const { recentChatHistory } = require("../../../utils/chats/index");
 const { resetMemory } = require("../../../utils/chats/commands/reset");
+const { Workspace } = require("../../../models/workspace");
+const {
+  handleMobileCommand,
+} = require("../../../endpoints/mobile/utils/index");
 
 const workspace = { id: 1, slug: "workspace-one", chatMode: "chat" };
 const otherWorkspace = { id: 2, slug: "workspace-two", chatMode: "chat" };
@@ -455,6 +468,64 @@ describe("UI /reset — workspace thread", () => {
     expect(await modelMemory({ user: userA, thread: threadT6 })).toEqual([
       "t6-userA",
     ]);
+    expectNothingDeleted();
+  });
+});
+
+describe("Mobile reset-chat - POST /mobile/reset-chat", () => {
+  function mobileResponse(user = null) {
+    return {
+      locals: { user },
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  }
+
+  test("single-user: clears the default thread but never API sessions", async () => {
+    Workspace.get.mockResolvedValue(workspace);
+    const response = mobileResponse();
+
+    await handleMobileCommand(
+      {
+        params: { command: "reset-chat" },
+        body: { workspaceSlug: workspace.slug },
+      },
+      response
+    );
+
+    expect(response.json).toHaveBeenCalledWith({ success: true });
+    // Same scope as the UI /reset: no user filter in single-user mode, so
+    // user-attributed rows on the default thread clear too. API session
+    // history lives on that same default thread and must survive.
+    await expectOnlyChanged({
+      workspaceListing: [],
+      userAListing: [],
+      userBListing: [],
+    });
+    expect(await modelMemory({ apiSessionId: "sess-a" })).toEqual([
+      "sess-a-1",
+      "sess-a-2",
+    ]);
+    expectNothingDeleted();
+  });
+
+  test("multi-user: clears only that user's default-thread history", async () => {
+    Workspace.getWithUser.mockResolvedValue(workspace);
+    const response = mobileResponse(userA);
+
+    await handleMobileCommand(
+      {
+        params: { command: "reset-chat" },
+        body: { workspaceSlug: workspace.slug },
+      },
+      response
+    );
+
+    await expectOnlyChanged({
+      workspaceListing: ["ws-single-1", "ws-single-2", "ws-userB"],
+      userAListing: [],
+    });
+    expect(await modelMemory({ user: userA })).toEqual([]);
     expectNothingDeleted();
   });
 });

--- a/server/endpoints/mobile/utils/index.js
+++ b/server/endpoints/mobile/utils/index.js
@@ -126,6 +126,7 @@ async function handleMobileCommand(request, response) {
       workspaceId: workspace.id,
       ...(user ? { user_id: user.id } : {}),
       thread_id: threadId, // null here is the default thread.
+      api_session_id: null, // API session chats also live on the default thread - a mobile reset must not clear them
     });
     return response.status(200).json({ success: true });
   }


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

resolves #6247

### Description

`markThreadHistoryInvalidV2` applies whatever where clause it is handed:

```js
await prisma.workspace_chats.updateMany({
  where: whereClause,
  data: { include: false },
});
```

so anything the clause omits is unconstrained. The mobile `reset-chat` handler omits `api_session_id`, and API session chats are written with `thread_id: null`, which puts them on the default thread.

In single-user mode the clause reduces to `{ workspaceId, thread_id: null }`, so a mobile reset marks every API session chat in the workspace `include: false`. It disappears from the model's context and, since #6237 added the `include` filter, from `GET /v1/workspace/:slug/chats?apiSessionId=...` as well.

Multi-user is not affected, and I checked rather than assumed. The clause adds `user_id` there, and the two endpoints that carry a `sessionId` both pass `user: null`, so every API session row has a null `user_id`. Both API session readers require `user_id: null` too.

The three sibling call sites already pin the key. The Telegram `/reset` handler passes `api_session_id: null`, and both `apiChatHandler` paths pass the session being reset. The UI reset, `markHistoryInvalid`, was given the same clause in `02b1f3c1` with the comment `API session chats also live on the default thread - a UI reset must not clear them`. Mobile was the only caller left without it.

### Additional Information

Worth flagging, because after this change it becomes visible rather than silent.

The two mobile read paths, the workspace chat count and the workspace-content listing, both query `{ workspaceId, include: true, ...(user ? { user_id } : {}) }` with no `api_session_id` clause. `forWorkspaceByUser` excludes them with the comment `do not include api-session chats in the frontend for anyone`, and the mobile reads do not.

So in single-user mode the mobile app already shows API session chats. Before this change a reset cleared them, which hid the listing inconsistency behind data loss. After it, those chats stay listed and reset no longer removes them. That is a pre-existing listing bug rather than something this introduces, but it is the behaviour you would see, and I did not want it read as a regression. Happy to send that as a separate PR if you want the mobile reads to match the frontend ones.

I also considered whether a mobile client should be able to reset a named API session. No mobile route can name one: `reset-chat` reads only `workspaceSlug` and `threadSlug`, and mobile `stream-chat` hardcodes `sessionId: null`, so every row mobile can create or read already has `api_session_id: null`. `null` scopes the reset to exactly what mobile owns.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

### Test

The reset contract file added in `02b1f3c1` says every reset writer must only touch its own scope, and lists the scopes it covers. Mobile was not one of them. This adds it there, using that file's existing harness, so the assertion is about surviving rows rather than the shape of a call.

Three states, not two:

| | single-user test | multi-user test |
| --- | --- | --- |
| this change | pass | pass |
| `api_session_id` removed (current code) | **fail** | pass |
| `api_session_id: undefined` | **fail** | pass |

The multi-user row is honest rather than decorative: that test passes with and without the fix, because multi-user was never broken. It is there to pin that, not to guard this change. The single-user test is the guard, and `undefined` is included because Prisma drops an undefined where field, which is the mistake that produced #6239.

The existing clause-shape assertions in `server/__tests__/endpoints/mobile/utils/index.test.js` needed the new key, so they were updated rather than added to.

Full suite: 50 suites, 674 tests, all passing, against a 50 suite and 672 test baseline on master measured with the same harness. `cd server && yarn lint:check` clean.
