### PR TITLE
fix: stop citation cleanup mangling scraped code and numbered links

### DIFF
--- a/collector/__tests__/processLink/helpers/htmlToMarkdown.test.js
+++ b/collector/__tests__/processLink/helpers/htmlToMarkdown.test.js
@@ -1,0 +1,38 @@
+/* eslint-env jest, node */
+process.env.STORAGE_DIR = "test-storage"; // needed for tests to run
+const {
+  htmlToMarkdown,
+} = require("../../../processLink/helpers/htmlToMarkdown");
+
+describe("htmlToMarkdown citation stripping", () => {
+  it("keeps a numeric index inside a fenced code block", async () => {
+    const markdown = await htmlToMarkdown(
+      "<pre><code>const second = items[1];</code></pre>"
+    );
+    expect(markdown).toContain("items[1]");
+  });
+
+  it("keeps a numeric index inside inline code", async () => {
+    const markdown = await htmlToMarkdown(
+      "<p>Use <code>arr[0]</code> to read the first element.</p>"
+    );
+    expect(markdown).toContain("`arr[0]`");
+  });
+
+  it("keeps a footnote link whose visible text is a number", async () => {
+    const markdown = await htmlToMarkdown(
+      '<p>See note<sup><a href="#fn1">1</a></sup> end.</p>',
+      "https://example.com"
+    );
+    // compactLinks emits an unescaped [1](#fn1), so the citation regex ate the
+    // link text and left a dangling (#fn1) behind.
+    expect(markdown).toBe("See note[1](#fn1) end.");
+  });
+
+  it("still removes a reference superscript from prose", async () => {
+    const markdown = await htmlToMarkdown(
+      '<p>As shown in the study<sup class="reference">[1]</sup>, results vary.</p>'
+    );
+    expect(markdown).toBe("As shown in the study, results vary.");
+  });
+});

--- a/collector/__tests__/processLink/helpers/htmlToMarkdown.test.js
+++ b/collector/__tests__/processLink/helpers/htmlToMarkdown.test.js
@@ -4,51 +4,220 @@ const {
   htmlToMarkdown,
 } = require("../../../processLink/helpers/htmlToMarkdown");
 
