### PR TITLE
feat: describe uploaded images with a vision model so they are queryable

### DIFF
--- a/collector/__tests__/processSingleFile/convert/asImage.test.js
+++ b/collector/__tests__/processSingleFile/convert/asImage.test.js
@@ -1,0 +1,226 @@
+/* eslint-env jest, node */
+process.env.STORAGE_DIR = "test-storage";
+
+const mockOcrImage = jest.fn();
+const mockOpenAiDescribe = jest.fn();
+const mockGenericDescribe = jest.fn();
+
+jest.mock("../../../utils/OCRLoader", () =>
+  jest.fn().mockImplementation(() => ({ ocrImage: mockOcrImage }))
+);
+jest.mock("../../../utils/VisionProviders/OpenAiVision", () => ({
+  OpenAiVision: jest
+    .fn()
+    .mockImplementation(() => ({ describeImage: mockOpenAiDescribe })),
+}));
+jest.mock("../../../utils/VisionProviders/GenericOpenAiVision", () => ({
+  GenericOpenAiVision: jest
+    .fn()
+    .mockImplementation(() => ({ describeImage: mockGenericDescribe })),
+}));
+jest.mock("../../../utils/files", () => ({
+  createdDate: jest.fn(() => "1/1/2026"),
+  trashFile: jest.fn(),
+  writeToServerDocuments: jest.fn(({ data }) => data),
+}));
+
+const OCRLoader = require("../../../utils/OCRLoader");
+const {
+  OpenAiVision,
+} = require("../../../utils/VisionProviders/OpenAiVision");
+const {
+  GenericOpenAiVision,
+} = require("../../../utils/VisionProviders/GenericOpenAiVision");
+const { trashFile } = require("../../../utils/files");
+const asImage = require("../../../processSingleFile/convert/asImage");
+
+const FULL_FILE_PATH = "/hotdir/diagram.png";
+const FILENAME = "diagram.png";
+const MARKER = "[Machine-generated image description]";
+
+function convert(options = {}, metadata = {}) {
+  return asImage({
+    fullFilePath: FULL_FILE_PATH,
+    filename: FILENAME,
+    options,
+    metadata,
+  });
+}
+
+describe("asImage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOcrImage.mockResolvedValue("");
+    mockOpenAiDescribe.mockResolvedValue({ content: "", error: null });
+    mockGenericDescribe.mockResolvedValue({ content: "", error: null });
+  });
+
+  describe("with no vision provider configured", () => {
+    it("embeds only the OCR text and never builds a vision provider", async () => {
+      mockOcrImage.mockResolvedValue("Total due: $40");
+      const { success, documents } = await convert();
+
+      expect(success).toBe(true);
+      expect(OpenAiVision).not.toHaveBeenCalled();
+      expect(GenericOpenAiVision).not.toHaveBeenCalled();
+      expect(documents[0].pageContent).toBe("Total due: $40");
+      expect(documents[0].description).toBe("Unknown");
+      expect(documents[0].docSource).toBe("image file uploaded by the user.");
+    });
+
+    it("rejects an image with no text using the original failure response", async () => {
+      const result = await convert();
+
+      expect(result).toEqual({
+        success: false,
+        reason: "No text content found in diagram.png.",
+        documents: [],
+      });
+      expect(trashFile).toHaveBeenCalledWith(FULL_FILE_PATH);
+    });
+
+    it("keeps the file on disk when parsing an absolute path", async () => {
+      await convert({ absolutePath: "/some/where/diagram.png" });
+      expect(trashFile).not.toHaveBeenCalled();
+    });
+
+    it("ignores an unknown provider name", async () => {
+      const result = await convert({ visionProvider: "not-a-provider" });
+
+      expect(OpenAiVision).not.toHaveBeenCalled();
+      expect(result.reason).toBe("No text content found in diagram.png.");
+    });
+
+    it("ignores object prototype keys used as a provider name", async () => {
+      const result = await convert({ visionProvider: "constructor" });
+
+      expect(result.reason).toBe("No text content found in diagram.png.");
+    });
+  });
+
+  describe("with a vision provider configured", () => {
+    it("appends the description to the OCR text behind a provenance marker", async () => {
+      mockOcrImage.mockResolvedValue("Q3 REVENUE");
+      mockOpenAiDescribe.mockResolvedValue({
+        content: "A bar chart of quarterly revenue.",
+        error: null,
+      });
+
+      const { success, documents } = await convert({
+        visionProvider: "openai",
+        openAiKey: "sk-test",
+      });
+
+      expect(success).toBe(true);
+      expect(OpenAiVision).toHaveBeenCalledWith({
+        options: { visionProvider: "openai", openAiKey: "sk-test" },
+      });
+      expect(mockOpenAiDescribe).toHaveBeenCalledWith(FULL_FILE_PATH);
+      expect(documents[0].pageContent).toBe(
+        `Q3 REVENUE\n\n${MARKER}\nA bar chart of quarterly revenue.`
+      );
+      expect(documents[0].docSource).toBe(
+        "image file uploaded by the user, described by a vision model."
+      );
+      expect(documents[0].description).toBe(
+        "Machine-generated description of an image."
+      );
+      expect(documents[0].wordCount).toBe(
+        documents[0].pageContent.split(" ").length
+      );
+    });
+
+    it("selects the generic provider for generic-openai", async () => {
+      mockGenericDescribe.mockResolvedValue({
+        content: "A screenshot of a terminal.",
+        error: null,
+      });
+
+      const { documents } = await convert({
+        visionProvider: "generic-openai",
+        VisionGenericOpenAiBaseUrl: "http://localhost:11434/v1",
+      });
+
+      expect(GenericOpenAiVision).toHaveBeenCalledTimes(1);
+      expect(OpenAiVision).not.toHaveBeenCalled();
+      expect(documents[0].pageContent).toBe(
+        `${MARKER}\nA screenshot of a terminal.`
+      );
+    });
+
+    it("succeeds on an image with no OCR text once it has a description", async () => {
+      mockOpenAiDescribe.mockResolvedValue({
+        content: "A photo of a dog on a beach.",
+        error: null,
+      });
+
+      const { success, reason, documents } = await convert({
+        visionProvider: "openai",
+      });
+
+      expect(success).toBe(true);
+      expect(reason).toBeNull();
+      expect(documents[0].pageContent).toBe(
+        `${MARKER}\nA photo of a dog on a beach.`
+      );
+    });
+
+    it("still fails when OCR and the description are both empty", async () => {
+      const result = await convert({ visionProvider: "openai" });
+
+      expect(result).toEqual({
+        success: false,
+        reason: "No text content found in diagram.png.",
+        documents: [],
+      });
+      expect(trashFile).toHaveBeenCalledWith(FULL_FILE_PATH);
+    });
+
+    it("falls back to OCR-only when the provider returns an error", async () => {
+      mockOcrImage.mockResolvedValue("Total due: $40");
+      mockOpenAiDescribe.mockResolvedValue({
+        content: "",
+        error: "429 rate limited",
+      });
+
+      const { success, documents } = await convert({
+        visionProvider: "openai",
+      });
+
+      expect(success).toBe(true);
+      expect(documents[0].pageContent).toBe("Total due: $40");
+      expect(documents[0].docSource).toBe("image file uploaded by the user.");
+    });
+
+    it("falls back to OCR-only when the provider throws", async () => {
+      mockOcrImage.mockResolvedValue("Total due: $40");
+      mockOpenAiDescribe.mockRejectedValue(new Error("socket hang up"));
+
+      const { success, documents } = await convert({
+        visionProvider: "openai",
+      });
+
+      expect(success).toBe(true);
+      expect(documents[0].pageContent).toBe("Total due: $40");
+    });
+
+    it("falls back to OCR-only when the provider cannot be constructed", async () => {
+      mockOcrImage.mockResolvedValue("Total due: $40");
+      OpenAiVision.mockImplementationOnce(() => {
+        throw new Error("No OpenAI API key was set.");
+      });
+
+      const { success, documents } = await convert({
+        visionProvider: "openai",
+      });
+
+      expect(success).toBe(true);
+      expect(documents[0].pageContent).toBe("Total due: $40");
+    });
+
+    it("passes the OCR language list through untouched", async () => {
+      await convert({ visionProvider: "openai", ocr: { langList: "deu" } });
+      expect(OCRLoader).toHaveBeenCalledWith({ targetLanguages: "deu" });
+    });
+  });
+});

