### PR TITLE
fix: support self-hosted FastCRW search

### DIFF
--- a/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderOptions/index.jsx
+++ b/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderOptions/index.jsx
@@ -398,12 +398,13 @@ export function CrwSearchOptions({ settings }) {
           className="text-blue-300 underline"
         >
           self-host.
-        </a>
+        </a>{" "}
+        Self-hosted instances work without an API key.
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
-            API Key
+            API Key (required for hosted fastCRW only)
           </label>
           <input
             type="password"
@@ -411,7 +412,6 @@ export function CrwSearchOptions({ settings }) {
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="fastCRW API Key"
             defaultValue={settings?.AgentCrwApiKey ? "*".repeat(20) : ""}
-            required={true}
             autoComplete="off"
             spellCheck={false}
           />

--- a/server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js
+++ b/server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js
@@ -1,0 +1,227 @@
+/* eslint-env jest */
+jest.mock("../../../../../models/systemSettings", () => ({
+  SystemSettings: { get: jest.fn() },
+}));
+jest.mock("../../../../../utils/helpers/tiktoken", () => ({
+  TokenManager: jest.fn().mockImplementation(() => ({
+    countFromString: jest.fn(() => 0),
+  })),
+}));
+jest.mock("../../../../../endpoints/utils", () => ({
+  getAnythingLLMUserAgent: jest.fn(() => "AnythingLLM"),
+}));
+
+const {
+  webBrowsing,
+} = require("../../../../../utils/agents/aibitat/plugins/web-browsing.js");
+
+const ORIGINAL_CRW_KEY = process.env.AGENT_CRW_API_KEY;
+const ORIGINAL_CRW_URL = process.env.AGENT_CRW_API_URL;
+
+function setup() {
+  const aibitat = {
+    introspect: jest.fn(),
+    addCitation: jest.fn(),
+    handlerProps: { log: jest.fn() },
+    function: (config) => (aibitat._fn = config),
+  };
+  webBrowsing.plugin.call(webBrowsing).setup(aibitat);
+
+  const countTokens = jest.fn((str) => String(str?.length || 0));
+  aibitat._fn.countTokens = countTokens;
+
+  // Provide the fields _crwSearch reads off `this` without running the full
+  // AIbitat invocation machinery.
+  const ctx = {
+    ...aibitat._fn,
+    super: aibitat,
+    caller: "WebSearchAgent",
+    introspect: aibitat.introspect,
+  };
+
+  return { aibitat, ctx };
+}
+
+function mockOkResponse(payload) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(payload),
+  });
+}
+
+function mockErrorResponse(status, statusText) {
+  return Promise.resolve({ ok: false, status, statusText });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (ORIGINAL_CRW_KEY === undefined) delete process.env.AGENT_CRW_API_KEY;
+  else process.env.AGENT_CRW_API_KEY = ORIGINAL_CRW_KEY;
+  if (ORIGINAL_CRW_URL === undefined) delete process.env.AGENT_CRW_API_URL;
+  else process.env.AGENT_CRW_API_URL = ORIGINAL_CRW_URL;
+});
+
+describe("fastCRW (_crwSearch) agent search provider", () => {
+  test("self-hosted instance without an API key sends no Authorization header", async () => {
+    delete process.env.AGENT_CRW_API_KEY;
+    process.env.AGENT_CRW_API_URL = "http://localhost:3000";
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        mockOkResponse({
+          success: true,
+          data: {
+            results: [
+              {
+                title: "Debian releases",
+                url: "https://www.debian.org/releases/",
+                description: "The latest stable release of Debian.",
+              },
+            ],
+          },
+        })
+      );
+
+    const { ctx } = setup();
+    const reply = await ctx._crwSearch("Debian latest stable release");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://localhost:3000/v1/search");
+    expect(options.method).toBe("POST");
+    expect(options.headers).not.toHaveProperty("Authorization");
+    expect(options.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(options.body)).toEqual({
+      query: "Debian latest stable release",
+    });
+    expect(JSON.parse(reply)).toEqual([
+      {
+        title: "Debian releases",
+        link: "https://www.debian.org/releases/",
+        snippet: "The latest stable release of Debian.",
+      },
+    ]);
+  });
+
+  test("authenticated fastCRW sends a Bearer header and reads hosted response shape", async () => {
+    process.env.AGENT_CRW_API_KEY = "test-key";
+    delete process.env.AGENT_CRW_API_URL;
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        mockOkResponse({
+          success: true,
+          data: [
+            {
+              title: "Rust runtime",
+              url: "https://example.com/rust",
+              description: "Async runtime details.",
+            },
+          ],
+        })
+      );
+
+    const { ctx } = setup();
+    const reply = await ctx._crwSearch("rust async runtime");
+
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe("https://fastcrw.com/api/v1/search");
+    expect(options.headers).toHaveProperty(
+      "Authorization",
+      "Bearer test-key"
+    );
+    expect(JSON.parse(reply)[0]).toEqual({
+      title: "Rust runtime",
+      link: "https://example.com/rust",
+      snippet: "Async runtime details.",
+    });
+  });
+
+  test("normalizes both hosted (data array) and self-hosted (data.results) responses", async () => {
+    process.env.AGENT_CRW_API_KEY = "test-key";
+    delete process.env.AGENT_CRW_API_URL;
+
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        mockOkResponse({
+          success: true,
+          data: [
+            {
+              title: "Hosted result",
+              url: "https://example.com/a",
+              description: "desc a",
+            },
+          ],
+        })
+      );
+
+    let { ctx } = setup();
+    let reply = await ctx._crwSearch("hosted");
+    expect(JSON.parse(reply)[0]).toEqual({
+      title: "Hosted result",
+      link: "https://example.com/a",
+      snippet: "desc a",
+    });
+
+    process.env.AGENT_CRW_API_URL = "http://localhost:3000";
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        mockOkResponse({
+          success: true,
+          data: {
+            results: [
+              {
+                title: "Self-hosted result",
+                url: "https://example.com/b",
+                description: "desc b",
+              },
+            ],
+          },
+        })
+      );
+
+    ({ ctx } = setup());
+    reply = await ctx._crwSearch("self-hosted");
+    expect(JSON.parse(reply)[0]).toEqual({
+      title: "Self-hosted result",
+      link: "https://example.com/b",
+      snippet: "desc b",
+    });
+  });
+
+  test("returns a clean error message on an HTTP failure without leaking the API key", async () => {
+    process.env.AGENT_CRW_API_KEY = "super-secret-key-12345";
+    delete process.env.AGENT_CRW_API_URL;
+    jest.spyOn(global, "fetch").mockResolvedValue(mockErrorResponse(404, "Not Found"));
+
+    const { ctx, aibitat } = setup();
+    const reply = await ctx._crwSearch("missing route");
+
+    expect(reply).toContain("There was an error searching for content.");
+    expect(reply).toMatch(/404 - Not Found/);
+    expect(reply).not.toContain("super-secret-key-12345");
+    expect(
+      aibitat.handlerProps.log.mock.calls[0][0]
+    ).toContain("404 - Not Found");
+    expect(
+      aibitat.handlerProps.log.mock.calls[0][0]
+    ).not.toContain("super-secret-key-12345");
+  });
+
+  test.each([
+    ["http://localhost:3000", "http://localhost:3000/v1/search"],
+    ["http://localhost:3000/", "http://localhost:3000/v1/search"],
+    ["http://localhost:3000/api", "http://localhost:3000/api/v1/search"],
+    ["http://localhost:3000/custom/path", "http://localhost:3000/custom/path/v1/search"],
+  ])("builds the search endpoint for base URL %s", async (baseUrl, expected) => {
+    process.env.AGENT_CRW_API_URL = baseUrl;
+    jest.spyOn(global, "fetch").mockResolvedValue(mockOkResponse({ success: true, data: [] }));
+
+    const { ctx } = setup();
+    await ctx._crwSearch("some query");
+
+    expect(global.fetch.mock.calls[0][0]).toBe(expected);
+  });
+});

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1260,25 +1260,21 @@ const webBrowsing = {
           },
 
           _crwSearch: async function (query) {
-            if (!process.env.AGENT_CRW_API_KEY) {
-              this.super.introspect(
-                `${this.caller}: I can't use fastCRW searching because the user has not defined the required API key.\nVisit: https://fastcrw.com/ to create the API key.`
-              );
-              return `Search is disabled and no content was found. This functionality is disabled because the user has not set it up yet.`;
-            }
-
             this.super.introspect(
               `${this.caller}: Using fastCRW to search for "${
                 query.length > 100 ? `${query.slice(0, 100)}...` : query
               }"`
             );
 
-            let baseUrl = "https://fastcrw.com/api";
-            if ("AGENT_CRW_API_URL" in process.env) {
+            const apiKey = process.env.AGENT_CRW_API_KEY || "";
+            let searchUrl = "https://fastcrw.com/api/v1/search";
+            const configuredUrl = process.env.AGENT_CRW_API_URL;
+            if (configuredUrl) {
               try {
-                baseUrl = new URL(process.env.AGENT_CRW_API_URL);
-                baseUrl.pathname = ""; // remove the trailing slash or any other path
-                baseUrl = baseUrl.toString();
+                const parsed = new URL(configuredUrl);
+                const path = parsed.pathname.replace(/\/+$/, "");
+                parsed.pathname = `${path}/v1/search`;
+                searchUrl = parsed.toString();
               } catch (e) {
                 this.super.handlerProps.log(
                   `invalid fastCRW Search URL: ${e.message}`
@@ -1286,18 +1282,24 @@ const webBrowsing = {
               }
             }
 
-            const { response, error } = await fetch(`${baseUrl}/v1/search`, {
+            const headers = { "Content-Type": "application/json" };
+            // Hosted fastCRW requires a Bearer token; self-hosted deployments
+            // accept requests without authentication. Only send the header when
+            // an API key is actually configured.
+            if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+            const { response, error } = await fetch(searchUrl, {
               method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${process.env.AGENT_CRW_API_KEY}`,
-              },
+              headers,
               body: JSON.stringify({ query }),
             })
               .then((res) => {
                 if (res.ok) return res.json();
                 throw new Error(
-                  `${res.status} - ${res.statusText}. params: ${JSON.stringify({ auth: this.middleTruncate(process.env.AGENT_CRW_API_KEY, 5), q: query })}`
+                  `${res.status} - ${res.statusText}. params: ${JSON.stringify({
+                    auth: apiKey ? this.middleTruncate(apiKey, 5) : "none",
+                    q: query,
+                  })}`
                 );
               })
               .then((data) => {
@@ -1317,8 +1319,14 @@ const webBrowsing = {
             if (error)
               return `There was an error searching for content. ${error}`;
 
+            // Hosted fastCRW returns the results array directly under `data`; a
+            // self-hosted engine nests them as `data.results`. Handle both.
+            const searchResults = Array.isArray(response.data)
+              ? response.data
+              : response.data?.results ?? [];
+
             const data = [];
-            response.data?.forEach((searchResult) => {
+            searchResults.forEach((searchResult) => {
               const { title, url, description } = searchResult;
               data.push({
                 title,


### PR DESCRIPTION

### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

resolves #6278

### Description

Fixes FastCRW web search for self-hosted deployments.

The search request could generate an incorrect URL with a double slash, resulting in a `404 - Not Found` error. Self-hosted instances were also blocked by the mandatory API key requirement and used a different response structure.

This change:

- Fixes FastCRW search URL construction.
- Supports self-hosted instances without an API key.
- Sends the authorization header only when an API key is configured.
- Supports both hosted and self-hosted response formats.
- Makes the FastCRW API key optional in the UI for self-hosted configurations.

Existing hosted FastCRW configurations remain supported.

### Developer Validations

- [x] I have tested my code functionality
- [ ] Docker build succeeds locally bhia ye raha mera msg pr me ye wala msg add kar tune jo msg diya he usko skip kar de