-describe("htmlToMarkdown citation stripping", () => {
-  it("keeps a numeric index inside a fenced code block", async () => {
-    const markdown = await htmlToMarkdown(
-      "<pre><code>const second = items[1];</code></pre>"
-    );
-    expect(markdown).toContain("items[1]");
+describe("htmlToMarkdown", () => {
+  describe("input handling", () => {
+    it("returns an empty string for null, undefined, and non-string input", async () => {
+      expect(await htmlToMarkdown(null)).toBe("");
+      expect(await htmlToMarkdown(undefined)).toBe("");
+      expect(await htmlToMarkdown(12345)).toBe("");
+      expect(await htmlToMarkdown("")).toBe("");
+    });
+
+    it("trims surrounding whitespace from the output", async () => {
+      expect(await htmlToMarkdown("<div>  <p>x</p>  </div>")).toBe("x");
+    });
   });
 
-  it("keeps a numeric index inside inline code", async () => {
-    const markdown = await htmlToMarkdown(
-      "<p>Use <code>arr[0]</code> to read the first element.</p>"
-    );
-    expect(markdown).toContain("`arr[0]`");
+  describe("content container selection", () => {
+    it("prefers <article> over <main> to avoid page chrome", async () => {
+      const markdown = await htmlToMarkdown(
+        "<main><p>file tree chrome</p><article><p>readme body</p></article></main>"
+      );
+      expect(markdown).toBe("readme body");
+    });
+
+    it("scopes to [role=main] when no article or main exists", async () => {
+      const markdown = await htmlToMarkdown(
+        '<div role="main"><p>kept</p></div><div><p>outside</p></div>'
+      );
+      expect(markdown).toBe("kept");
+    });
+
+    it("uses the whole document when no content container exists", async () => {
+      const markdown = await htmlToMarkdown("<div><p>a</p><p>b</p></div>");
+      expect(markdown).toBe("a\n\nb");
+    });
   });
 
-  it("keeps a footnote link whose visible text is a number", async () => {
-    const markdown = await htmlToMarkdown(
-      '<p>See note<sup><a href="#fn1">1</a></sup> end.</p>',
-      "https://example.com"
-    );
-    // compactLinks emits an unescaped [1](#fn1), so the citation regex ate the
-    // link text and left a dangling (#fn1) behind.
-    expect(markdown).toBe("See note[1](#fn1) end.");
+  describe("junk and hidden element stripping", () => {
+    it("removes nav, header, footer, and aside even inside the content container", async () => {
+      const markdown = await htmlToMarkdown(
+        "<nav>menu</nav><article><header>h</header><p>keep</p><aside>ad</aside><footer>f</footer></article>"
+      );
+      expect(markdown).toBe("keep");
+    });
+
+    it("removes script and style content", async () => {
+      const markdown = await htmlToMarkdown(
+        "<p>a</p><script>evil()</script><style>p{}</style>"
+      );
+      expect(markdown).toBe("a");
+    });
+
+    it("removes elements hidden via inline style, hidden, or aria-hidden", async () => {
+      const markdown = await htmlToMarkdown(
+        '<article><p style="display: none">a</p><p style="visibility:hidden">b</p>' +
+          '<p hidden>c</p><p aria-hidden="true">d</p><p>kept</p></article>'
+      );
+      expect(markdown).toBe("kept");
+    });
   });
 
-  it("keeps a numeric image alt text", async () => {
-    const markdown = await htmlToMarkdown(
-      '<p><img src="/a.png" alt="1"></p>',
-      "https://example.com"
-    );
-    expect(markdown).toBe("![1](https://example.com/a.png)");
+  describe("URL resolution", () => {
+    it("resolves relative link hrefs against the base URL", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><a href="/x/y">go</a></p>',
+        "https://ex.com/base/"
+      );
+      expect(markdown).toBe("[go](https://ex.com/x/y)");
+    });
+
+    it("leaves mailto and fragment hrefs untouched", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><a href="mailto:a@b.c">mail</a> <a href="#top">top</a></p>',
+        "https://ex.com"
+      );
+      expect(markdown).toBe("[mail](mailto:a@b.c) [top](#top)");
+    });
+
+    it("leaves relative hrefs as-is when no base URL is given", async () => {
+      const markdown = await htmlToMarkdown('<p><a href="/x/y">go</a></p>');
+      expect(markdown).toBe("[go](/x/y)");
+    });
+
+    it("resolves relative image srcs against the base URL", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><img src="./pics/a.png" alt="pic"></p>',
+        "https://ex.com/docs/"
+      );
+      expect(markdown).toBe("![pic](https://ex.com/docs/pics/a.png)");
+    });
   });
 
-  it("keeps a bracketed number inside a link target", async () => {
-    const markdown = await htmlToMarkdown(
-      '<p><a href="/docs/[1]/page">link</a></p>',
-      "https://example.com"
-    );
-    expect(markdown).toBe("[link](https://example.com/docs/[1]/page)");
+  describe("image filtering", () => {
+    it("removes base64 data-URI images", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p>t <img src="data:image/png;base64,AAAA" alt="x"></p>',
+        "https://ex.com"
+      );
+      expect(markdown).toBe("t");
+    });
+
+    it("removes badge/tracking images from ignored basepaths", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p>t <img src="https://img.shields.io/badge/x.svg" alt="badge"></p>',
+        "https://ex.com"
+      );
+      expect(markdown).toBe("t");
+    });
+
+    it("gives alt-less images a filename-based alt", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><img src="/imgs/photo.png"></p>',
+        "https://ex.com"
+      );
+      expect(markdown).toBe("![photo.png](https://ex.com/imgs/photo.png)");
+    });
   });
 
-  it("still removes a reference superscript from prose", async () => {
-    const markdown = await htmlToMarkdown(
-      '<p>As shown in the study<sup class="reference">[1]</sup>, results vary.</p>'
-    );
-    expect(markdown).toBe("As shown in the study, results vary.");
+  describe("compactLinks rule", () => {
+    it("collapses whitespace inside link text", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><a href="/x">two\n  words</a></p>',
+        "https://ex.com"
+      );
+      expect(markdown).toBe("[two words](https://ex.com/x)");
+    });
+
+    it("drops links with no visible text entirely", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p>before<a href="/x">   </a>after</p>',
+        "https://ex.com"
+      );
+      expect(markdown).toBe("before after");
+    });
+
+    it("keeps the text of an anchor with no href", async () => {
+      const markdown = await htmlToMarkdown("<p><a>plain</a></p>");
+      expect(markdown).toBe("plain");
+    });
+  });
+
+  describe("long URL stripping", () => {
+    const longUrl = `https://ex.com/${"a".repeat(300)}`;
+
+    it("removes images with 200+ character URLs", async () => {
+      const markdown = await htmlToMarkdown(
+        `<p>keep <img src="${longUrl}.png" alt="big"> end</p>`
+      );
+      expect(markdown).toBe("keep end");
+    });
+
+    it("unwraps links with 200+ character URLs, keeping the text", async () => {
+      const markdown = await htmlToMarkdown(
+        `<p><a href="${longUrl}">label</a></p>`
+      );
+      expect(markdown).toBe("label");
+    });
+  });
+
+  describe("citation stripping", () => {
+    it("removes reference and noprint superscripts before conversion", async () => {
+      expect(
+        await htmlToMarkdown(
+          '<p>As shown in the study<sup class="reference">[1]</sup>, results vary.</p>'
+        )
+      ).toBe("As shown in the study, results vary.");
+      expect(
+        await htmlToMarkdown('<p>fact<sup class="noprint">[note]</sup>.</p>')
+      ).toBe("fact.");
+    });
+
+    it("removes reference-section containers like .reflist", async () => {
+      const markdown = await htmlToMarkdown(
+        '<article><p>body</p><div class="reflist"><p>ref1</p></div></article>'
+      );
+      expect(markdown).toBe("body");
+    });
+
+    it("keeps a numeric index inside a fenced code block", async () => {
+      const markdown = await htmlToMarkdown(
+        "<pre><code>const second = items[1];</code></pre>"
+      );
+      expect(markdown).toContain("items[1]");
+    });
+
+    it("keeps a numeric index inside inline code", async () => {
+      const markdown = await htmlToMarkdown(
+        "<p>Use <code>arr[0]</code> to read the first element.</p>"
+      );
+      expect(markdown).toContain("`arr[0]`");
+    });
+
+    it("keeps a footnote link whose visible text is a number", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p>See note<sup><a href="#fn1">1</a></sup> end.</p>',
+        "https://example.com"
+      );
+      // compactLinks emits an unescaped [1](#fn1), so the citation regex ate the
+      // link text and left a dangling (#fn1) behind.
+      expect(markdown).toBe("See note[1](#fn1) end.");
+    });
+
+    it("keeps a numeric image alt text", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><img src="/a.png" alt="1"></p>',
+        "https://example.com"
+      );
+      expect(markdown).toBe("![1](https://example.com/a.png)");
+    });
+
+    it("keeps a bracketed number inside a link target", async () => {
+      const markdown = await htmlToMarkdown(
+        '<p><a href="/docs/[1]/page">link</a></p>',
+        "https://example.com"
+      );
+      expect(markdown).toBe("[link](https://example.com/docs/[1]/page)");
+    });
   });
 });

