### PR TITLE
Reasoning effort controls

### DIFF
--- a/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
@@ -2,7 +2,10 @@ import { useState, useEffect } from "react";
 import System from "@/models/system";
 import { CaretDown, CaretUp } from "@phosphor-icons/react";
 
-export default function AnthropicAiOptions({ settings }) {
+export default function AnthropicAiOptions({
+  settings,
+  reasoningControl = null,
+}) {
   const [showAdvancedControls, setShowAdvancedControls] = useState(false);
   const [inputValue, setInputValue] = useState(settings?.AnthropicApiKey);
   const [anthropicApiKey, setAnthropicApiKey] = useState(
@@ -35,6 +38,7 @@ export default function AnthropicAiOptions({ settings }) {
             settings={settings}
           />
         )}
+        {reasoningControl}
       </div>
       <div className="flex justify-start mt-4">
         <button

--- a/frontend/src/components/LLMSelection/DeepSeekOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/DeepSeekOptions/index.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import System from "@/models/system";
 
-export default function DeepSeekOptions({ settings }) {
+export default function DeepSeekOptions({ settings, reasoningControl = null }) {
   const [inputValue, setInputValue] = useState(settings?.DeepSeekApiKey);
   const [deepSeekApiKey, setDeepSeekApiKey] = useState(
     settings?.DeepSeekApiKey
@@ -29,6 +29,7 @@ export default function DeepSeekOptions({ settings }) {
       {!settings?.credentialsOnly && (
         <DeepSeekModelSelection settings={settings} apiKey={deepSeekApiKey} />
       )}
+      {reasoningControl}
     </div>
   );
 }

--- a/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
@@ -1,7 +1,10 @@
 import System from "@/models/system";
 import { useEffect, useState } from "react";
 
-export default function GeminiLLMOptions({ settings }) {
+export default function GeminiLLMOptions({
+  settings,
+  reasoningControl = null,
+}) {
   const [inputValue, setInputValue] = useState(settings?.GeminiLLMApiKey);
   const [geminiApiKey, setGeminiApiKey] = useState(settings?.GeminiLLMApiKey);
 
@@ -56,6 +59,7 @@ export default function GeminiLLMOptions({ settings }) {
             </div> */}
           </>
         )}
+        {reasoningControl}
       </div>
     </div>
   );

--- a/frontend/src/components/LLMSelection/OllamaLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/OllamaLLMOptions/index.jsx
@@ -6,7 +6,10 @@ import useProviderEndpointAutoDiscovery from "@/hooks/useProviderEndpointAutoDis
 import { Tooltip } from "react-tooltip";
 import { Link } from "react-router-dom";
 
-export default function OllamaLLMOptions({ settings }) {
+export default function OllamaLLMOptions({
+  settings,
+  reasoningControl = null,
+}) {
   const {
     autoDetecting: loading,
     basePath,
@@ -33,6 +36,7 @@ export default function OllamaLLMOptions({ settings }) {
           basePath={basePath.value}
           authToken={authToken.value}
         />
+        {reasoningControl}
       </div>
       <div className="flex justify-start mt-4">
         <button

--- a/frontend/src/components/LLMSelection/OpenAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/OpenAiOptions/index.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import System from "@/models/system";
 
-export default function OpenAiOptions({ settings }) {
+export default function OpenAiOptions({ settings, reasoningControl = null }) {
   const [inputValue, setInputValue] = useState(settings?.OpenAiKey);
   const [openAIKey, setOpenAIKey] = useState(settings?.OpenAiKey);
 
@@ -27,6 +27,7 @@ export default function OpenAiOptions({ settings }) {
       {!settings?.credentialsOnly && (
         <OpenAIModelSelection settings={settings} apiKey={openAIKey} />
       )}
+      {reasoningControl}
     </div>
   );
 }

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/RenderMetrics/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/RenderMetrics/index.jsx
@@ -34,12 +34,14 @@ function getAutoShowMetrics() {
  * - Model name
  * - Duration and output TPS
  * - Timestamp
- * @param {metrics: {duration:number, outputTps: number, model?: string, timestamp?: number}} metrics
+ * @param {metrics: {duration:number, outputTps: number, model?: string, reasoningEffort?: string, timestamp?: number}} metrics
  * @returns {string}
  */
 function buildMetricsString(metrics = {}) {
   return [
-    metrics?.model ? metrics.model : "",
+    metrics?.model
+      ? `${metrics.model}${metrics?.reasoningEffort ? ` (${metrics.reasoningEffort})` : ""}`
+      : "",
     `${formatDuration(metrics.duration)} (${formatTps(metrics.outputTps)} tok/s)`,
     metrics?.timestamp
       ? formatDateTimeAsMoment(metrics.timestamp, "MMM D, h:mm A")

--- a/frontend/src/components/WorkspaceChat/ChatContainer/WorkspaceModelPicker/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/WorkspaceModelPicker/index.jsx
@@ -19,8 +19,19 @@ async function resolveModelName(workspace, systemSettings, t) {
   const effectiveProvider =
     workspace.chatProvider ?? systemSettings?.LLMProvider;
 
-  if (effectiveProvider !== "anythingllm-router")
-    return workspace.chatModel ?? systemSettings?.LLMModel ?? "";
+  if (effectiveProvider !== "anythingllm-router") {
+    const modelName = workspace.chatModel ?? systemSettings?.LLMModel ?? "";
+    const reasoningEffort =
+      workspace.reasoningEffort ?? systemSettings?.ReasoningEffort ?? null;
+    if (!reasoningEffort) return modelName;
+
+    // A stored effort can outlive a model switch - only show it when the
+    // current model actually supports it, matching what gets sent.
+    const capabilities = await Workspace.llmCapabilities(workspace.slug);
+    return capabilities?.reasoningOptions?.includes(reasoningEffort)
+      ? `${modelName} (${reasoningEffort})`
+      : modelName;
+  }
 
   const routerId = workspace.router_id || systemSettings?.ModelRouterId;
   if (!routerId) return t("model-router.metrics.model-router-default");

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -253,6 +253,13 @@ const TRANSLATIONS = {
       "desc-end":
         "The higher the number the more creative. For some models this can lead to incoherent responses when set too high.",
     },
+    reasoning_effort: {
+      title: "Reasoning Effort",
+      description:
+        "Controls how much your model thinks before responding. Only shown for models that support reasoning controls.",
+      default: "Provider default",
+      global_default: "Global default ({{value}})",
+    },
   },
   "vector-workspace": {
     identifier: "Vector database identifier",

--- a/frontend/src/models/promptHistory.js
+++ b/frontend/src/models/promptHistory.js
@@ -63,12 +63,15 @@ const PromptHistory = {
     }
   },
 
-  delete: async function (id) {
+  delete: async function (workspaceId, id) {
     try {
-      return await fetch(`${API_BASE}/workspace/prompt-history/${id}`, {
-        method: "DELETE",
-        headers: baseHeaders(),
-      })
+      return await fetch(
+        `${API_BASE}/workspace/${workspaceId}/prompt-history/${id}`,
+        {
+          method: "DELETE",
+          headers: baseHeaders(),
+        }
+      )
         .then((res) => res.json())
         .catch((error) => {
           console.error("Error deleting prompt history:", error);

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -68,6 +68,31 @@ const System = {
       .catch(() => null);
   },
   /**
+   * Fetches the capabilities of the system LLM (or a given provider/model).
+   * @param {string|null} [provider] - Provider to preview capabilities for; defaults to the system LLM preference
+   * @param {string|null} [model] - Model to preview capabilities for; defaults to the provider's model preference
+   * @param {string|null} [basePath] - Unsaved base path for local providers
+   * @returns {Promise<{reasoning: 'unknown' | boolean, reasoningOptions: string[]}>}
+   */
+  llmCapabilities: async function (
+    provider = null,
+    model = null,
+    basePath = null
+  ) {
+    const params = new URLSearchParams();
+    if (provider) params.set("provider", provider);
+    if (model) params.set("model", model);
+    if (basePath) params.set("basePath", basePath);
+    const capabilities = await fetch(
+      `${API_BASE}/system/llm-capabilities?${params.toString()}`,
+      { headers: baseHeaders() }
+    )
+      .then((res) => res.json())
+      .then((res) => res.capabilities)
+      .catch(() => null);
+    return capabilities ?? { reasoning: "unknown", reasoningOptions: [] };
+  },
+  /**
    * Without a folderName, returns the folder shells for the picker.
    * With one, returns that folder's documents.
    * @param {string|null} folderName

--- a/frontend/src/models/workspace.js
+++ b/frontend/src/models/workspace.js
@@ -250,6 +250,25 @@ const Workspace = {
       .catch(() => null);
     return workspace;
   },
+  /**
+   * Fetches the capabilities of the workspace's current LLM model.
+   * @param {string} slug - Workspace slug
+   * @param {{provider: string, model: string|null}|null} [pendingLLM] - Unsaved provider/model selection to preview capabilities for
+   * @returns {Promise<{reasoning: 'unknown' | boolean, reasoningOptions: string[]}>}
+   */
+  llmCapabilities: async function (slug = "", pendingLLM = null) {
+    const params = new URLSearchParams();
+    if (pendingLLM?.provider) params.set("provider", pendingLLM.provider);
+    if (pendingLLM?.model) params.set("model", pendingLLM.model);
+    const capabilities = await fetch(
+      `${API_BASE}/workspace/${slug}/llm-capabilities?${params.toString()}`,
+      { headers: baseHeaders() }
+    )
+      .then((res) => res.json())
+      .then((res) => res.capabilities)
+      .catch(() => null);
+    return capabilities ?? { reasoning: "unknown", reasoningOptions: [] };
+  },
   delete: async function (slug) {
     const result = await fetch(`${API_BASE}/workspace/${slug}`, {
       method: "DELETE",

--- a/frontend/src/pages/GeneralSettings/LLMPreference/SystemReasoningEffort/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/SystemReasoningEffort/index.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import System from "@/models/system";
+
+/**
+ * Sets the system-wide default reasoning effort for the selected LLM provider.
+ * Workspaces without their own reasoning effort fall back to this value.
+ * @param {object} props
+ * @param {object} props.settings - System settings
+ * @param {string|null} props.selectedLLM - Currently selected (possibly unsaved) provider
+ * @param {string|null} [props.selectedModel] - Currently selected (possibly unsaved) model
+ * @param {string|null} [props.basePath] - Unsaved base path for local providers
+ * @param {number} [props.refreshKey] - Bumped by the parent to force a capability refetch (eg: after save)
+ */
+export default function SystemReasoningEffort({
+  settings,
+  selectedLLM,
+  selectedModel = null,
+  basePath = null,
+  refreshKey = 0,
+}) {
+  const { t } = useTranslation();
+  const [capabilities, setCapabilities] = useState(null);
+
+  useEffect(() => {
+    async function fetchCapabilities() {
+      setCapabilities(
+        await System.llmCapabilities(selectedLLM, selectedModel, basePath)
+      );
+    }
+    fetchCapabilities();
+  }, [selectedLLM, selectedModel, basePath, refreshKey]);
+
+  if (
+    capabilities?.reasoning !== true ||
+    !capabilities?.reasoningOptions?.length
+  )
+    return null;
+
+  return (
+    <div className="flex flex-col w-60">
+      <label className="text-white text-sm font-semibold block mb-3">
+        {t("chat.reasoning_effort.title")}
+      </label>
+      <select
+        key={`${selectedLLM}-${selectedModel}`}
+        name="ReasoningEffort"
+        defaultValue={settings?.ReasoningEffort ?? ""}
+        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 capitalize"
+      >
+        <option value="">{t("chat.reasoning_effort.default")}</option>
+        {capabilities.reasoningOptions.map((option) => (
+          <option key={option} value={option} className="capitalize">
+            {option}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -88,6 +88,7 @@ import LLMItem from "@/components/LLMSelection/LLMItem";
 import { CaretUpDown, MagnifyingGlass, X } from "@phosphor-icons/react";
 import CTAButton from "@/components/lib/CTAButton";
 import OMLXOptions from "@/components/LLMSelection/OMLXOptions";
+import SystemReasoningEffort from "./SystemReasoningEffort";
 
 export const MODEL_ROUTER_PROVIDER = {
   name: "Model Router",
@@ -108,7 +109,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "OpenAI",
     value: "openai",
     logo: OpenAiLogo,
-    options: (settings) => <OpenAiOptions settings={settings} />,
+    options: (settings, extras) => (
+      <OpenAiOptions settings={settings} {...extras} />
+    ),
     description: "The standard option for most non-commercial use.",
     requiredConfig: ["OpenAiKey"],
   },
@@ -124,7 +127,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "Anthropic",
     value: "anthropic",
     logo: AnthropicLogo,
-    options: (settings) => <AnthropicAiOptions settings={settings} />,
+    options: (settings, extras) => (
+      <AnthropicAiOptions settings={settings} {...extras} />
+    ),
     description: "A friendly AI Assistant hosted by Anthropic.",
     requiredConfig: ["AnthropicApiKey"],
   },
@@ -132,7 +137,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "Gemini",
     value: "gemini",
     logo: GeminiLogo,
-    options: (settings) => <GeminiLLMOptions settings={settings} />,
+    options: (settings, extras) => (
+      <GeminiLLMOptions settings={settings} {...extras} />
+    ),
     description: "Google's largest and most capable AI model",
     requiredConfig: ["GeminiLLMApiKey"],
   },
@@ -149,7 +156,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "Ollama",
     value: "ollama",
     logo: OllamaLogo,
-    options: (settings) => <OllamaLLMOptions settings={settings} />,
+    options: (settings, extras) => (
+      <OllamaLLMOptions settings={settings} {...extras} />
+    ),
     description: "Run LLMs locally on your own machine.",
     requiredConfig: ["OllamaLLMBasePath"],
   },
@@ -157,7 +166,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "LM Studio",
     value: "lmstudio",
     logo: LMStudioLogo,
-    options: (settings) => <LMStudioOptions settings={settings} />,
+    options: (settings, extras) => (
+      <LMStudioOptions settings={settings} {...extras} />
+    ),
     description:
       "Discover, download, and run thousands of cutting edge LLMs in a few clicks.",
     requiredConfig: ["LMStudioBasePath"],
@@ -174,7 +185,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "Lemonade",
     value: "lemonade",
     logo: LemonadeLogo,
-    options: (settings) => <LemonadeOptions settings={settings} />,
+    options: (settings, extras) => (
+      <LemonadeOptions settings={settings} {...extras} />
+    ),
     description:
       "Run local LLMs, ASR, TTS, and more in a single unified AI runtime.",
     requiredConfig: ["LemonadeLLMBasePath"],
@@ -287,7 +300,9 @@ export const AVAILABLE_LLM_PROVIDERS = [
     name: "DeepSeek",
     value: "deepseek",
     logo: DeepSeekLogo,
-    options: (settings) => <DeepSeekOptions settings={settings} />,
+    options: (settings, extras) => (
+      <DeepSeekOptions settings={settings} {...extras} />
+    ),
     description: "Run DeepSeek's powerful LLMs.",
     requiredConfig: ["DeepSeekApiKey"],
   },
@@ -456,6 +471,13 @@ export default function GeneralLLMPreference() {
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredLLMs, setFilteredLLMs] = useState([]);
   const [selectedLLM, setSelectedLLM] = useState(null);
+  // Unsaved model/base path selections bubbled up from the provider's options
+  // component so dependent controls (eg: reasoning effort) can preview
+  // capabilities before the form is saved.
+  const [pendingModel, setPendingModel] = useState(null);
+  const [pendingBasePath, setPendingBasePath] = useState(null);
+  // Bumped on save so capability-dependent controls refetch.
+  const [savedCount, setSavedCount] = useState(0);
   const [searchMenuOpen, setSearchMenuOpen] = useState(false);
   const searchInputRef = useRef(null);
   const { t } = useTranslation();
@@ -474,6 +496,7 @@ export default function GeneralLLMPreference() {
       showToast(`Failed to save LLM settings: ${error}`, "error");
     } else {
       showToast("LLM preferences saved successfully.", "success");
+      setSavedCount((count) => count + 1);
     }
     setSaving(false);
     setHasChanges(!!error);
@@ -482,6 +505,8 @@ export default function GeneralLLMPreference() {
   const updateLLMChoice = (selection) => {
     setSearchQuery("");
     setSelectedLLM(selection);
+    setPendingModel(null);
+    setPendingBasePath(null);
     setSearchMenuOpen(false);
     setHasChanges(true);
   };
@@ -655,13 +680,31 @@ export default function GeneralLLMPreference() {
                 )}
               </div>
               <div
-                onChange={() => setHasChanges(true)}
+                onChange={(e) => {
+                  setHasChanges(true);
+                  // Every provider's model selector input is named `*ModelPref`
+                  // and every local provider's endpoint input `*BasePath`.
+                  if (e.target?.name?.endsWith("ModelPref"))
+                    setPendingModel(e.target.value);
+                  if (e.target?.name?.endsWith("BasePath"))
+                    setPendingBasePath(e.target.value);
+                }}
                 className="mt-4 flex flex-col gap-y-1"
               >
                 {selectedLLM &&
                   AVAILABLE_LLM_PROVIDERS.find(
                     (llm) => llm.value === selectedLLM
-                  )?.options?.(settings)}
+                  )?.options?.(settings, {
+                    reasoningControl: (
+                      <SystemReasoningEffort
+                        settings={settings}
+                        selectedLLM={selectedLLM}
+                        selectedModel={pendingModel}
+                        basePath={pendingBasePath}
+                        refreshKey={savedCount}
+                      />
+                    ),
+                  })}
               </div>
             </div>
           </form>

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/ChatPromptHistory/PromptHistoryItem/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/ChatPromptHistory/PromptHistoryItem/index.jsx
@@ -9,6 +9,7 @@ const MAX_PROMPT_LENGTH = 200; // chars
 
 export default function PromptHistoryItem({
   id,
+  workspaceSlug,
   prompt,
   modifiedAt,
   user,
@@ -24,7 +25,7 @@ export default function PromptHistoryItem({
 
   const deleteHistory = async (id) => {
     if (window.confirm(t("chat.prompt.history.deleteConfirm"))) {
-      const { success } = await PromptHistory.delete(id);
+      const { success } = await PromptHistory.delete(workspaceSlug, id);
       if (success) {
         setHistory((prevHistory) =>
           prevHistory.filter((item) => item.id !== id)

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/ChatPromptHistory/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/ChatPromptHistory/index.jsx
@@ -90,6 +90,7 @@ export default forwardRef(function ChatPromptHistory(
             <PromptHistoryItem
               key={item.id}
               id={item.id}
+              workspaceSlug={workspaceSlug}
               {...item}
               onRestore={() => onRestore(item.prompt)}
               onPublishClick={onPublishClick}

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ReasoningEffortSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ReasoningEffortSettings/index.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import Workspace from "@/models/workspace";
+
+/**
+ * @param {object} props
+ * @param {object} props.settings - System settings
+ * @param {object} props.workspace - Workspace object
+ * @param {function} props.setHasChanges - Marks the settings form dirty
+ * @param {{provider: string, model: string|null}|null} [props.pendingLLM] - Unsaved provider/model selection to preview capabilities for
+ */
+export default function ReasoningEffortSettings({
+  settings,
+  workspace,
+  setHasChanges,
+  pendingLLM = null,
+}) {
+  const { t } = useTranslation();
+  const [capabilities, setCapabilities] = useState(null);
+
+  useEffect(() => {
+    async function fetchCapabilities() {
+      setCapabilities(
+        await Workspace.llmCapabilities(workspace.slug, pendingLLM)
+      );
+    }
+    fetchCapabilities();
+  }, [workspace.slug, workspace.chatProvider, workspace.chatModel, pendingLLM]);
+
+  if (
+    capabilities?.reasoning !== true ||
+    !capabilities?.reasoningOptions?.length
+  )
+    return null;
+
+  return (
+    <div>
+      <div className="flex flex-col gap-y-[8px] mb-[8px]">
+        <label htmlFor="reasoningEffort" className="block input-label">
+          {t("chat.reasoning_effort.title")}
+        </label>
+        <p className="text-white text-opacity-60 text-xs font-medium">
+          {t("chat.reasoning_effort.description")}
+        </p>
+      </div>
+      <select
+        key={`${pendingLLM?.provider ?? workspace?.chatProvider}-${pendingLLM?.model ?? workspace?.chatModel}`}
+        name="reasoningEffort"
+        defaultValue={workspace?.reasoningEffort ?? ""}
+        onChange={() => setHasChanges(true)}
+        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 capitalize"
+      >
+        <option value="">
+          {settings?.ReasoningEffort
+            ? t("chat.reasoning_effort.global_default", {
+                value: settings.ReasoningEffort,
+              })
+            : t("chat.reasoning_effort.default")}
+        </option>
+        {capabilities.reasoningOptions.map((option) => (
+          <option key={option} value={option} className="capitalize">
+            {option}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
@@ -7,6 +7,7 @@ export default function ChatModelSelection({
   provider,
   workspace,
   setHasChanges,
+  onModelChange = () => {},
 }) {
   const { defaultModels, customModels, loading, downloadedModels } =
     useGetProviderModels(provider);
@@ -52,8 +53,9 @@ export default function ChatModelSelection({
       <select
         name="chatModel"
         required={true}
-        onChange={() => {
+        onChange={(e) => {
           setHasChanges(true);
+          onModelChange(e.target.value);
         }}
         className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
       >

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
@@ -34,10 +34,18 @@ const LLMS = [LLM_DEFAULT, ...ALL_LLM_PROVIDERS].filter(
   (llm) => !DISABLED_PROVIDERS.includes(llm.value)
 );
 
+/**
+ * @param {object} props
+ * @param {object} props.settings - System settings
+ * @param {object} props.workspace - Workspace object
+ * @param {function} props.setHasChanges - Marks the settings form dirty
+ * @param {function} [props.onSelectionChange] - Called with `{ provider, model }` when the unsaved provider/model selection changes
+ */
 export default function WorkspaceLLMSelection({
   settings,
   workspace,
   setHasChanges,
+  onSelectionChange = () => {},
 }) {
   const [filteredLLMs, setFilteredLLMs] = useState([]);
   const [selectedLLM, setSelectedLLM] = useState(
@@ -52,6 +60,7 @@ export default function WorkspaceLLMSelection({
     setSelectedLLM(selection);
     setSearchMenuOpen(false);
     setHasChanges(true);
+    onSelectionChange({ provider: selection, model: null });
   }
 
   function handleXButton() {
@@ -163,13 +172,21 @@ export default function WorkspaceLLMSelection({
         selectedLLM={selectedLLM}
         workspace={workspace}
         setHasChanges={setHasChanges}
+        onModelChange={(model) =>
+          onSelectionChange({ provider: selectedLLM, model })
+        }
       />
     </div>
   );
 }
 
 // TODO: Add this to agent selector as well as make generic component.
-function ModelSelector({ selectedLLM, workspace, setHasChanges }) {
+function ModelSelector({
+  selectedLLM,
+  workspace,
+  setHasChanges,
+  onModelChange,
+}) {
   if (selectedLLM === "anythingllm-router") {
     return (
       <RouterSelection workspace={workspace} setHasChanges={setHasChanges} />
@@ -205,6 +222,7 @@ function ModelSelector({ selectedLLM, workspace, setHasChanges }) {
       provider={selectedLLM}
       workspace={workspace}
       setHasChanges={setHasChanges}
+      onModelChange={onModelChange}
     />
   );
 }

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/index.jsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import ChatHistorySettings from "./ChatHistorySettings";
 import ChatPromptSettings from "./ChatPromptSettings";
 import ChatTemperatureSettings from "./ChatTemperatureSettings";
+import ReasoningEffortSettings from "./ReasoningEffortSettings";
 import ChatModeSelection from "./ChatModeSelection";
 import WorkspaceLLMSelection from "./WorkspaceLLMSelection";
 import ChatQueryRefusalResponse from "./ChatQueryRefusalResponse";
@@ -15,6 +16,12 @@ export default function ChatSettings({ workspace }) {
   const [settings, setSettings] = useState({});
   const [hasChanges, setHasChanges] = useState(false);
   const [saving, setSaving] = useState(false);
+  // Tracks saved updates so children depending on the workspace's current
+  // provider/model (eg: reasoning controls) re-render without a page refresh.
+  const [currentWorkspace, setCurrentWorkspace] = useState(workspace);
+  // Unsaved provider/model selection from the LLM picker so dependent
+  // controls can preview capabilities before the form is saved.
+  const [pendingLLM, setPendingLLM] = useState(null);
 
   const formEl = useRef(null);
   useEffect(() => {
@@ -38,6 +45,8 @@ export default function ChatSettings({ workspace }) {
     );
     if (updatedWorkspace) {
       showToast("Workspace updated!", "success", { clear: true });
+      setCurrentWorkspace(updatedWorkspace);
+      setPendingLLM(null);
       setHasChanges(false);
     } else {
       showToast(`Error: ${message}`, "error", { clear: true });
@@ -65,6 +74,13 @@ export default function ChatSettings({ workspace }) {
         <WorkspaceLLMSelection
           settings={settings}
           workspace={workspace}
+          setHasChanges={setHasChanges}
+          onSelectionChange={setPendingLLM}
+        />
+        <ReasoningEffortSettings
+          settings={settings}
+          workspace={currentWorkspace ?? workspace}
+          pendingLLM={pendingLLM}
           setHasChanges={setHasChanges}
         />
         <ChatModeSelection

--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -327,9 +327,9 @@ function apiDocumentEndpoints(app) {
     async (request, response) => {
       /*
     #swagger.tags = ['Documents']
-    #swagger.description = 'Upload a valid URL for AnythingLLM to scrape and prepare for embedding. Optionally, specify a comma-separated list of workspace slugs to embed the document into post-upload.'
+    #swagger.description = 'Upload a valid URL for AnythingLLM to scrape and prepare for embedding. The link property can be a single URL string or an array of URL strings. Optionally, specify a comma-separated list of workspace slugs to embed the document into post-upload.'
     #swagger.requestBody = {
-      description: 'Link of web address to be scraped and optionally a comma-separated list of workspace slugs to embed the document into post-upload, and optional metadata.',
+      description: 'Link of web address to be scraped and optionally a comma-separated list of workspace slugs to embed the document into post-upload, and optional metadata. The link property also accepts an array of links to process in a single request.',
       required: true,
       content: {
           "application/json": {
@@ -391,11 +391,31 @@ function apiDocumentEndpoints(app) {
       try {
         const Collector = new CollectorApi();
         const {
-          link,
+          link = "",
           addToWorkspaces = "",
           scraperHeaders = {},
           metadata: _metadata = {},
         } = reqBody(request);
+
+        // `link` can be a single URL string or an array of URL strings.
+        // Drop any non-string or empty entries - URL validation itself is
+        // handled by the collector when each link is processed.
+        const links = (Array.isArray(link) ? link : [link])
+          .filter((url) => typeof url === "string" && url.trim().length > 0)
+          .map((url) => url.trim());
+
+        if (links.length === 0) {
+          return response
+            .status(422)
+            .json({
+              success: false,
+              error:
+                "link must be a non-empty string or an array of non-empty strings.",
+              documents: [],
+            })
+            .end();
+        }
+
         const metadata =
           typeof _metadata === "string"
             ? safeJsonParse(_metadata, {})
@@ -407,37 +427,69 @@ function apiDocumentEndpoints(app) {
             .status(500)
             .json({
               success: false,
-              error: `Document processing API is not online. Link ${link} will not be processed automatically.`,
+              error: `Document processing API is not online. Link(s) ${links.join(", ")} will not be processed automatically.`,
+              documents: [],
             })
             .end();
         }
 
-        const { success, reason, documents } = await Collector.processLink(
-          link,
-          scraperHeaders,
-          metadata
+        const results = await Promise.all(
+          links.map(async (url) => ({
+            url,
+            ...(await Collector.processLink(url, scraperHeaders, metadata)),
+          }))
         );
-        if (!success) {
+
+        const documents = [];
+        const failures = [];
+        for (const result of results) {
+          const {
+            url,
+            success,
+            reason,
+            documents: linkDocuments = [],
+          } = result;
+          if (!success) {
+            failures.push({ url, reason: reason || "Failed to process link." });
+            continue;
+          }
+
+          Collector.log(
+            `Link ${url} uploaded processed and successfully. It is now available in documents.`
+          );
+          await Telemetry.sendTelemetry("link_uploaded");
+          await EventLogs.logEvent("api_link_uploaded", { link: url });
+          documents.push(...linkDocuments);
+        }
+
+        if (!!addToWorkspaces) {
+          for (const document of documents) {
+            await Document.api.uploadToWorkspace(
+              addToWorkspaces,
+              document.location
+            );
+          }
+        }
+
+        const error =
+          failures.length === 0
+            ? null
+            : links.length === 1
+              ? failures[0].reason
+              : failures
+                  .map(({ url, reason }) => `${url}: ${reason}`)
+                  .join("; ");
+
+        if (documents.length === 0 && failures.length > 0) {
           return response
             .status(500)
-            .json({ success: false, error: reason, documents })
+            .json({ success: false, error, documents })
             .end();
         }
 
-        Collector.log(
-          `Link ${link} uploaded processed and successfully. It is now available in documents.`
-        );
-        await Telemetry.sendTelemetry("link_uploaded");
-        await EventLogs.logEvent("api_link_uploaded", {
-          link,
-        });
-
-        if (!!addToWorkspaces)
-          await Document.api.uploadToWorkspace(
-            addToWorkspaces,
-            documents?.[0].location
-          );
-        response.status(200).json({ success: true, error: null, documents });
+        response
+          .status(200)
+          .json({ success: failures.length === 0, error, documents });
       } catch (e) {
         console.error(e.message, e);
         response.sendStatus(500).end();

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -10,7 +10,7 @@ const {
   getDocumentsByDocPaths,
 } = require("../utils/files");
 const { purgeDocument, purgeFolder } = require("../utils/files/purgeDocument");
-const { getVectorDbClass } = require("../utils/helpers");
+const { getVectorDbClass, getLLMProvider } = require("../utils/helpers");
 const { updateENV, dumpENV } = require("../utils/helpers/updateENV");
 const {
   reqBody,
@@ -584,6 +584,49 @@ function systemEndpoints(app) {
       } catch (e) {
         console.error(e.message, e);
         response.sendStatus(500).end();
+      }
+    }
+  );
+
+  app.get(
+    "/system/llm-capabilities",
+    [validatedRequest, flexUserRoleValid([ROLES.admin])],
+    async (request, response) => {
+      // Local providers read their endpoint from the ENV, so previewing an
+      // unsaved base path means overriding it for the duration of this check.
+      const BASE_PATH_ENV = {
+        ollama: "OLLAMA_BASE_PATH",
+        lmstudio: "LMSTUDIO_BASE_PATH",
+        lemonade: "LEMONADE_LLM_BASE_PATH",
+      };
+
+      // Optional overrides let the UI preview capabilities for an unsaved
+      // provider selection - otherwise the system LLM preference is used.
+      const { provider = null, model = null, basePath = null } = request.query;
+      const envKey = provider ? BASE_PATH_ENV[String(provider)] : null;
+      const originalBasePath = envKey ? process.env[envKey] : null;
+
+      try {
+        if (envKey && basePath) process.env[envKey] = String(basePath);
+        const LLMProvider = getLLMProvider({
+          provider: provider ? String(provider) : null,
+          model: model ? String(model) : null,
+        });
+        const capabilities = (await LLMProvider.getModelCapabilities?.()) ?? {
+          reasoning: "unknown",
+          reasoningOptions: [],
+        };
+        return response.status(200).json({ capabilities });
+      } catch (e) {
+        console.error(e.message, e);
+        return response.status(200).json({
+          capabilities: { reasoning: "unknown", reasoningOptions: [] },
+        });
+      } finally {
+        if (envKey && basePath) {
+          if (originalBasePath === undefined) delete process.env[envKey];
+          else process.env[envKey] = originalBasePath;
+        }
       }
     }
   );

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -9,7 +9,11 @@ const { Workspace } = require("../models/workspace");
 const { Document } = require("../models/documents");
 const { DocumentVectors } = require("../models/vectors");
 const { WorkspaceChats } = require("../models/workspaceChats");
-const { getVectorDbClass, stripThinkingFromText } = require("../utils/helpers");
+const {
+  getVectorDbClass,
+  getLLMProvider,
+  stripThinkingFromText,
+} = require("../utils/helpers");
 const { handleFileUpload } = require("../utils/files/multer");
 const { validatedRequest } = require("../utils/middleware/validatedRequest");
 const { Telemetry } = require("../models/telemetry");
@@ -406,6 +410,47 @@ function workspaceEndpoints(app) {
       } catch (e) {
         console.error(e.message, e);
         response.sendStatus(500).end();
+      }
+    }
+  );
+
+  app.get(
+    "/workspace/:slug/llm-capabilities",
+    [validatedRequest, flexUserRoleValid([ROLES.all])],
+    async (request, response) => {
+      try {
+        const { slug } = request.params;
+        const user = await userFromSession(request, response);
+        const workspace = multiUserMode(response)
+          ? await Workspace.getWithUser(user, { slug })
+          : await Workspace.get({ slug });
+        if (!workspace) return response.sendStatus(400);
+
+        // Optional overrides let the UI preview capabilities for an unsaved
+        // provider/model selection. "default" means the system LLM preference.
+        const { provider = null, model = null } = request.query;
+        const LLMProvider = getLLMProvider({
+          provider: provider
+            ? provider === "default"
+              ? null
+              : String(provider)
+            : workspace.chatProvider,
+          model: provider
+            ? model
+              ? String(model)
+              : null
+            : workspace.chatModel,
+        });
+        const capabilities = (await LLMProvider.getModelCapabilities?.()) ?? {
+          reasoning: "unknown",
+          reasoningOptions: [],
+        };
+        return response.status(200).json({ capabilities });
+      } catch (e) {
+        console.error(e.message, e);
+        return response.status(200).json({
+          capabilities: { reasoning: "unknown", reasoningOptions: [] },
+        });
       }
     }
   );

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -643,7 +643,7 @@ function workspaceEndpoints(app) {
       } catch (error) {
         console.error("Error processing the suggested messages:", error);
         response.status(500).json({
-          success: true,
+          success: false,
           message: "Error saving the suggested messages.",
         });
       }
@@ -934,7 +934,11 @@ function workspaceEndpoints(app) {
 
   app.get(
     "/workspace/:slug/prompt-history",
-    [validatedRequest, flexUserRoleValid([ROLES.all]), validWorkspaceSlug],
+    [
+      validatedRequest,
+      flexUserRoleValid([ROLES.admin, ROLES.manager]),
+      validWorkspaceSlug,
+    ],
     async (_, response) => {
       try {
         response.status(200).json({
@@ -971,7 +975,7 @@ function workspaceEndpoints(app) {
   );
 
   app.delete(
-    "/workspace/prompt-history/:id",
+    "/workspace/:slug/prompt-history/:id",
     [
       validatedRequest,
       flexUserRoleValid([ROLES.admin, ROLES.manager]),

--- a/server/endpoints/workspacesParsedFiles.js
+++ b/server/endpoints/workspacesParsedFiles.js
@@ -100,7 +100,7 @@ function workspaceParsedFilesEndpoints(app) {
         await EventLogs.logEvent(
           "document_embedded",
           {
-            documentName: document?.name || "unknown",
+            documentName: document?.filename || "unknown",
             workspaceId: workspace.id,
           },
           user?.id

--- a/server/models/promptHistory.js
+++ b/server/models/promptHistory.js
@@ -86,6 +86,25 @@ const PromptHistory = {
   },
 
   /**
+   * Delete a single prompt history entry scoped to a workspace.
+   * @param {Object} options
+   * @param {number} options.id - The ID of the prompt history entry.
+   * @param {number} options.workspaceId - The workspace the entry must belong to.
+   * @returns {Promise<boolean>} true only if a matching entry was deleted.
+   */
+  deleteForWorkspace: async function ({ id, workspaceId }) {
+    try {
+      const { count } = await prisma.prompt_history.deleteMany({
+        where: { id: Number(id), workspaceId: Number(workspaceId) },
+      });
+      return count > 0;
+    } catch (error) {
+      console.error(error.message);
+      return false;
+    }
+  },
+
+  /**
    * Utility method to handle prompt changes and create history entries
    * @param {import('./workspace').Workspace} workspaceData - The workspace object (previous state)
    * @param {{id: number, role: string}|null} user - The user making the change

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -526,6 +526,7 @@ const SystemSettings = {
       // --------------------------------------------------------
       LLMProvider: llmProvider,
       LLMModel: getBaseLLMProviderModel({ provider: llmProvider }) || null,
+      ReasoningEffort: process.env.REASONING_EFFORT || null,
       ModelRouterId: process.env.MODEL_ROUTER_ID || null,
       ...this.llmPreferenceKeys(),
 

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -24,6 +24,7 @@ function isNullOrNaN(value) {
  * @property {number} similarityThreshold - The similarity threshold of the workspace
  * @property {string} chatProvider - The chat provider of the workspace
  * @property {string} chatModel - The chat model of the workspace
+ * @property {string|null} reasoningEffort - The reasoning effort for the chat model (null = provider default)
  * @property {number} topN - The top N of the workspace
  * @property {string} chatMode - The chat mode of the workspace
  * @property {string} agentProvider - The agent provider of the workspace
@@ -34,6 +35,16 @@ function isNullOrNaN(value) {
 
 const Workspace = {
   VALID_CHAT_MODES: ["chat", "query", "automatic"],
+  VALID_REASONING_EFFORTS: [
+    "off",
+    "on",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+  ],
   defaultPrompt: SystemSettings.saneDefaultSystemPrompt,
 
   // Used for generic updates so we can validate keys in request body
@@ -49,6 +60,7 @@ const Workspace = {
     "similarityThreshold",
     "chatProvider",
     "chatModel",
+    "reasoningEffort",
     "topN",
     "chatMode",
     "agentProvider",
@@ -105,6 +117,11 @@ const Workspace = {
     chatModel: (value) => {
       if (!value || typeof value !== "string") return null;
       return String(value);
+    },
+    reasoningEffort: (value) => {
+      if (!value || !Workspace.VALID_REASONING_EFFORTS.includes(value))
+        return null;
+      return value;
     },
     agentProvider: (value) => {
       if (!value || typeof value !== "string" || value === "none") return null;

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -671,7 +671,7 @@ const Workspace = {
    */
   deletePromptHistory: async function ({ workspaceId, id }) {
     try {
-      return await PromptHistory.delete({ id, workspaceId });
+      return await PromptHistory.deleteForWorkspace({ id, workspaceId });
     } catch (error) {
       console.error(error.message);
       return false;

--- a/server/prisma/migrations/20260901232437_init/migration.sql
+++ b/server/prisma/migrations/20260901232437_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN "reasoningEffort" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -132,6 +132,7 @@ model workspaces {
   similarityThreshold          Float?                         @default(0.25)
   chatProvider                 String?
   chatModel                    String?
+  reasoningEffort              String?
   topN                         Int?                           @default(4)
   chatMode                     String?                        @default("chat")
   pfpFilename                  String?

--- a/server/swagger/openapi.json
+++ b/server/swagger/openapi.json
@@ -1063,7 +1063,7 @@
         "tags": [
           "Documents"
         ],
-        "description": "Upload a valid URL for AnythingLLM to scrape and prepare for embedding. Optionally, specify a comma-separated list of workspace slugs to embed the document into post-upload.",
+        "description": "Upload a valid URL for AnythingLLM to scrape and prepare for embedding. The link property can be a single URL string or an array of URL strings. Optionally, specify a comma-separated list of workspace slugs to embed the document into post-upload.",
         "parameters": [],
         "responses": {
           "200": {
@@ -1119,7 +1119,7 @@
           }
         },
         "requestBody": {
-          "description": "Link of web address to be scraped and optionally a comma-separated list of workspace slugs to embed the document into post-upload, and optional metadata.",
+          "description": "Link of web address to be scraped and optionally a comma-separated list of workspace slugs to embed the document into post-upload, and optional metadata. The link property also accepts an array of links to process in a single request.",
           "required": true,
           "content": {
             "application/json": {

--- a/server/utils/AiProviders/anthropic/index.js
+++ b/server/utils/AiProviders/anthropic/index.js
@@ -10,6 +10,7 @@ const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
 const { getAnythingLLMUserAgent } = require("../../../endpoints/utils");
+const { validReasoningEffort } = require("../../helpers/reasoningEffort");
 
 class AnthropicLLM {
   /**
@@ -21,6 +22,8 @@ class AnthropicLLM {
     "claude-opus-4-7",
     "claude-opus-4-8",
     "claude-sonnet-5",
+    "claude-opus-5",
+    "claude-fable-5",
     // Add other models here if identified
   ];
 
@@ -210,7 +213,63 @@ class AnthropicLLM {
     ];
   }
 
-  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+  /**
+   * Builds the reasoning portion of the request body when a reasoning effort
+   * is set - otherwise an empty object so the provider default applies.
+   * Anthropic's `output_config.effort` controls response thoroughness and
+   * token spend with or without extended thinking enabled.
+   * @param {string|null} reasoningEffort
+   * @returns {object}
+   */
+  #constructReasoningConfig(reasoningEffort = null) {
+    const effort = validReasoningEffort(
+      "anthropic",
+      this.model,
+      reasoningEffort
+    );
+    if (!effort) return {};
+    return { output_config: { effort } };
+  }
+
+  /**
+   * Builds the sampling portion of the request body. Models that accept
+   * `output_config.effort` deprecate `temperature` and reject requests
+   * sending both, so temperature is only sent when no effort is set.
+   * @param {string|null} reasoningEffort
+   * @param {number} temperature
+   * @returns {object}
+   */
+  samplingParams(reasoningEffort = null, temperature = this.defaultTemp) {
+    const reasoningConfig = this.#constructReasoningConfig(reasoningEffort);
+    if (Object.keys(reasoningConfig).length > 0) return reasoningConfig;
+    return { temperature: this.temperatureParam(temperature) };
+  }
+
+  /**
+   * Returns the capabilities of the model.
+   * @returns {Promise<{reasoning: 'unknown' | boolean, reasoningOptions: string[]}>}
+   */
+  async getModelCapabilities() {
+    try {
+      const model = await this.anthropic.models.retrieve(this.model);
+      const effortCapabilities = model.capabilities?.effort;
+      if (!effortCapabilities?.supported)
+        return { reasoning: false, reasoningOptions: [] };
+
+      const reasoningOptions = Object.entries(effortCapabilities)
+        .filter(([level, config]) => level !== "supported" && config?.supported)
+        .map(([level]) => level);
+      return { reasoning: true, reasoningOptions };
+    } catch (error) {
+      console.error("Anthropic:getModelCapabilities", error.message);
+      return { reasoning: "unknown", reasoningOptions: [] };
+    }
+  }
+
+  async getChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     await this.assertModelMaxTokens();
     try {
       const systemContent = messages[0].content;
@@ -229,7 +288,7 @@ class AnthropicLLM {
             max_tokens: this.maxTokens,
             system: this.#buildSystemPrompt(systemContent),
             messages: messages.slice(1), // Pop off the system message
-            temperature: this.temperatureParam(temperature),
+            ...this.samplingParams(reasoningEffort, temperature),
           })
           .finalMessage()
       );
@@ -258,7 +317,10 @@ class AnthropicLLM {
     }
   }
 
-  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+  async streamGetChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     await this.assertModelMaxTokens();
     const systemContent = messages[0].content;
     const measuredStreamRequest = await LLMPerformanceMonitor.measureStream({
@@ -267,7 +329,7 @@ class AnthropicLLM {
         max_tokens: this.maxTokens,
         system: this.#buildSystemPrompt(systemContent),
         messages: messages.slice(1), // Pop off the system message
-        temperature: this.temperatureParam(temperature),
+        ...this.samplingParams(reasoningEffort, temperature),
       }),
       messages,
       runPromptTokenCalculation: false,

--- a/server/utils/AiProviders/deepseek/index.js
+++ b/server/utils/AiProviders/deepseek/index.js
@@ -6,6 +6,10 @@ const { MODEL_MAP } = require("../modelMap");
 const {
   handleDefaultStreamResponseV2,
 } = require("../../helpers/chat/responses");
+const {
+  PROVIDER_REASONING_EFFORTS,
+  validReasoningEffort,
+} = require("../../helpers/reasoningEffort");
 
 class DeepSeekLLM {
   constructor(embedder = null, modelPreference = null) {
@@ -94,7 +98,38 @@ class DeepSeekLLM {
     return textResponse;
   }
 
-  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+  /**
+   * Builds the reasoning portion of the request body when a reasoning effort
+   * is set - otherwise an empty object so the provider default applies.
+   * DeepSeek only supports toggling thinking on or off via the `thinking` param.
+   * @param {string|null} reasoningEffort
+   * @returns {object}
+   */
+  #constructReasoningConfig(reasoningEffort = null) {
+    const effort = validReasoningEffort(
+      "deepseek",
+      this.model,
+      reasoningEffort
+    );
+    if (!effort) return {};
+    return { thinking: { type: effort === "on" ? "enabled" : "disabled" } };
+  }
+
+  /**
+   * Returns the capabilities of the model.
+   * @returns {Promise<{reasoning: boolean, reasoningOptions: string[]}>}
+   */
+  async getModelCapabilities() {
+    return {
+      reasoning: true,
+      reasoningOptions: PROVIDER_REASONING_EFFORTS.deepseek(this.model),
+    };
+  }
+
+  async getChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     if (!(await this.isValidChatCompletionModel(this.model)))
       throw new Error(
         `DeepSeek chat: ${this.model} is not valid for chat completion!`
@@ -106,6 +141,7 @@ class DeepSeekLLM {
           model: this.model,
           messages,
           temperature,
+          ...this.#constructReasoningConfig(reasoningEffort),
         })
         .catch((e) => {
           throw new Error(e.message);
@@ -135,7 +171,10 @@ class DeepSeekLLM {
     };
   }
 
-  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+  async streamGetChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     if (!(await this.isValidChatCompletionModel(this.model)))
       throw new Error(
         `DeepSeek chat: ${this.model} is not valid for chat completion!`
@@ -147,6 +186,7 @@ class DeepSeekLLM {
         stream: true,
         messages,
         temperature,
+        ...this.#constructReasoningConfig(reasoningEffort),
       }),
       messages,
       runPromptTokenCalculation: false,

--- a/server/utils/AiProviders/gemini/index.js
+++ b/server/utils/AiProviders/gemini/index.js
@@ -11,6 +11,10 @@ const {
 const { MODEL_MAP } = require("../modelMap");
 const { defaultGeminiModels, v1BetaModels } = require("./defaultModels");
 const { safeJsonParse } = require("../../http");
+const {
+  PROVIDER_REASONING_EFFORTS,
+  validReasoningEffort,
+} = require("../../helpers/reasoningEffort");
 const cacheFolder = path.resolve(
   process.env.STORAGE_DIR
     ? path.resolve(process.env.STORAGE_DIR, "models", "gemini")
@@ -377,13 +381,52 @@ class GeminiLLM {
     ];
   }
 
-  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+  /**
+   * Builds the reasoning portion of the request body when a reasoning effort
+   * is set - otherwise an empty object so the provider default applies.
+   * Gemini's OpenAI-compatible endpoint accepts `reasoning_effort` and maps
+   * it to a thinking budget.
+   * @param {string|null} reasoningEffort
+   * @returns {object}
+   */
+  #constructReasoningConfig(reasoningEffort = null) {
+    const effort = validReasoningEffort("gemini", this.model, reasoningEffort);
+    if (!effort) return {};
+    return { reasoning_effort: effort };
+  }
+
+  /**
+   * Returns the capabilities of the model.
+   * @returns {Promise<{reasoning: 'unknown' | boolean, reasoningOptions: string[]}>}
+   */
+  async getModelCapabilities() {
+    try {
+      const modelInfo = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${this.model}?key=${process.env.GEMINI_API_KEY}`
+      ).then((res) => res.json());
+      if (modelInfo.thinking !== true)
+        return { reasoning: false, reasoningOptions: [] };
+      return {
+        reasoning: true,
+        reasoningOptions: PROVIDER_REASONING_EFFORTS.gemini(this.model),
+      };
+    } catch (error) {
+      console.error("Gemini:getModelCapabilities", error.message);
+      return { reasoning: "unknown", reasoningOptions: [] };
+    }
+  }
+
+  async getChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     const result = await LLMPerformanceMonitor.measureAsyncFunction(
       this.openai.chat.completions
         .create({
           model: this.model,
           messages,
           temperature: temperature,
+          ...this.#constructReasoningConfig(reasoningEffort),
         })
         .catch((e) => {
           console.error(e);
@@ -412,13 +455,17 @@ class GeminiLLM {
     };
   }
 
-  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+  async streamGetChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     const measuredStreamRequest = await LLMPerformanceMonitor.measureStream({
       func: this.openai.chat.completions.create({
         model: this.model,
         stream: true,
         messages,
         temperature: temperature,
+        ...this.#constructReasoningConfig(reasoningEffort),
         stream_options: {
           include_usage: true,
         },

--- a/server/utils/AiProviders/ollama/index.js
+++ b/server/utils/AiProviders/ollama/index.js
@@ -9,6 +9,10 @@ const {
 } = require("../../helpers/chat/LLMPerformanceMonitor");
 const { Ollama } = require("ollama");
 const { v4: uuidv4 } = require("uuid");
+const {
+  PROVIDER_REASONING_EFFORTS,
+  validReasoningEffort,
+} = require("../../helpers/reasoningEffort");
 
 // Docs: https://github.com/jmorganca/ollama/blob/main/docs/api.md
 class OllamaAILLM {
@@ -267,7 +271,24 @@ class OllamaAILLM {
     ];
   }
 
-  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+  /**
+   * Builds the reasoning portion of the request body when a reasoning effort
+   * is set - otherwise an empty object so the provider default applies.
+   * Ollama's `think` accepts a boolean toggle or an effort level string.
+   * @param {string|null} reasoningEffort
+   * @returns {object}
+   */
+  #constructReasoningConfig(reasoningEffort = null) {
+    const effort = validReasoningEffort("ollama", this.model, reasoningEffort);
+    if (!effort) return {};
+    if (["on", "off"].includes(effort)) return { think: effort === "on" };
+    return { think: effort };
+  }
+
+  async getChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     const result = await LLMPerformanceMonitor.measureAsyncFunction(
       this.client
         .chat({
@@ -275,6 +296,7 @@ class OllamaAILLM {
           stream: false,
           messages,
           keep_alive: this.keepAlive,
+          ...this.#constructReasoningConfig(reasoningEffort),
           options: {
             temperature,
             num_ctx: this.promptWindowLimit(),
@@ -320,13 +342,17 @@ class OllamaAILLM {
     };
   }
 
-  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+  async streamGetChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     const measuredStreamRequest = await LLMPerformanceMonitor.measureStream({
       func: this.client.chat({
         model: this.model,
         stream: true,
         messages,
         keep_alive: this.keepAlive,
+        ...this.#constructReasoningConfig(reasoningEffort),
         options: {
           temperature,
           num_ctx: this.promptWindowLimit(),
@@ -471,16 +497,23 @@ class OllamaAILLM {
 
   /**
    * Returns the capabilities of the model.
-   * @returns {Promise<{tools: 'unknown' | boolean, reasoning: 'unknown' | boolean, imageGeneration: 'unknown' | boolean, vision: 'unknown' | boolean}>}
+   * @returns {Promise<{tools: 'unknown' | boolean, reasoning: 'unknown' | boolean, reasoningOptions: string[], imageGeneration: 'unknown' | boolean, vision: 'unknown' | boolean}>}
    */
   async getModelCapabilities() {
     try {
       const { capabilities = [] } = await this.client.show({
         model: this.model,
       });
+
+      const supportsReasoning = capabilities.includes("thinking");
+      const reasoningOptions = supportsReasoning
+        ? PROVIDER_REASONING_EFFORTS.ollama(this.model)
+        : [];
+
       return {
         tools: capabilities.includes("tools") ? true : false,
-        reasoning: capabilities.includes("thinking") ? true : false,
+        reasoning: supportsReasoning,
+        reasoningOptions,
         imageGeneration: false, // we dont have any image generation capabilities for Ollama or anywhere right now.
         vision: capabilities.includes("vision") ? true : false,
       };
@@ -489,6 +522,7 @@ class OllamaAILLM {
       return {
         tools: "unknown",
         reasoning: "unknown",
+        reasoningOptions: [],
         imageGeneration: "unknown",
         vision: "unknown",
       };

--- a/server/utils/AiProviders/openAi/index.js
+++ b/server/utils/AiProviders/openAi/index.js
@@ -10,6 +10,10 @@ const { MODEL_MAP } = require("../modelMap");
 const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
+const {
+  PROVIDER_REASONING_EFFORTS,
+  validReasoningEffort,
+} = require("../../helpers/reasoningEffort");
 
 class OpenAiLLM {
   constructor(embedder = null, modelPreference = null) {
@@ -145,7 +149,32 @@ class OpenAiLLM {
     return temperature;
   }
 
-  async getChatCompletion(messages = null, { temperature = 0.7 }) {
+  /**
+   * Builds the reasoning portion of the request body when a supported
+   * reasoning effort is set - otherwise an empty object so the provider
+   * default applies.
+   * @param {string|null} reasoningEffort
+   * @returns {object}
+   */
+  #constructReasoningConfig(reasoningEffort = null) {
+    const effort = validReasoningEffort("openai", this.model, reasoningEffort);
+    if (!effort) return {};
+    return { reasoning: { effort: effort === "off" ? "none" : effort } };
+  }
+
+  /**
+   * Returns the capabilities of the model.
+   * @returns {Promise<{reasoning: boolean, reasoningOptions: string[]}>}
+   */
+  async getModelCapabilities() {
+    const reasoningOptions = PROVIDER_REASONING_EFFORTS.openai(this.model);
+    return { reasoning: reasoningOptions.length > 0, reasoningOptions };
+  }
+
+  async getChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     if (!(await this.isValidChatCompletionModel(this.model)))
       throw new Error(
         `OpenAI chat: ${this.model} is not valid for chat completion!`
@@ -158,6 +187,7 @@ class OpenAiLLM {
           input: messages,
           store: false,
           temperature: this.#temperature(this.model, temperature),
+          ...this.#constructReasoningConfig(reasoningEffort),
         })
         .catch((e) => {
           throw new Error(e.message);
@@ -184,7 +214,10 @@ class OpenAiLLM {
     };
   }
 
-  async streamGetChatCompletion(messages = null, { temperature = 0.7 }) {
+  async streamGetChatCompletion(
+    messages = null,
+    { temperature = 0.7, reasoningEffort = null }
+  ) {
     if (!(await this.isValidChatCompletionModel(this.model)))
       throw new Error(
         `OpenAI chat: ${this.model} is not valid for chat completion!`
@@ -197,6 +230,7 @@ class OpenAiLLM {
         input: messages,
         store: false,
         temperature: this.#temperature(this.model, temperature),
+        ...this.#constructReasoningConfig(reasoningEffort),
       }),
       messages,
       runPromptTokenCalculation: false,

--- a/server/utils/agents/aibitat/index.js
+++ b/server/utils/agents/aibitat/index.js
@@ -1436,16 +1436,30 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
    */
   #buildProviderForConfig(config) {
     if (typeof config.provider === "object") return config.provider;
+    const reasoningEffort =
+      config.reasoningEffort ?? this.defaultProvider?.reasoningEffort ?? null;
 
     switch (config.provider) {
       case "openai":
-        return new Providers.OpenAIProvider({ model: config.model });
+        return new Providers.OpenAIProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "anthropic":
-        return new Providers.AnthropicProvider({ model: config.model });
+        return new Providers.AnthropicProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "lmstudio":
-        return new Providers.LMStudioProvider({ model: config.model });
+        return new Providers.LMStudioProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "ollama":
-        return new Providers.OllamaProvider({ model: config.model });
+        return new Providers.OllamaProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "groq":
         return new Providers.GroqProvider({ model: config.model });
       case "togetherai":
@@ -1475,7 +1489,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
       case "moonshotai":
         return new Providers.MoonshotAiProvider({ model: config.model });
       case "deepseek":
-        return new Providers.DeepSeekProvider({ model: config.model });
+        return new Providers.DeepSeekProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "litellm":
         return new Providers.LiteLLMProvider({ model: config.model });
       case "apipie":
@@ -1489,7 +1506,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
       case "ppio":
         return new Providers.PPIOProvider({ model: config.model });
       case "gemini":
-        return new Providers.GeminiProvider({ model: config.model });
+        return new Providers.GeminiProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "cometapi":
         return new Providers.CometApiProvider({ model: config.model });
       case "foundry":
@@ -1505,7 +1525,10 @@ https://docs.anythingllm.com/agent/intelligent-tool-selection
       case "sambanova":
         return new Providers.SambaNovaProvider({ model: config.model });
       case "lemonade":
-        return new Providers.LemonadeProvider({ model: config.model });
+        return new Providers.LemonadeProvider({
+          model: config.model,
+          reasoningEffort,
+        });
       case "omlx":
         return new Providers.OMLXProvider({ model: config.model });
       case "minimax":

--- a/server/utils/agents/aibitat/providers/ai-provider.js
+++ b/server/utils/agents/aibitat/providers/ai-provider.js
@@ -18,6 +18,9 @@ const { toValidNumber, safeJsonParse } = require("../../../http");
 const { getLLMProviderClass } = require("../../../helpers");
 const { MODEL_PRICING } = require("../../../helpers/modelPricing");
 const { toNonNegativeNumber } = require("../../../helpers/numbers");
+const {
+  PROVIDER_REASONING_EFFORTS,
+} = require("../../../helpers/reasoningEffort");
 const { parseLMStudioBasePath } = require("../../../AiProviders/lmStudio");
 const { parseFoundryBasePath } = require("../../../AiProviders/foundry");
 const { parseOMLXBasePath } = require("../../../AiProviders/omlx");
@@ -720,6 +723,18 @@ class Provider {
       completion_tokens: completionTokens,
     });
 
+    // Only report an effort the provider actually applied to its requests -
+    // an invalid stored value is dropped at request time and should not show
+    // on the chat's metrics.
+    const providerKey = this.providerSlug ?? this.providerTag;
+    const reasoningEffort =
+      this.reasoningEffort &&
+      (
+        PROVIDER_REASONING_EFFORTS[providerKey]?.(this.model ?? "") ?? []
+      ).includes(this.reasoningEffort)
+        ? this.reasoningEffort
+        : null;
+
     this.lastUsage = {
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
@@ -730,6 +745,7 @@ class Provider {
       model: this.model,
       provider: this.constructor.name,
       timestamp,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
       ...(cost ?? {}),
     };
 
@@ -745,6 +761,7 @@ class Provider {
     totals.model = this.model;
     totals.provider = this.constructor.name;
     totals.timestamp = timestamp;
+    if (reasoningEffort) totals.reasoningEffort = reasoningEffort;
     if (cost) {
       totals.inputCost = (totals.inputCost ?? 0) + cost.inputCost;
       totals.outputCost = (totals.outputCost ?? 0) + cost.outputCost;

--- a/server/utils/agents/aibitat/providers/anthropic.js
+++ b/server/utils/agents/aibitat/providers/anthropic.js
@@ -1,3 +1,4 @@
+const { validReasoningEffort } = require("../../../helpers/reasoningEffort");
 const Anthropic = require("@anthropic-ai/sdk");
 const { AnthropicLLM } = require("../../../AiProviders/anthropic");
 const { RetryError } = require("../error.js");
@@ -24,6 +25,7 @@ class AnthropicProvider extends Provider {
         },
       },
       model = "claude-sonnet-4-6",
+      reasoningEffort = null,
     } = config;
 
     const client = new Anthropic(options);
@@ -31,6 +33,22 @@ class AnthropicProvider extends Provider {
     super(client);
     this.providerTag = "anthropic";
     this.model = model;
+    this.reasoningEffort = reasoningEffort;
+  }
+
+  /**
+   * The reasoning portion of the request body when a supported reasoning
+   * effort is set - otherwise an empty object so the provider default applies.
+   * @returns {object}
+   */
+  get reasoningConfig() {
+    const effort = validReasoningEffort(
+      "anthropic",
+      this.model,
+      this.reasoningEffort
+    );
+    if (!effort) return {};
+    return { output_config: { effort } };
   }
 
   /**
@@ -261,6 +279,7 @@ class AnthropicProvider extends Provider {
           ...(Array.isArray(functions) && functions?.length > 0
             ? { tools: this.#formatFunctions(functions) }
             : {}),
+          ...this.reasoningConfig,
         },
         { headers: { "anthropic-beta": "tools-2024-04-04" } } // Required to we can use tools.
       );
@@ -408,6 +427,7 @@ class AnthropicProvider extends Provider {
           ...(Array.isArray(functions) && functions?.length > 0
             ? { tools: this.#formatFunctions(functions) }
             : {}),
+          ...this.reasoningConfig,
         },
         { headers: { "anthropic-beta": "tools-2024-04-04" } } // Required to we can use tools.
       );

--- a/server/utils/agents/aibitat/providers/deepseek.js
+++ b/server/utils/agents/aibitat/providers/deepseek.js
@@ -1,3 +1,4 @@
+const { validReasoningEffort } = require("../../../helpers/reasoningEffort");
 const OpenAI = require("openai");
 const Provider = require("./ai-provider.js");
 const InheritMultiple = require("./helpers/classes.js");
@@ -11,7 +12,7 @@ class DeepSeekProvider extends InheritMultiple([Provider, UnTooled]) {
 
   constructor(config = {}) {
     super();
-    const { model = "deepseek-chat" } = config;
+    const { model = "deepseek-chat", reasoningEffort = null } = config;
     const client = new OpenAI({
       baseURL: "https://api.deepseek.com/v1",
       apiKey: process.env.DEEPSEEK_API_KEY ?? null,
@@ -20,6 +21,7 @@ class DeepSeekProvider extends InheritMultiple([Provider, UnTooled]) {
     this.providerTag = "deepseek";
     this._client = client;
     this.model = model;
+    this.reasoningEffort = reasoningEffort;
     this.verbose = true;
     this.maxTokens = process.env.DEEPSEEK_MAX_TOKENS
       ? toValidNumber(process.env.DEEPSEEK_MAX_TOKENS, 1024)
@@ -28,6 +30,22 @@ class DeepSeekProvider extends InheritMultiple([Provider, UnTooled]) {
 
   get client() {
     return this._client;
+  }
+
+  /**
+   * The reasoning portion of the request body when a supported reasoning
+   * effort is set - otherwise an empty object so the provider default applies.
+   * DeepSeek only supports toggling thinking on or off.
+   * @returns {object}
+   */
+  get reasoningConfig() {
+    const effort = validReasoningEffort(
+      "deepseek",
+      this.model,
+      this.reasoningEffort
+    );
+    if (!effort) return {};
+    return { thinking: { type: effort === "on" ? "enabled" : "disabled" } };
   }
 
   get supportsAgentStreaming() {

--- a/server/utils/agents/aibitat/providers/gemini.js
+++ b/server/utils/agents/aibitat/providers/gemini.js
@@ -1,3 +1,4 @@
+const { validReasoningEffort } = require("../../../helpers/reasoningEffort");
 const OpenAI = require("openai");
 const Provider = require("./ai-provider.js");
 const { RetryError } = require("../error.js");
@@ -12,7 +13,7 @@ class GeminiProvider extends Provider {
   model;
 
   constructor(config = {}) {
-    const { model = "gemini-2.0-flash-lite" } = config;
+    const { model = "gemini-2.0-flash-lite", reasoningEffort = null } = config;
     super();
     this.providerTag = "gemini";
     this.className = "GeminiProvider";
@@ -42,11 +43,27 @@ class GeminiProvider extends Provider {
 
     this._client = client;
     this.model = model;
+    this.reasoningEffort = reasoningEffort;
     this.verbose = true;
   }
 
   get client() {
     return this._client;
+  }
+
+  /**
+   * The reasoning portion of the request body when a supported reasoning
+   * effort is set - otherwise an empty object so the provider default applies.
+   * @returns {object}
+   */
+  get reasoningConfig() {
+    const effort = validReasoningEffort(
+      "gemini",
+      this.model,
+      this.reasoningEffort
+    );
+    if (!effort) return {};
+    return { reasoning_effort: effort };
   }
 
   /**
@@ -257,6 +274,7 @@ class GeminiProvider extends Provider {
         messages: this.#formatMessages(messages),
         stream: true,
         stream_options: { include_usage: true },
+        ...this.reasoningConfig,
         ...(Array.isArray(functions) && functions?.length > 0
           ? {
               tools: this.#formatFunctions(functions),
@@ -384,6 +402,7 @@ class GeminiProvider extends Provider {
         model: this.model,
         stream: false,
         messages: this.#formatMessages(messages),
+        ...this.reasoningConfig,
         ...(Array.isArray(functions) && functions?.length > 0
           ? {
               tools: this.#formatFunctions(functions),

--- a/server/utils/agents/aibitat/providers/helpers/tooled.js
+++ b/server/utils/agents/aibitat/providers/helpers/tooled.js
@@ -203,6 +203,7 @@ async function tooledStream(
     stream_options: { include_usage: true },
     messages: formattedMessages,
     ...(tools.length > 0 ? { tools } : {}),
+    ...(provider?.reasoningConfig ?? {}),
   });
 
   const result = {
@@ -378,6 +379,7 @@ async function tooledComplete(
     stream: false,
     messages: formattedMessages,
     ...(tools.length > 0 ? { tools } : {}),
+    ...(provider?.reasoningConfig ?? {}),
   });
 
   const completion = response.choices[0].message;

--- a/server/utils/agents/aibitat/providers/ollama.js
+++ b/server/utils/agents/aibitat/providers/ollama.js
@@ -1,3 +1,4 @@
+const { validReasoningEffort } = require("../../../helpers/reasoningEffort");
 const Provider = require("./ai-provider.js");
 const InheritMultiple = require("./helpers/classes.js");
 const UnTooled = require("./helpers/untooled.js");
@@ -19,6 +20,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
     const {
       // options = {},
       model = null,
+      reasoningEffort = null,
     } = config;
 
     super();
@@ -32,12 +34,30 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       fetch: OllamaAILLM.applyOllamaFetch(),
     });
     this.model = model;
+    this.reasoningEffort = reasoningEffort;
     this.verbose = true;
     this._supportsToolCalling = null;
   }
 
   get client() {
     return this._client;
+  }
+
+  /**
+   * The reasoning portion of the request body when a supported reasoning
+   * effort is set - otherwise an empty object so the provider default applies.
+   * Ollama's `think` accepts a boolean toggle or an effort level string.
+   * @returns {object}
+   */
+  get reasoningConfig() {
+    const effort = validReasoningEffort(
+      "ollama",
+      this.model,
+      this.reasoningEffort
+    );
+    if (!effort) return {};
+    if (["on", "off"].includes(effort)) return { think: effort === "on" };
+    return { think: effort };
   }
 
   get supportsAgentStreaming() {
@@ -78,6 +98,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
     const response = await this.client.chat({
       model: this.model,
       messages,
+      ...this.reasoningConfig,
       options: this.queryOptions,
     });
     return response?.message?.content || null;
@@ -89,6 +110,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
       model: this.model,
       messages,
       stream: true,
+      ...this.reasoningConfig,
       options: this.queryOptions,
     });
   }
@@ -312,6 +334,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
         messages: formattedMessages,
         ...(tools.length > 0 ? { tools } : {}),
         stream: true,
+        ...this.reasoningConfig,
         options: this.queryOptions,
       });
 
@@ -506,6 +529,7 @@ class OllamaProvider extends InheritMultiple([Provider, UnTooled]) {
         model: this.model,
         messages: formattedMessages,
         ...(tools.length > 0 ? { tools } : {}),
+        ...this.reasoningConfig,
         options: this.queryOptions,
       });
 

--- a/server/utils/agents/aibitat/providers/openai.js
+++ b/server/utils/agents/aibitat/providers/openai.js
@@ -3,6 +3,7 @@ const Provider = require("./ai-provider.js");
 const { RetryError } = require("../error.js");
 const { v4 } = require("uuid");
 const { safeJsonParse } = require("../../../http");
+const { validReasoningEffort } = require("../../../helpers/reasoningEffort");
 
 /**
  * The agent provider for the OpenAI API.
@@ -16,6 +17,7 @@ class OpenAIProvider extends Provider {
         apiKey: process.env.OPEN_AI_KEY,
       },
       model = "gpt-4.1-nano",
+      reasoningEffort = null,
     } = config;
 
     const client = new OpenAI(options);
@@ -24,6 +26,22 @@ class OpenAIProvider extends Provider {
 
     this.providerTag = "openai";
     this.model = model;
+    this.reasoningEffort = reasoningEffort;
+  }
+
+  /**
+   * The reasoning portion of the request body when a supported reasoning
+   * effort is set - otherwise an empty object so the provider default applies.
+   * @returns {object}
+   */
+  get reasoningConfig() {
+    const effort = validReasoningEffort(
+      "openai",
+      this.model,
+      this.reasoningEffort
+    );
+    if (!effort) return {};
+    return { reasoning: { effort: effort === "off" ? "none" : effort } };
   }
 
   get supportsAgentStreaming() {
@@ -155,6 +173,7 @@ class OpenAIProvider extends Provider {
         ...(Array.isArray(functions) && functions?.length > 0
           ? { tools: this.#formatFunctions(functions) }
           : {}),
+        ...this.reasoningConfig,
       });
 
       const completion = {
@@ -277,6 +296,7 @@ class OpenAIProvider extends Provider {
         ...(Array.isArray(functions) && functions?.length > 0
           ? { tools: this.#formatFunctions(functions) }
           : {}),
+        ...this.reasoningConfig,
       });
 
       if (response.usage) this.recordUsage(response.usage);

--- a/server/utils/agents/ephemeral.js
+++ b/server/utils/agents/ephemeral.js
@@ -517,9 +517,11 @@ class EphemeralAgentHandler extends AgentHandler {
       toolOverrides: null,
     }
   ) {
+    const { resolveReasoningEffort } = require("../chats");
     this.aibitat = new AIbitat({
       provider: this.provider ?? "openai",
       model: this.model ?? "gpt-4.1-nano",
+      reasoningEffort: resolveReasoningEffort(this.#workspace),
       chats: await this.#chatHistory(20),
       handlerProps: {
         invocation: {

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -852,9 +852,11 @@ class AgentHandler {
     }
   ) {
     this.#args = args;
+    const { resolveReasoningEffort } = require("../chats");
     this.aibitat = new AIbitat({
       provider: this.provider ?? "openai",
       model: this.model ?? "gpt-4.1-nano",
+      reasoningEffort: resolveReasoningEffort(this.invocation?.workspace),
       chats: await this.#chatHistory(20),
       handlerProps: {
         invocation: this.invocation,

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -10,6 +10,7 @@ const {
   sourceIdentifier,
   recentChatHistory,
   grepAllSlashCommands,
+  resolveReasoningEffort,
 } = require("./index");
 const {
   EphemeralAgentHandler,
@@ -449,6 +450,7 @@ async function chatSync({
     await LLMConnector.getChatCompletion(messages, {
       temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
       user: user,
+      reasoningEffort: resolveReasoningEffort(workspace),
     });
   const performanceMetrics = addChatCostToMetrics(completionMetrics, {
     routingMetadata,
@@ -843,6 +845,7 @@ async function streamChat({
       await LLMConnector.getChatCompletion(messages, {
         temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
         user: user,
+        reasoningEffort: resolveReasoningEffort(workspace),
       });
     completeText = textResponse;
     metrics = addChatCostToMetrics(performanceMetrics, {
@@ -863,6 +866,7 @@ async function streamChat({
     const stream = await LLMConnector.streamGetChatCompletion(messages, {
       temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
       user: user,
+      reasoningEffort: resolveReasoningEffort(workspace),
     });
     completeText = await LLMConnector.handleStream(response, stream, { uuid });
     metrics = addChatCostToMetrics(stream.metrics, {

--- a/server/utils/chats/index.js
+++ b/server/utils/chats/index.js
@@ -140,8 +140,28 @@ function sourceIdentifier(sourceDocument) {
   return `title:${sourceDocument.title}-timestamp:${sourceDocument.published}`;
 }
 
+/**
+ * Resolves the reasoning effort for a chat - the workspace's own setting wins,
+ * otherwise the system-wide default. Logged when set so chat logs show what
+ * effort was requested; providers still ignore values their model cannot use.
+ * @param {import("@prisma/client").workspaces|null} workspace
+ * @returns {string|null}
+ */
+function resolveReasoningEffort(workspace = null) {
+  const reasoningEffort =
+    workspace?.reasoningEffort ?? process.env.REASONING_EFFORT ?? null;
+  if (reasoningEffort)
+    console.log(
+      `\x1b[36m[ReasoningEffort]\x1b[0m Chat requested with ${
+        workspace?.reasoningEffort ? "workspace" : "global"
+      } reasoning effort "${reasoningEffort}"`
+    );
+  return reasoningEffort;
+}
+
 module.exports = {
   sourceIdentifier,
+  resolveReasoningEffort,
   recentChatHistory,
   chatPrompt,
   grepCommand,

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -13,6 +13,7 @@ const {
   chatPrompt,
   recentChatHistory,
   sourceIdentifier,
+  resolveReasoningEffort,
 } = require("./index");
 
 const VALID_CHAT_MODE = ["automatic", "chat", "query"];
@@ -291,6 +292,7 @@ async function streamChatWithWorkspace(
       await LLMConnector.getChatCompletion(messages, {
         temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
         user: user,
+        reasoningEffort: resolveReasoningEffort(workspace),
       });
 
     completeText = textResponse;
@@ -312,6 +314,7 @@ async function streamChatWithWorkspace(
     const stream = await LLMConnector.streamGetChatCompletion(messages, {
       temperature: workspace?.openAiTemp ?? LLMConnector.defaultTemp,
       user: user,
+      reasoningEffort: resolveReasoningEffort(workspace),
     });
     completeText = await LLMConnector.handleStream(response, stream, {
       uuid,

--- a/server/utils/helpers/index.js
+++ b/server/utils/helpers/index.js
@@ -457,8 +457,8 @@ function getLLMProviderClass({ provider = null } = {}) {
       const { LlmmanLLM } = require("../AiProviders/llmman");
       return LlmmanLLM;
     case "privatemode":
-      const { PrivateModeLLM } = require("../AiProviders/privatemode");
-      return PrivateModeLLM;
+      const { PrivatemodeLLM } = require("../AiProviders/privatemode");
+      return PrivatemodeLLM;
     case "sambanova":
       const { SambaNovaLLM } = require("../AiProviders/sambanova");
       return SambaNovaLLM;

--- a/server/utils/helpers/modelPricing/index.js
+++ b/server/utils/helpers/modelPricing/index.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 const { toNonNegativeNumber } = require("../numbers");
+const { PROVIDER_REASONING_EFFORTS } = require("../reasoningEffort");
 
 /**
  * @typedef {Object} ModelCost - USD per 1,000,000 tokens (models.dev conventions)
@@ -372,13 +373,27 @@ function addChatCostToMetrics(
   metrics = {},
   { routingMetadata = null, workspace = null, connector = null } = {}
 ) {
-  return addCostToMetrics(metrics, {
-    provider:
-      routingMetadata?.routedTo?.provider ??
-      workspace?.chatProvider ??
-      process.env.LLM_PROVIDER,
-    model: routingMetadata?.routedTo?.model ?? connector?.model,
-  });
+  const provider =
+    routingMetadata?.routedTo?.provider ??
+    workspace?.chatProvider ??
+    process.env.LLM_PROVIDER;
+  const model = routingMetadata?.routedTo?.model ?? connector?.model;
+
+  // Only report an effort the provider will actually apply - a stale value
+  // from a provider/model switch is dropped at request time and should not
+  // show on the chat's metrics.
+  const storedEffort =
+    workspace?.reasoningEffort ?? process.env.REASONING_EFFORT ?? null;
+  const reasoningEffort =
+    storedEffort &&
+    (PROVIDER_REASONING_EFFORTS[provider]?.(model ?? "") ?? []).includes(
+      storedEffort
+    )
+      ? storedEffort
+      : null;
+
+  const withCost = addCostToMetrics(metrics, { provider, model });
+  return reasoningEffort ? { ...withCost, reasoningEffort } : withCost;
 }
 
 module.exports = {

--- a/server/utils/helpers/reasoningEffort.js
+++ b/server/utils/helpers/reasoningEffort.js
@@ -1,0 +1,49 @@
+/**
+ * Reasoning effort levels each provider accepts per model. A stored effort can
+ * outlive a provider/model switch, so request builders validate against this
+ * map before sending. Verified against live provider APIs (Sept 2026).
+ * @type {Record<string, (model?: string) => string[]>}
+ */
+const PROVIDER_REASONING_EFFORTS = {
+  // "off" is sent as "none". gpt-5.x rejects "minimal", gpt-5 rejects "none".
+  openai: (model = "") => {
+    if (/^gpt-5\.\d/.test(model)) return ["off", "low", "medium", "high"];
+    if (model.startsWith("gpt-5")) return ["minimal", "low", "medium", "high"];
+    if (model.startsWith("o")) return ["low", "medium", "high"];
+    return [];
+  },
+  // Superset - levels vary per model. The UI list comes from their models API.
+  anthropic: () => ["low", "medium", "high", "xhigh", "max"],
+  // No model accepts "none"; pro models also reject "minimal".
+  gemini: (model = "") =>
+    model.includes("pro")
+      ? ["low", "medium", "high"]
+      : ["minimal", "low", "medium", "high"],
+  ollama: () => ["on", "off", "low", "medium", "high", "max"],
+  // "off" is sent as "none".
+  lmstudio: () => ["off", "minimal", "low", "medium", "high"],
+  // Lemonade does no validation of its own - this gate is the only guard.
+  lemonade: () => ["off", "low", "medium", "high"],
+  // Only the thinking toggle is documented.
+  deepseek: () => ["on", "off"],
+};
+
+/**
+ * Returns the effort when the provider's API accepts it for the model,
+ * otherwise logs and returns null so no reasoning params are sent.
+ * @param {string} provider - Provider key from PROVIDER_REASONING_EFFORTS
+ * @param {string|null} model - Model name the request targets
+ * @param {string|null} reasoningEffort - Stored effort to validate
+ * @returns {string|null}
+ */
+function validReasoningEffort(provider, model, reasoningEffort = null) {
+  if (!reasoningEffort) return null;
+  const allowed = PROVIDER_REASONING_EFFORTS[provider]?.(model ?? "") ?? [];
+  if (allowed.includes(reasoningEffort)) return reasoningEffort;
+  console.log(
+    `\x1b[36m[ReasoningEffort]\x1b[0m Ignoring reasoning effort "${reasoningEffort}" - not supported by ${provider} model "${model}".`
+  );
+  return null;
+}
+
+module.exports = { PROVIDER_REASONING_EFFORTS, validReasoningEffort };

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -6,6 +6,10 @@ const KEY_MAPPING = {
     envKey: "LLM_PROVIDER",
     checks: [isNotEmpty, supportedLLM],
   },
+  ReasoningEffort: {
+    envKey: "REASONING_EFFORT",
+    checks: [validReasoningEffort],
+  },
   // Model Router Settings
   ModelRouterId: {
     envKey: "MODEL_ROUTER_ID",
@@ -1127,6 +1131,14 @@ function validLocalWhisper(input = "") {
   return validSelection
     ? null
     : `${input} is not a valid Whisper model selection.`;
+}
+
+function validReasoningEffort(input = "") {
+  if (!input) return null; // Empty clears the setting.
+  const { Workspace } = require("../../models/workspace");
+  return Workspace.VALID_REASONING_EFFORTS.includes(input)
+    ? null
+    : "Invalid reasoning effort value";
 }
 
 function supportedLLM(input = "") {


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #

### Description

<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->

- add a per-workspace reasoning effort setting in chat settings, only shown for models that support reasoning controls
- add a brain icon picker in the chat input to change the workspace effort without leaving the chat
- add a system-wide default reasoning effort on the LLM preference page, rendered inline with each provider's settings; workspaces without their own setting fall back to it
- add per-provider wire mappings (reasoning effort, output_config, thinking, think) and capability endpoints for workspace + system scope
- validate the stored effort against the model's live capabilities before every request so a stale value from a model switch, or a provider without reasoning controls, is dropped instead of failing the chat or being misreported
- apply the effort on regular chat, agent chats, the developer API, embed, openai-compatible, and telegram paths
- show the applied effort on the chat model indicator and per-message metrics, persisted with each chat

Provider support:

- [x] OpenAI
- [x] Anthropic
- [x] Gemini
- [x] Ollama
- [x] DeepSeek
- [x] LM Studio (per-model options from the LM Studio models API)
- [x] Lemonade (gpt-oss levels, thinking on/off for other models)

### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