--- a/collector/__tests__/utils/VisionProviders/index.test.js
+++ b/collector/__tests__/utils/VisionProviders/index.test.js
@@ -1,0 +1,159 @@
+/* eslint-env jest, node */
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const mockCreate = jest.fn();
+jest.mock("openai", () => ({
+  OpenAI: jest.fn().mockImplementation((config) => ({
+    config,
+    chat: { completions: { create: mockCreate } },
+  })),
+}));
+
+const { OpenAI } = require("openai");
+const { OpenAiVision } = require("../../../utils/VisionProviders/OpenAiVision");
+const {
+  GenericOpenAiVision,
+} = require("../../../utils/VisionProviders/GenericOpenAiVision");
+const {
+  DESCRIPTION_PROMPT,
+} = require("../../../utils/VisionProviders/utils");
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function completion(content) {
+  return { choices: [{ message: { content } }] };
+}
+
+describe("Vision providers", () => {
+  let tmpDir;
+  let imagePath;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vision-provider-"));
+    imagePath = path.join(tmpDir, "chart.png");
+    fs.writeFileSync(imagePath, PNG_BYTES);
+  });
+
+  afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("OpenAiVision", () => {
+    it("requires an API key", () => {
+      expect(() => new OpenAiVision({ options: {} })).toThrow(
+        "No OpenAI API key was set."
+      );
+    });
+
+    it("sends the image as a base64 data URL and returns the description", async () => {
+      mockCreate.mockResolvedValue(
+        completion("  A bar chart of quarterly revenue.  ")
+      );
+      const provider = new OpenAiVision({ options: { openAiKey: "sk-test" } });
+      const result = await provider.describeImage(imagePath);
+
+      expect(result).toEqual({
+        content: "A bar chart of quarterly revenue.",
+        error: null,
+      });
+
+      const [payload] = mockCreate.mock.calls[0];
+      expect(payload.model).toBe("gpt-4o-mini");
+      expect(payload.messages[0].content[0]).toEqual({
+        type: "text",
+        text: DESCRIPTION_PROMPT,
+      });
+      expect(payload.messages[0].content[1].image_url.url).toBe(
+        `data:image/png;base64,${PNG_BYTES.toString("base64")}`
+      );
+    });
+
+    it("returns an error instead of throwing when the request fails", async () => {
+      mockCreate.mockRejectedValue(new Error("429 rate limited"));
+      const provider = new OpenAiVision({ options: { openAiKey: "sk-test" } });
+
+      expect(await provider.describeImage(imagePath)).toEqual({
+        content: "",
+        error: "429 rate limited",
+      });
+    });
+
+    it("returns an error when the response has no content", async () => {
+      mockCreate.mockResolvedValue(completion(""));
+      const provider = new OpenAiVision({ options: { openAiKey: "sk-test" } });
+
+      expect(await provider.describeImage(imagePath)).toEqual({
+        content: "",
+        error: "No description was returned.",
+      });
+    });
+
+    it("returns an error and makes no request when the file is missing", async () => {
+      const provider = new OpenAiVision({ options: { openAiKey: "sk-test" } });
+
+      expect(
+        await provider.describeImage(path.join(tmpDir, "missing.png"))
+      ).toEqual({
+        content: "",
+        error: "Image could not be read from disk.",
+      });
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GenericOpenAiVision", () => {
+    it("requires a base URL", () => {
+      expect(() => new GenericOpenAiVision({ options: {} })).toThrow(
+        "No base URL was set."
+      );
+    });
+
+    it("uses the configured base URL, key and model", async () => {
+      mockCreate.mockResolvedValue(completion("A screenshot of a terminal."));
+      const provider = new GenericOpenAiVision({
+        options: {
+          VisionGenericOpenAiBaseUrl: "http://localhost:11434/v1",
+          VisionGenericOpenAiApiKey: "sk-local",
+          VisionGenericOpenAiModel: "qwen2.5vl",
+        },
+      });
+      const result = await provider.describeImage(imagePath);
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        baseURL: "http://localhost:11434/v1",
+        apiKey: "sk-local",
+      });
+      expect(mockCreate.mock.calls[0][0].model).toBe("qwen2.5vl");
+      expect(result.content).toBe("A screenshot of a terminal.");
+    });
+
+    it("defaults the model when none is configured", async () => {
+      mockCreate.mockResolvedValue(completion("A diagram."));
+      const provider = new GenericOpenAiVision({
+        options: { VisionGenericOpenAiBaseUrl: "http://localhost:11434/v1" },
+      });
+      await provider.describeImage(imagePath);
+
+      expect(OpenAI).toHaveBeenCalledWith({
+        baseURL: "http://localhost:11434/v1",
+        apiKey: null,
+      });
+      expect(mockCreate.mock.calls[0][0].model).toBe("llava");
+    });
+
+    it("derives the data URL mime from the file extension", async () => {
+      const jpegPath = path.join(tmpDir, "photo.jpg");
+      fs.writeFileSync(jpegPath, PNG_BYTES);
+      mockCreate.mockResolvedValue(completion("A photo."));
+      const provider = new GenericOpenAiVision({
+        options: { VisionGenericOpenAiBaseUrl: "http://localhost:11434/v1" },
+      });
+      await provider.describeImage(jpegPath);
+
+      expect(mockCreate.mock.calls[0][0].messages[0].content[1].image_url.url)
+        .toBe(`data:image/jpeg;base64,${PNG_BYTES.toString("base64")}`);
+    });
+  });
+});