--- a/collector/__tests__/processLink/helpers/htmlToMarkdown.test.js
+++ b/collector/__tests__/processLink/helpers/htmlToMarkdown.test.js
@@ -29,6 +29,22 @@ describe("htmlToMarkdown citation stripping", () => {
     expect(markdown).toBe("See note[1](#fn1) end.");
   });
 
+  it("keeps a numeric image alt text", async () => {
+    const markdown = await htmlToMarkdown(
+      '<p><img src="/a.png" alt="1"></p>',
+      "https://example.com"
+    );
+    expect(markdown).toBe("![1](https://example.com/a.png)");
+  });
+
+  it("keeps a bracketed number inside a link target", async () => {
+    const markdown = await htmlToMarkdown(
+      '<p><a href="/docs/[1]/page">link</a></p>',
+      "https://example.com"
+    );
+    expect(markdown).toBe("[link](https://example.com/docs/[1]/page)");
+  });
+
   it("still removes a reference superscript from prose", async () => {
     const markdown = await htmlToMarkdown(
       '<p>As shown in the study<sup class="reference">[1]</sup>, results vary.</p>'

--- a/collector/processLink/helpers/htmlToMarkdown.js
+++ b/collector/processLink/helpers/htmlToMarkdown.js
@@ -102,7 +102,6 @@ function htmlToMarkdown(html, baseUrl) {
       return textMatch ? textMatch[1] : "";
     });
 
-    markdown = markdown.replace(/\[[\d]+\]/g, "");
     markdown = markdown.replace(/\[#cite[^\]]*\]/g, "");
     markdown = markdown.replace(/\[edit\]/gi, "");
 


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

resolves #6254

### Description

`htmlToMarkdown` ran this over the whole converted document to strip citation markers:

```js
markdown = markdown.replace(/\[[\d]+\]/g, "");
```

It never cleanly removed one. Turndown escapes brackets in prose text to `\[1\]`, which that pattern cannot match, so every context it did match was one it should have left alone.

**Inside code**, Turndown leaves brackets literal, so the regex ate them:

| input | before | after |
| --- | --- | --- |
| `<pre><code>const second = items[1];</code></pre>` | ``` const second = items; ``` | ``` const second = items[1]; ``` |
| `<p>Use <code>arr[0]</code></p>` | ``Use `arr` `` | ``Use `arr[0]` `` |

Scraping a page that documents an array index stored the wrong snippet, and the failure is silent: the link imports fine, and the corrupted text is what the model later cites.

**In markdown syntax**, Turndown and the converter emit unescaped brackets, and the pattern ate those too. `compactLinks` builds an unescaped `[text](href)`, so a link whose visible text is a number lost its text and stranded the URL:

```
<p>See note<sup><a href="#fn1">1</a></sup> end.</p>
  before: See note(#fn1) end.
  after:  See note[1](#fn1) end.

<a href="/page/1">1</a>
  before: (https://example.com/page/1)
  after:  [1](https://example.com/page/1)
```

Footnote markers and pagination controls are exactly the numbered links a scraped article tends to have.

Two further cases, same cause:

```
<p><img src="/a.png" alt="1"></p>
  before: !(/a.png)                  after: ![1](/a.png)

<p><a href="/docs/[1]/page">link</a></p>
  before: [link](/docs//page)        after: [link](/docs/[1]/page)
```

The second corrupts the URL itself rather than the text around it.

Reference superscripts are removed before conversion by `stripCitations`, which drops `sup.reference` and `sup.noprint`, so citation handling does not depend on this regex.

### Additional Information

The sibling `\[#cite...\]` and `\[edit\]` cleanups on the next two lines have the same shape and the same problem. `<pre><code>menu[edit] = true;</code></pre>` still stores `menu = true;` after this change. I left them alone to keep this reviewable, and can send them separately.

I considered scoping the regex to non-code regions instead of deleting it. That means writing a fence and span parser inside a cleanup line, and it still would not fix the numbered-link case, since those are real link syntax. Since every confirmed match corrupted source content or generated Markdown syntax, deleting it is the smaller and more honest change.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

### Test

Six tests in a new `collector/__tests__/processLink/helpers/htmlToMarkdown.test.js`.

Three states rather than two:

| implementation | result |
| --- | --- |
| this change | 6 pass |
| current code | 5 fail, the citation test passes |
| narrower `/\[\d+\](?!\()/g` | 3 fail, 3 pass |

The citation test passing under current code is deliberate. It is a control: it shows `stripCitations` already handles reference superscripts independently, so the deletion is not what would break citation removal. It would fail the wrong fix that removed `stripCitations` instead.

Full suite: 51 suites, 685 tests, all passing, against a 50 suite and 679 test baseline on master measured in the same tree. `cd collector && yarn lint:check` clean.