--- a/collector/processSingleFile/convert/asImage.js
+++ b/collector/processSingleFile/convert/asImage.js
@@ -7,6 +7,41 @@ const {
 } = require("../../utils/files");
 const OCRLoader = require("../../utils/OCRLoader");
 const { default: slugify } = require("slugify");
+const { OpenAiVision } = require("../../utils/VisionProviders/OpenAiVision");
+const {
+  GenericOpenAiVision,
+} = require("../../utils/VisionProviders/GenericOpenAiVision");
+
+const VISION_PROVIDERS = {
+  openai: OpenAiVision,
+  "generic-openai": GenericOpenAiVision,
+};
+
+// Marks the model-written text inside pageContent so it is never read back as OCR ground truth.
+const DESCRIPTION_HEADER = "[Machine-generated image description]";
+
+/**
+ * Describe the image with the configured vision provider. Returns an empty string
+ * when none is set or the provider fails so ingestion always falls back to OCR-only.
+ * @param {string} fullFilePath
+ * @param {Object} options
+ * @returns {Promise<string>}
+ */
+async function describeImage(fullFilePath, options) {
+  if (!VISION_PROVIDERS.hasOwnProperty(options?.visionProvider)) return "";
+  const VisionProvider = VISION_PROVIDERS[options.visionProvider];
+
+  try {
+    const { content, error } = await new VisionProvider({
+      options,
+    }).describeImage(fullFilePath);
+    if (!!error) throw new Error(error);
+    return content || "";
+  } catch (e) {
+    console.error(`Could not describe image. ${e.message}`);
+    return "";
+  }
+}
 
 async function asImage({
   fullFilePath = "",
@@ -14,9 +49,17 @@ async function asImage({
   options = {},
   metadata = {},
 }) {
-  let content = await new OCRLoader({
+  const ocrContent = await new OCRLoader({
     targetLanguages: options?.ocr?.langList,
   }).ocrImage(fullFilePath);
+  const description = await describeImage(fullFilePath, options);
+  const described = !!description?.length;
+  const content = [
+    ocrContent?.length ? ocrContent : null,
+    described ? `${DESCRIPTION_HEADER}\n${description}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 
   if (!content?.length) {
     console.error(`Resulting text content was empty for ${filename}.`);
@@ -34,8 +77,14 @@ async function asImage({
     url: "file://" + fullFilePath,
     title: metadata.title || filename,
     docAuthor: metadata.docAuthor || "Unknown",
-    description: metadata.description || "Unknown",
-    docSource: metadata.docSource || "image file uploaded by the user.",
+    description:
+      metadata.description ||
+      (described ? "Machine-generated description of an image." : "Unknown"),
+    docSource:
+      metadata.docSource ||
+      (described
+        ? "image file uploaded by the user, described by a vision model."
+        : "image file uploaded by the user."),
     chunkSource: metadata.chunkSource || "",
     published: createdDate(fullFilePath),
     wordCount: content.split(" ").length,

--- a/collector/utils/VisionProviders/GenericOpenAiVision.js
+++ b/collector/utils/VisionProviders/GenericOpenAiVision.js
@@ -1,0 +1,59 @@
+const { imageToDataUrl, DESCRIPTION_PROMPT } = require("./utils");
+
+class GenericOpenAiVision {
+  constructor({ options }) {
+    const { OpenAI: OpenAIApi } = require("openai");
+    if (!options.VisionGenericOpenAiBaseUrl)
+      throw new Error("No base URL was set.");
+
+    this.openai = new OpenAIApi({
+      baseURL: options.VisionGenericOpenAiBaseUrl,
+      apiKey: options.VisionGenericOpenAiApiKey || null,
+    });
+    this.model = options.VisionGenericOpenAiModel || "llava";
+    this.temperature = 0;
+    this.#log("Initialized.");
+  }
+
+  #log(text, ...args) {
+    console.log(`\x1b[32m[GenericOpenAiVision]\x1b[0m ${text}`, ...args);
+  }
+
+  async describeImage(fullFilePath) {
+    const dataUrl = imageToDataUrl(fullFilePath);
+    if (!dataUrl)
+      return { content: "", error: "Image could not be read from disk." };
+
+    return await this.openai.chat.completions
+      .create({
+        model: this.model,
+        temperature: this.temperature,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: DESCRIPTION_PROMPT },
+              { type: "image_url", image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+      })
+      .then((response) => {
+        const content = response?.choices?.[0]?.message?.content;
+        if (!content)
+          return { content: "", error: "No description was returned." };
+        return { content: content.trim(), error: null };
+      })
+      .catch((error) => {
+        this.#log(
+          `Could not get any response from openai compatible vision endpoint`,
+          error.message
+        );
+        return { content: "", error: error.message };
+      });
+  }
+}
+
+module.exports = {
+  GenericOpenAiVision,
+};

--- a/collector/utils/VisionProviders/OpenAiVision.js
+++ b/collector/utils/VisionProviders/OpenAiVision.js
@@ -1,0 +1,57 @@
+const { imageToDataUrl, DESCRIPTION_PROMPT } = require("./utils");
+
+class OpenAiVision {
+  constructor({ options }) {
+    const { OpenAI: OpenAIApi } = require("openai");
+    if (!options.openAiKey) throw new Error("No OpenAI API key was set.");
+
+    this.openai = new OpenAIApi({
+      apiKey: options.openAiKey,
+    });
+    this.model = "gpt-4o-mini";
+    this.temperature = 0;
+    this.#log("Initialized.");
+  }
+
+  #log(text, ...args) {
+    console.log(`\x1b[32m[OpenAiVision]\x1b[0m ${text}`, ...args);
+  }
+
+  async describeImage(fullFilePath) {
+    const dataUrl = imageToDataUrl(fullFilePath);
+    if (!dataUrl)
+      return { content: "", error: "Image could not be read from disk." };
+
+    return await this.openai.chat.completions
+      .create({
+        model: this.model,
+        temperature: this.temperature,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: DESCRIPTION_PROMPT },
+              { type: "image_url", image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+      })
+      .then((response) => {
+        const content = response?.choices?.[0]?.message?.content;
+        if (!content)
+          return { content: "", error: "No description was returned." };
+        return { content: content.trim(), error: null };
+      })
+      .catch((error) => {
+        this.#log(
+          `Could not get any response from openai vision`,
+          error.message
+        );
+        return { content: "", error: error.message };
+      });
+  }
+}
+
+module.exports = {
+  OpenAiVision,
+};

--- a/collector/utils/VisionProviders/utils.js
+++ b/collector/utils/VisionProviders/utils.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const { MimeDetector } = require("../files/mime");
+
+const DESCRIPTION_PROMPT =
+  "Describe this image factually so it can be searched later. Cover the subject, any visible text, and the structure of charts or diagrams. Do not speculate about anything you cannot see.";
+
+/**
+ * Reads an image off disk as a base64 data URL for OpenAI-style `image_url` content parts.
+ * @param {string} fullFilePath
+ * @returns {string|null}
+ */
+function imageToDataUrl(fullFilePath) {
+  if (!fs.existsSync(fullFilePath)) return null;
+  const mime = new MimeDetector().getType(fullFilePath) || "image/png";
+  return `data:${mime};base64,${fs.readFileSync(fullFilePath, {
+    encoding: "base64",
+  })}`;
+}
+
+module.exports = {
+  DESCRIPTION_PROMPT,
+  imageToDataUrl,
+};

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -353,6 +353,22 @@ GID='1000'
 # WHISPER_GENERIC_OPEN_AI_MODEL="whisper-small"
 
 ###########################################
+####### Image Description Selection #######
+###########################################
+# (default) uploaded images are OCR'd only and never described.
+# VISION_PROVIDER="none"
+
+# describe uploaded images with an openai hosted vision model.
+# VISION_PROVIDER="openai"
+# OPEN_AI_KEY=sk-xxxxxxxx
+
+# describe uploaded images with any OpenAI compatible vision endpoint.
+# VISION_PROVIDER="generic-openai"
+# VISION_GENERIC_OPEN_AI_BASE_URL="http://localhost:11434/v1"
+# VISION_GENERIC_OPEN_AI_API_KEY=sk-xxxxxxxx
+# VISION_GENERIC_OPEN_AI_MODEL="llava"
+
+###########################################
 ######## TTS/STT Model Selection ##########
 ###########################################
 # TTS_PROVIDER="native"

--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -264,6 +264,12 @@ const SidebarOptions = ({ user = null, t }) => (
               roles: ["admin"],
             },
             {
+              btnText: "Image Description",
+              href: paths.settings.visionPreference(),
+              flex: true,
+              roles: ["admin"],
+            },
+            {
               btnText: t("settings.model-router"),
               href: paths.settings.modelRouters(),
               flex: true,

--- a/frontend/src/components/VisionSelection/DisabledVisionOptions/index.jsx
+++ b/frontend/src/components/VisionSelection/DisabledVisionOptions/index.jsx
@@ -1,0 +1,10 @@
+export default function DisabledVisionOptions() {
+  return (
+    <div className="w-full h-10 items-center flex">
+      <p className="text-sm font-base text-white text-opacity-60">
+        Uploaded images are processed with OCR only. Images without readable
+        text will continue to be rejected.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/VisionSelection/GenericOpenAiOptions/index.jsx
+++ b/frontend/src/components/VisionSelection/GenericOpenAiOptions/index.jsx
@@ -1,0 +1,61 @@
+export default function GenericOpenAiVisionOptions({ settings }) {
+  return (
+    <div className="flex gap-x-7 gap-[36px] mt-1.5 flex-wrap">
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          Base URL
+        </label>
+        <input
+          type="url"
+          name="VisionGenericOpenAiBaseUrl"
+          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          placeholder="http://localhost:11434/v1"
+          defaultValue={settings?.VisionGenericOpenAiBaseUrl}
+          required={true}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          The base URL of the OpenAI-compatible service used to describe images.
+        </p>
+      </div>
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          API Key
+        </label>
+        <input
+          type="password"
+          name="VisionGenericOpenAiApiKey"
+          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          placeholder="API Key"
+          defaultValue={
+            settings?.VisionGenericOpenAiApiKey ? "*".repeat(20) : ""
+          }
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          Optional - Only required if your service enforces authentication.
+        </p>
+      </div>
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          Vision Model
+        </label>
+        <input
+          type="text"
+          name="VisionGenericOpenAiModel"
+          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          placeholder="llava"
+          defaultValue={settings?.VisionGenericOpenAiModel}
+          required={true}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          The model identifier to be used to describe images.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VisionSelection/OpenAiOptions/index.jsx
+++ b/frontend/src/components/VisionSelection/OpenAiOptions/index.jsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+export default function OpenAiVisionOptions({ settings }) {
+  const [inputValue, setInputValue] = useState(settings?.OpenAiKey);
+  const [_openAIKey, setOpenAIKey] = useState(settings?.OpenAiKey);
+
+  return (
+    <div className="flex gap-x-7 gap-[36px] mt-1.5">
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          API Key
+        </label>
+        <input
+          type="password"
+          name="OpenAiKey"
+          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          placeholder="OpenAI API Key"
+          defaultValue={settings?.OpenAiKey ? "*".repeat(20) : ""}
+          required={true}
+          autoComplete="off"
+          spellCheck={false}
+          onChange={(e) => setInputValue(e.target.value)}
+          onBlur={() => setOpenAIKey(inputValue)}
+        />
+      </div>
+      <div className="flex flex-col w-60">
+        <label className="text-white text-sm font-semibold block mb-3">
+          Vision Model
+        </label>
+        <select
+          disabled={true}
+          className="border-none flex-shrink-0 bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+        >
+          <option disabled={true} selected={true}>
+            GPT-4o mini
+          </option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -87,6 +87,17 @@ const router = createBrowserRouter([
         },
       },
       {
+        path: "/settings/vision-preference",
+        lazy: async () => {
+          const { default: GeneralVisionPreference } = await import(
+            "@/pages/GeneralSettings/VisionPreference"
+          );
+          return {
+            element: <AdminRoute Component={GeneralVisionPreference} />,
+          };
+        },
+      },
+      {
         path: "/settings/audio-preference",
         lazy: async () => {
           const { default: GeneralAudioPreference } = await import(

--- a/frontend/src/pages/GeneralSettings/VisionPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/VisionPreference/index.jsx
@@ -1,0 +1,250 @@
+import React, { useEffect, useState, useRef } from "react";
+import { isMobile } from "react-device-detect";
+import Sidebar from "@/components/SettingsSidebar";
+import System from "@/models/system";
+import showToast from "@/utils/toast";
+import PreLoader from "@/components/Preloader";
+import OpenAiLogo from "@/media/llmprovider/openai.png";
+import GenericOpenAiLogo from "@/media/llmprovider/generic-openai.png";
+import AnythingLLMIcon from "@/media/logo/anything-llm-icon.png";
+import OpenAiVisionOptions from "@/components/VisionSelection/OpenAiOptions";
+import GenericOpenAiVisionOptions from "@/components/VisionSelection/GenericOpenAiOptions";
+import DisabledVisionOptions from "@/components/VisionSelection/DisabledVisionOptions";
+import LLMItem from "@/components/LLMSelection/LLMItem";
+import { CaretUpDown, MagnifyingGlass, X } from "@phosphor-icons/react";
+import CTAButton from "@/components/lib/CTAButton";
+
+const PROVIDERS = [
+  {
+    name: "Disabled",
+    value: "none",
+    logo: AnythingLLMIcon,
+    options: () => <DisabledVisionOptions />,
+    description: "Only extract text from uploaded images with OCR.",
+  },
+  {
+    name: "OpenAI",
+    value: "openai",
+    logo: OpenAiLogo,
+    options: (settings) => <OpenAiVisionOptions settings={settings} />,
+    description:
+      "Describe images with an OpenAI vision model using your API key.",
+  },
+  {
+    name: "OpenAI Compatible",
+    value: "generic-openai",
+    logo: GenericOpenAiLogo,
+    options: (settings) => <GenericOpenAiVisionOptions settings={settings} />,
+    description:
+      "Describe images using any OpenAI-compatible API via custom configuration.",
+  },
+];
+
+export default function VisionModelPreference() {
+  const [saving, setSaving] = useState(false);
+  const [hasChanges, setHasChanges] = useState(false);
+  const [settings, setSettings] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [filteredProviders, setFilteredProviders] = useState([]);
+  const [selectedProvider, setSelectedProvider] = useState(null);
+  const [searchMenuOpen, setSearchMenuOpen] = useState(false);
+  const searchInputRef = useRef(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const data = { VisionProvider: selectedProvider };
+    const formData = new FormData(form);
+
+    for (var [key, value] of formData.entries()) data[key] = value;
+    const { error } = await System.updateSystem(data);
+    setSaving(true);
+
+    if (error) {
+      showToast(`Failed to save preferences: ${error}`, "error");
+    } else {
+      showToast("Image description preferences saved successfully.", "success");
+    }
+    setSaving(false);
+    setHasChanges(!!error);
+  };
+
+  const updateProviderChoice = (selection) => {
+    setSearchQuery("");
+    setSelectedProvider(selection);
+    setSearchMenuOpen(false);
+    setHasChanges(true);
+  };
+
+  const handleXButton = () => {
+    if (searchQuery.length > 0) {
+      setSearchQuery("");
+      if (searchInputRef.current) searchInputRef.current.value = "";
+    } else {
+      setSearchMenuOpen(!searchMenuOpen);
+    }
+  };
+
+  useEffect(() => {
+    async function fetchKeys() {
+      const _settings = await System.keys();
+      setSettings(_settings);
+      setSelectedProvider(_settings?.VisionProvider || "none");
+      setLoading(false);
+    }
+    fetchKeys();
+  }, []);
+
+  useEffect(() => {
+    const filtered = PROVIDERS.filter((provider) =>
+      provider.name.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+    setFilteredProviders(filtered);
+  }, [searchQuery, selectedProvider]);
+
+  const selectedProviderObject = PROVIDERS.find(
+    (provider) => provider.value === selectedProvider
+  );
+
+  return (
+    <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
+      <Sidebar />
+      {loading ? (
+        <div
+          style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
+          className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-[16px] bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
+        >
+          <div className="w-full h-full flex justify-center items-center">
+            <PreLoader />
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
+          className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-[16px] bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
+        >
+          <form onSubmit={handleSubmit} className="flex w-full">
+            <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] py-16 md:py-6">
+              <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+                <div className="flex gap-x-4 items-center">
+                  <p className="text-lg leading-6 font-bold text-white">
+                    Image Description Preference
+                  </p>
+                </div>
+                <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+                  When a provider is selected, uploaded images are described by
+                  a vision model and that description is embedded alongside any
+                  text found by OCR, which makes diagrams, screenshots and
+                  photos searchable. Descriptions are written by a model and are
+                  labeled as such inside the document.
+                </p>
+              </div>
+              <div className="w-full justify-end flex">
+                {hasChanges && (
+                  <CTAButton
+                    onClick={() => handleSubmit()}
+                    className="mt-3 mr-0 -mb-14 z-10"
+                  >
+                    {saving ? "Saving..." : "Save changes"}
+                  </CTAButton>
+                )}
+              </div>
+              <div className="text-base font-bold text-white mt-6 mb-4">
+                Image Description Provider
+              </div>
+              <div className="relative">
+                {searchMenuOpen && (
+                  <div
+                    className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-70 backdrop-blur-sm z-10"
+                    onClick={() => setSearchMenuOpen(false)}
+                  />
+                )}
+                {searchMenuOpen ? (
+                  <div className="absolute top-0 left-0 w-full max-w-[640px] max-h-[310px] min-h-[64px] bg-theme-settings-input-bg rounded-lg flex flex-col justify-between cursor-pointer border-2 border-primary-button z-20">
+                    <div className="w-full flex flex-col gap-y-1">
+                      <div className="flex items-center sticky top-0 z-10 border-b border-[#9CA3AF] mx-4 bg-theme-settings-input-bg">
+                        <MagnifyingGlass
+                          size={20}
+                          weight="bold"
+                          className="absolute left-4 z-30 text-theme-text-primary -ml-4 my-2"
+                        />
+                        <input
+                          type="text"
+                          name="provider-search"
+                          autoComplete="off"
+                          placeholder="Search image description providers"
+                          className="border-none -ml-4 my-2 bg-transparent z-20 pl-12 h-[38px] w-full px-4 py-1 text-sm outline-none focus:outline-primary-button active:outline-primary-button outline-none text-theme-text-primary placeholder:text-theme-text-primary placeholder:font-medium"
+                          onChange={(e) => setSearchQuery(e.target.value)}
+                          ref={searchInputRef}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") e.preventDefault();
+                          }}
+                        />
+                        <X
+                          size={20}
+                          weight="bold"
+                          className="cursor-pointer text-white hover:text-x-button"
+                          onClick={handleXButton}
+                        />
+                      </div>
+                      <div className="flex-1 pl-4 pr-2 flex flex-col gap-y-1 overflow-y-auto white-scrollbar pb-4 max-h-[245px]">
+                        {filteredProviders.map((provider) => (
+                          <LLMItem
+                            key={provider.name}
+                            name={provider.name}
+                            value={provider.value}
+                            image={provider.logo}
+                            description={provider.description}
+                            checked={selectedProvider === provider.value}
+                            onClick={() => updateProviderChoice(provider.value)}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    className="w-full max-w-[640px] h-[64px] bg-theme-settings-input-bg rounded-lg flex items-center p-[14px] justify-between cursor-pointer border-2 border-transparent hover:border-primary-button transition-all duration-300"
+                    type="button"
+                    onClick={() => setSearchMenuOpen(true)}
+                  >
+                    <div className="flex gap-x-4 items-center">
+                      <img
+                        src={selectedProviderObject.logo}
+                        alt={`${selectedProviderObject.name} logo`}
+                        className="w-10 h-10 rounded-md"
+                      />
+                      <div className="flex flex-col text-left">
+                        <div className="text-sm font-semibold text-white">
+                          {selectedProviderObject.name}
+                        </div>
+                        <div className="mt-1 text-xs text-description">
+                          {selectedProviderObject.description}
+                        </div>
+                      </div>
+                    </div>
+                    <CaretUpDown
+                      size={24}
+                      weight="bold"
+                      className="text-white"
+                    />
+                  </button>
+                )}
+              </div>
+              <div
+                onChange={() => setHasChanges(true)}
+                className="mt-4 flex flex-col gap-y-1"
+              >
+                {selectedProvider &&
+                  PROVIDERS.find(
+                    (provider) => provider.value === selectedProvider
+                  )?.options(settings)}
+              </div>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -122,6 +122,9 @@ export default {
     transcriptionPreference: () => {
       return "/settings/transcription-preference";
     },
+    visionPreference: () => {
+      return "/settings/vision-preference";
+    },
     audioPreference: () => {
       return "/settings/audio-preference";
     },

--- a/server/.env.example
+++ b/server/.env.example
@@ -360,6 +360,22 @@ WHISPER_PROVIDER="local"
 # WHISPER_GENERIC_OPEN_AI_MODEL="whisper-small"
 
 ###########################################
+####### Image Description Selection #######
+###########################################
+# (default) uploaded images are OCR'd only and never described.
+VISION_PROVIDER="none"
+
+# describe uploaded images with an openai hosted vision model.
+# VISION_PROVIDER="openai"
+# OPEN_AI_KEY=sk-xxxxxxxx
+
+# describe uploaded images with any OpenAI-compatible vision endpoint.
+# VISION_PROVIDER="generic-openai"
+# VISION_GENERIC_OPEN_AI_BASE_URL="http://localhost:11434/v1"
+# VISION_GENERIC_OPEN_AI_API_KEY=sk-xxxxxxxx
+# VISION_GENERIC_OPEN_AI_MODEL="llava"
+
+###########################################
 ######## TTS/STT Model Selection ##########
 ###########################################
 TTS_PROVIDER="native"

--- a/server/__tests__/utils/helpers/visionProvider.test.js
+++ b/server/__tests__/utils/helpers/visionProvider.test.js
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+const { updateENV } = require("../../../utils/helpers/updateENV.js");
+
+describe("VisionProvider ENV validation", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it.each(["none", "openai", "generic-openai"])(
+    "accepts %s as a provider",
+    async (provider) => {
+      const { newValues, error } = await updateENV({
+        VisionProvider: provider,
+      });
+
+      expect(error).toBe(false);
+      expect(newValues.VisionProvider).toBe(provider);
+      expect(process.env.VISION_PROVIDER).toBe(provider);
+    }
+  );
+
+  it("rejects an unsupported provider and leaves the ENV untouched", async () => {
+    process.env.VISION_PROVIDER = "none";
+    const { newValues, error } = await updateENV({ VisionProvider: "local" });
+
+    expect(error).toBe("local is not a valid vision model provider.");
+    expect(newValues).toEqual({});
+    expect(process.env.VISION_PROVIDER).toBe("none");
+  });
+
+  it("rejects an empty provider", async () => {
+    const { error } = await updateENV({ VisionProvider: "" });
+    expect(error).toBeTruthy();
+    expect(process.env.VISION_PROVIDER).toBeUndefined();
+  });
+
+  it("rejects a base URL that is not a URL", async () => {
+    const { error } = await updateENV({
+      VisionGenericOpenAiBaseUrl: "not a url",
+    });
+
+    expect(error).toBeTruthy();
+    expect(process.env.VISION_GENERIC_OPEN_AI_BASE_URL).toBeUndefined();
+  });
+
+  it("stores the generic provider configuration", async () => {
+    const { error } = await updateENV({
+      VisionGenericOpenAiBaseUrl: "http://localhost:11434/v1",
+      VisionGenericOpenAiApiKey: "sk-local",
+      VisionGenericOpenAiModel: "llava",
+    });
+
+    expect(error).toBe(false);
+    expect(process.env.VISION_GENERIC_OPEN_AI_BASE_URL).toBe(
+      "http://localhost:11434/v1"
+    );
+    expect(process.env.VISION_GENERIC_OPEN_AI_API_KEY).toBe("sk-local");
+    expect(process.env.VISION_GENERIC_OPEN_AI_MODEL).toBe("llava");
+  });
+});

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -542,6 +542,15 @@ const SystemSettings = {
       WhisperGenericOpenAiModel: process.env.WHISPER_GENERIC_OPEN_AI_MODEL,
 
       // --------------------------------------------------------
+      // Vision (image description) Selection Settings & Configs
+      // - Disabled by default so image uploads stay OCR-only.
+      // --------------------------------------------------------
+      VisionProvider: process.env.VISION_PROVIDER || "none",
+      VisionGenericOpenAiBaseUrl: process.env.VISION_GENERIC_OPEN_AI_BASE_URL,
+      VisionGenericOpenAiApiKey: !!process.env.VISION_GENERIC_OPEN_AI_API_KEY,
+      VisionGenericOpenAiModel: process.env.VISION_GENERIC_OPEN_AI_MODEL,
+
+      // --------------------------------------------------------
       // TTS/STT  Selection Settings & Configs
       // - Currently the only 3rd party is OpenAI or the native browser-built in
       // --------------------------------------------------------

--- a/server/utils/collectorApi/index.js
+++ b/server/utils/collectorApi/index.js
@@ -9,6 +9,10 @@ const { Agent } = require("undici");
  * @property {string} WhisperGenericOpenAiBaseUrl - The base URL of the OpenAI compatible endpoint used by the generic Whisper provider.
  * @property {string} WhisperGenericOpenAiApiKey - The API key used by the generic (OpenAI compatible) Whisper provider.
  * @property {string} WhisperGenericOpenAiModel - The transcription model used by the generic (OpenAI compatible) Whisper provider.
+ * @property {string} visionProvider - The provider used to describe uploaded images, defaults to "none"
+ * @property {string} VisionGenericOpenAiBaseUrl - The base URL of the OpenAI compatible endpoint used by the generic vision provider.
+ * @property {string} VisionGenericOpenAiApiKey - The API key used by the generic (OpenAI compatible) vision provider.
+ * @property {string} VisionGenericOpenAiModel - The vision model used by the generic (OpenAI compatible) vision provider.
  * @property {Object} ocr - The OCR options
  * @property {{allowAnyIp: "true"|null|undefined}} runtimeSettings - The runtime settings that are passed to the collector. Persisted across requests.
  */
@@ -73,6 +77,13 @@ class CollectorApi {
         process.env.WHISPER_GENERIC_OPEN_AI_API_KEY || null,
       WhisperGenericOpenAiModel:
         process.env.WHISPER_GENERIC_OPEN_AI_MODEL || null,
+      visionProvider: process.env.VISION_PROVIDER || "none",
+      VisionGenericOpenAiBaseUrl:
+        process.env.VISION_GENERIC_OPEN_AI_BASE_URL || null,
+      VisionGenericOpenAiApiKey:
+        process.env.VISION_GENERIC_OPEN_AI_API_KEY || null,
+      VisionGenericOpenAiModel:
+        process.env.VISION_GENERIC_OPEN_AI_MODEL || null,
       ocr: {
         langList: process.env.TARGET_OCR_LANG || "eng",
       },

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -566,6 +566,28 @@ const KEY_MAPPING = {
     postUpdate: [],
   },
 
+  // Vision (image description) providers
+  VisionProvider: {
+    envKey: "VISION_PROVIDER",
+    checks: [isNotEmpty, supportedVisionProvider],
+    postUpdate: [],
+  },
+  VisionGenericOpenAiBaseUrl: {
+    envKey: "VISION_GENERIC_OPEN_AI_BASE_URL",
+    checks: [isValidURL],
+    postUpdate: [],
+  },
+  VisionGenericOpenAiApiKey: {
+    envKey: "VISION_GENERIC_OPEN_AI_API_KEY",
+    checks: [],
+    postUpdate: [],
+  },
+  VisionGenericOpenAiModel: {
+    envKey: "VISION_GENERIC_OPEN_AI_MODEL",
+    checks: [isNotEmpty],
+    postUpdate: [],
+  },
+
   // System Settings
   AuthToken: {
     envKey: "AUTH_TOKEN",
@@ -1179,6 +1201,13 @@ function supportedTranscriptionProvider(input = "") {
   return validSelection
     ? null
     : `${input} is not a valid transcription model provider.`;
+}
+
+function supportedVisionProvider(input = "") {
+  const validSelection = ["none", "openai", "generic-openai"].includes(input);
+  return validSelection
+    ? null
+    : `${input} is not a valid vision model provider.`;
 }
 
 function validGeminiSafetySetting(input = "") {


### PR DESCRIPTION
resolves #3175

## What

Uploading an image only ever ran OCR. `collector/processSingleFile/convert/asImage.js` called `OCRLoader().ocrImage()` and, when OCR came back empty, deleted the file and returned `No text content found in <filename>.` — so a diagram, screenshot or photo with no printed text was **rejected outright** rather than ingested.

This adds an optional vision-describe step at ingest, which is the shape you described on the issue:

> Uploading an image, having it described and embedding that then later asking queries about **that** makes more sense for at least our use case.

## Implementation

- **`collector/utils/VisionProviders/`** — a new sibling directory modelled on `WhisperProviders/`, with `OpenAiVision` and `GenericOpenAiVision` (any OpenAI-compatible endpoint: Ollama, LM Studio, vLLM, LocalAI). Same class shape, constructor-options style and `{content, error}` contract as the Whisper providers. `openai` was already a collector dependency.
- **`asImage.js`** — a `VISION_PROVIDERS` map mirroring `asAudio.js`'s `WHISPER_PROVIDERS`. OCR still runs first and is unchanged.
- **Provenance.** The generated text is embedded behind a literal `[Machine-generated image description]` line and reflected in `docSource`/`description`, so model-written prose is never silently read back as OCR ground truth.
- **ENV: four keys.** `VISION_PROVIDER` (`none`/`openai`/`generic-openai`, default `none`) plus `VISION_GENERIC_OPEN_AI_{BASE_URL,API_KEY,MODEL}`. The OpenAI provider reuses the existing `OPEN_AI_KEY` rather than adding another. Config reaches the collector through the existing `#attachOptions()` channel.
- **Settings page** mirroring the transcription preference page, with the provider select and conditional fields.

### Behaviour when disabled

With no provider set, no provider object is constructed and ingestion is byte-for-byte what it is today, including the original failure message and the `trashFile()` call. A failing or unreachable vision endpoint logs and falls back to the OCR-only path — a vision outage cannot break image ingestion.

## Testing

`npx jest` from the repo root — **57 suites / 777 tests pass** (54/748 before this change). Lint clean in `collector/`, `server/` and `frontend/`; `yarn build` succeeds; `yarn translations:verify` passes.

Unit tests cover provider selection, the composed `pageContent` and its provenance marker, the empty-OCR-plus-description case that previously hard-failed, both-empty still failing with the original message, provider-throws falling back to OCR, and the `updateENV` validator. Network is mocked throughout.

Verified end-to-end on a running stack (server + collector + frontend) against a real vision model — Ollama's OpenAI-compatible endpoint with `moondream`:

- `VISION_PROVIDER` unset: a no-text PNG is still rejected with `No text content found in notext.png.`, and no provider is constructed.
- Enabled: the same file ingests, and `pageContent` carries the marker plus a correct description of the shapes in the image.
- Settings page saves and persists across reload; the masked API key round-trips without clobbering the stored value.
- Base URL pointed at a dead port: a text-bearing image still ingests via OCR, with the failure logged.
- Text-bearing image with vision on: OCR text and the marked description are both present and delimited.
- Non-image ingestion unaffected.

Two gaps I'd rather state than imply: the Docker/production env-file path wasn't exercised (in dev the config reaches the collector via the `#attachOptions()` payload, which is the intended route), and the hosted `openai` provider is unit-tested only — I had no key to run it live.

The model for the OpenAI provider is currently pinned the way `OpenAiWhisper` pins `whisper-1`; happy to expose it as a fifth key if you'd prefer that configurable.
