### PR TITLE
fix: make fastCRW web search work against self-hosted instances

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -471,7 +471,7 @@ GID='1000'
 # AGENT_PERPLEXITY_API_KEY=
 
 #------ fastCRW Search ----------- https://fastcrw.com/
-# AGENT_CRW_API_KEY=
+# AGENT_CRW_API_KEY= # Required for the managed endpoint. Optional for a self-hosted instance, which runs without auth by default.
 # AGENT_CRW_API_URL= # Optional. Defaults to https://fastcrw.com/api. Set for self-hosted fastCRW.
 
 #------ You.com Search ----------- https://you.com/docs

--- a/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderOptions/index.jsx
+++ b/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderOptions/index.jsx
@@ -389,7 +389,7 @@ export function CrwSearchOptions({ settings }) {
           className="text-blue-300 underline"
         >
           from fastCRW.
-        </a>
+        </a>{" "}
         You can also{" "}
         <a
           href="https://github.com/us/crw"
@@ -398,12 +398,14 @@ export function CrwSearchOptions({ settings }) {
           className="text-blue-300 underline"
         >
           self-host.
-        </a>
+        </a>{" "}
+        A self-hosted instance only needs the base URL below, and an API key
+        only if you configured one.
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
-            API Key
+            API Key (optional)
           </label>
           <input
             type="password"
@@ -411,14 +413,13 @@ export function CrwSearchOptions({ settings }) {
             className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="fastCRW API Key"
             defaultValue={settings?.AgentCrwApiKey ? "*".repeat(20) : ""}
-            required={true}
             autoComplete="off"
             spellCheck={false}
           />
         </div>
         <div className="flex flex-col w-60">
           <label className="text-white text-sm font-semibold block mb-3">
-            Base URL (optional)
+            Base URL (self-hosted)
           </label>
           <input
             type="url"

--- a/server/.env.example
+++ b/server/.env.example
@@ -477,7 +477,7 @@ STT_PROVIDER="native"
 # AGENT_PERPLEXITY_API_KEY=
 
 #------ fastCRW Search ----------- https://fastcrw.com/
-# AGENT_CRW_API_KEY=
+# AGENT_CRW_API_KEY= # Required for the managed endpoint. Optional for a self-hosted instance, which runs without auth by default.
 # AGENT_CRW_API_URL= # Optional. Defaults to https://fastcrw.com/api. Set for self-hosted fastCRW.
 
 #------ You.com Search ----------- https://you.com/docs

--- a/server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js
+++ b/server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js
@@ -1,0 +1,217 @@
+/* eslint-env jest */
+jest.mock("../../../../../models/systemSettings", () => ({
+  SystemSettings: { get: jest.fn() },
+}));
+jest.mock("../../../../../utils/helpers/tiktoken", () => ({
+  TokenManager: jest.fn().mockImplementation(() => ({
+    countFromString: () => "0",
+  })),
+}));
+jest.mock("../../../../../endpoints/utils", () => ({
+  getAnythingLLMUserAgent: () => "anything-llm",
+}));
+
+const {
+  webBrowsing,
+} = require("../../../../../utils/agents/aibitat/plugins/web-browsing.js");
+
+function setupPlugin() {
+  const aibitat = {
+    introspect: jest.fn(),
+    handlerProps: { log: jest.fn() },
+    function: (config) => (aibitat._fn = config),
+  };
+  webBrowsing.plugin.call(webBrowsing).setup(aibitat);
+  const config = aibitat._fn;
+  config.super = aibitat;
+  config.caller = "@agent";
+  config.reportSearchResultsCitations = jest.fn();
+  return config;
+}
+
+function mockFetch(body, { ok = true, status = 200 } = {}) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    statusText: ok ? "OK" : "Not Found",
+    json: async () => body,
+  });
+  return global.fetch;
+}
+
+const MANAGED_BODY = {
+  success: true,
+  data: [
+    {
+      url: "https://example.com/managed",
+      title: "Managed result",
+      description: "managed snippet",
+    },
+  ],
+};
+
+// A self-hosted instance nests its results one level deeper than the managed API.
+const SELF_HOSTED_BODY = {
+  success: true,
+  data: {
+    results: [
+      {
+        url: "https://example.com/self-hosted",
+        title: "Self-hosted result",
+        description: "self-hosted snippet",
+      },
+    ],
+  },
+};
+
+describe("web-browsing fastCRW search", () => {
+  let provider;
+
+  beforeEach(() => {
+    provider = setupPlugin();
+    delete process.env.AGENT_CRW_API_KEY;
+    delete process.env.AGENT_CRW_API_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.AGENT_CRW_API_KEY;
+    delete process.env.AGENT_CRW_API_URL;
+    delete global.fetch;
+  });
+
+  it("calls /v1/search on a self-hosted instance without a double slash", async () => {
+    process.env.AGENT_CRW_API_URL = "http://127.0.0.1:3000";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:3000/v1/search");
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: "Self-hosted result",
+        link: "https://example.com/self-hosted",
+        snippet: "self-hosted snippet",
+      },
+    ]);
+  });
+
+  it("tolerates trailing slashes on the base URL", async () => {
+    process.env.AGENT_CRW_API_URL = "http://127.0.0.1:3000/";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:3000/v1/search");
+  });
+
+  it("keeps a sub-path so an instance behind a reverse proxy stays reachable", async () => {
+    process.env.AGENT_CRW_API_URL = "https://example.com/crw";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://example.com/crw/v1/search"
+    );
+  });
+
+  it("omits the Authorization header when no API key is set", async () => {
+    process.env.AGENT_CRW_API_URL = "http://127.0.0.1:3000";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
+  it("still parses the managed response and sends the API key", async () => {
+    process.env.AGENT_CRW_API_KEY = "crw_live_example";
+    const fetchMock = mockFetch(MANAGED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://fastcrw.com/api/v1/search"
+    );
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe(
+      "Bearer crw_live_example"
+    );
+    expect(JSON.parse(result)).toEqual([
+      {
+        title: "Managed result",
+        link: "https://example.com/managed",
+        snippet: "managed snippet",
+      },
+    ]);
+  });
+
+  it("appends to the path and leaves a query string in place", async () => {
+    process.env.AGENT_CRW_API_URL = "http://127.0.0.1:3000/crw?token=abc";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:3000/crw/v1/search?token=abc"
+    );
+  });
+
+  it("requires an API key for the managed host whatever case it is typed in", async () => {
+    process.env.AGENT_CRW_API_URL = "https://FastCRW.com/api/";
+    const fetchMock = mockFetch(MANAGED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toMatch(/Search is disabled/);
+  });
+
+  it("stays disabled when neither an API key nor a base URL is set", async () => {
+    const fetchMock = mockFetch(MANAGED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toMatch(/Search is disabled/);
+  });
+
+  it("trims whitespace around the base URL", async () => {
+    process.env.AGENT_CRW_API_URL = "  http://127.0.0.1:3000  ";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    await provider._crwSearch("debian stable release");
+
+    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1:3000/v1/search");
+  });
+
+  it("still requires an API key when the base URL is the managed endpoint", async () => {
+    process.env.AGENT_CRW_API_URL = "https://fastcrw.com/api";
+    const fetchMock = mockFetch(MANAGED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toMatch(/Search is disabled/);
+  });
+
+  it("rejects a base URL that has no http or https scheme", async () => {
+    process.env.AGENT_CRW_API_URL = "localhost:3000";
+    const fetchMock = mockFetch(SELF_HOSTED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toMatch(/Search is disabled/);
+  });
+
+  it("does not fall back to the managed endpoint when the base URL is invalid", async () => {
+    process.env.AGENT_CRW_API_URL = "not a url";
+    process.env.AGENT_CRW_API_KEY = "crw_live_example";
+    const fetchMock = mockFetch(MANAGED_BODY);
+
+    const result = await provider._crwSearch("debian stable release");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toMatch(/Search is disabled/);
+  });
+});

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -1259,10 +1259,47 @@ const webBrowsing = {
             return result;
           },
 
+          /**
+           * fastCRW Search. Uses the managed endpoint by default, or any
+           * self-hosted instance when a base URL is set. A self-hosted instance
+           * runs without auth unless the operator configures API keys, so the
+           * API key is optional whenever a base URL is set.
+           * @param {string} query
+           * @returns {Promise<string>}
+           */
           _crwSearch: async function (query) {
-            if (!process.env.AGENT_CRW_API_KEY) {
+            const MANAGED_BASE_URL = "https://fastcrw.com/api";
+            const apiKey = process.env.AGENT_CRW_API_KEY || null;
+            const customBaseUrl = process.env.AGENT_CRW_API_URL?.trim() || null;
+
+            let searchURL;
+            try {
+              searchURL = new URL(customBaseUrl || MANAGED_BASE_URL);
+              if (
+                searchURL.protocol !== "http:" &&
+                searchURL.protocol !== "https:"
+              )
+                throw new Error(`unsupported protocol ${searchURL.protocol}`);
+              // Append to the configured path so an instance served under a
+              // sub-path stays reachable, and normalize the trailing slash so
+              // the join cannot emit "//v1/search", which fastCRW does not route.
+              searchURL.pathname = `${searchURL.pathname.replace(/\/+$/, "")}/v1/search`;
+            } catch (e) {
+              this.super.handlerProps.log(
+                `invalid fastCRW Search URL: ${e.message}`
+              );
               this.super.introspect(
-                `${this.caller}: I can't use fastCRW searching because the user has not defined the required API key.\nVisit: https://fastcrw.com/ to create the API key.`
+                `${this.caller}: I can't use fastCRW searching because the base URL provided is not a valid URL.`
+              );
+              return `Search is disabled and no content was found. This functionality is disabled because the user has not set it up yet.`;
+            }
+
+            // The managed endpoint always needs a key. A self-hosted instance
+            // runs without auth unless its operator configured API keys, so the
+            // key stays optional there.
+            if (!apiKey && searchURL.host === new URL(MANAGED_BASE_URL).host) {
+              this.super.introspect(
+                `${this.caller}: I can't use fastCRW searching because the user has not defined the required API key.\nVisit: https://fastcrw.com/ to create the API key, or set a base URL to use a self-hosted instance.`
               );
               return `Search is disabled and no content was found. This functionality is disabled because the user has not set it up yet.`;
             }
@@ -1273,31 +1310,18 @@ const webBrowsing = {
               }"`
             );
 
-            let baseUrl = "https://fastcrw.com/api";
-            if ("AGENT_CRW_API_URL" in process.env) {
-              try {
-                baseUrl = new URL(process.env.AGENT_CRW_API_URL);
-                baseUrl.pathname = ""; // remove the trailing slash or any other path
-                baseUrl = baseUrl.toString();
-              } catch (e) {
-                this.super.handlerProps.log(
-                  `invalid fastCRW Search URL: ${e.message}`
-                );
-              }
-            }
-
-            const { response, error } = await fetch(`${baseUrl}/v1/search`, {
+            const { response, error } = await fetch(searchURL.toString(), {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${process.env.AGENT_CRW_API_KEY}`,
+                ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
               },
               body: JSON.stringify({ query }),
             })
               .then((res) => {
                 if (res.ok) return res.json();
                 throw new Error(
-                  `${res.status} - ${res.statusText}. params: ${JSON.stringify({ auth: this.middleTruncate(process.env.AGENT_CRW_API_KEY, 5), q: query })}`
+                  `${res.status} - ${res.statusText}. params: ${JSON.stringify({ auth: apiKey ? this.middleTruncate(apiKey, 5) : "none", q: query })}`
                 );
               })
               .then((data) => {
@@ -1317,8 +1341,21 @@ const webBrowsing = {
             if (error)
               return `There was an error searching for content. ${error}`;
 
+            // The managed API returns `data` as a flat array of results, while a
+            // self-hosted instance nests them under `data.results`. That is an
+            // array for the query-only request sent above, and an object
+            // grouping results by source when `sources` is requested.
+            const payload = response?.data?.results ?? response?.data;
+            const searchResults = Array.isArray(payload)
+              ? payload
+              : [
+                  ...(payload?.web ?? []),
+                  ...(payload?.news ?? []),
+                  ...(payload?.images ?? []),
+                ];
+
             const data = [];
-            response.data?.forEach((searchResult) => {
+            searchResults.forEach((searchResult) => {
               const { title, url, description } = searchResult;
               data.push({
                 title,


### PR DESCRIPTION
### Pull Request Type

- [x] 🐛 fix (Bug fix)

### Relevant Issues

connect #6278

### Description

The fastCRW web search provider fails against every self-hosted fastCRW
instance. `_crwSearch` has three separate faults, chained, so fixing one only
surfaces the next.

**1. The request URL always gains a double slash when a base URL is set.**

```js
baseUrl = new URL(process.env.AGENT_CRW_API_URL);
baseUrl.pathname = "";          // WHATWG normalizes "" back to "/"
baseUrl = baseUrl.toString();   // "http://127.0.0.1:3000/"
fetch(`${baseUrl}/v1/search`)   // "http://127.0.0.1:3000//v1/search"
```

fastCRW registers the exact route `/v1/search`, so the leading empty segment is
a 404. This happens for every possible value of `AGENT_CRW_API_URL`, so the only
configuration that has ever worked is leaving it unset and using the managed
endpoint. `pathname = ""` also erased any sub-path, so an instance behind a
reverse proxy on `https://host/crw` could not be reached at all.

The URL is now built by appending to the parsed `URL`'s pathname, which keeps a
sub-path, keeps a query string, and cannot emit a double slash. Whitespace is
trimmed, and a value that is not an `http`/`https` URL now returns the same
"search is disabled" message the other providers give instead of proceeding to
a broken `fetch`.

**2. The response envelope differs between managed and self-hosted.**

The managed API returns `data` as a flat array. A self-hosted instance nests the
results one level deeper, under `data.results`. `response.data?.forEach(...)`
therefore threw `TypeError: response.data?.forEach is not a function` against a
self-hosted instance, which surfaced to the user as the tool handler's generic
"error while calling the function" message. Both shapes are now accepted.

**3. The API key was mandatory although a self-hosted instance has none.**

A self-hosted fastCRW runs without auth unless its operator configures API keys,
so there is no key to supply. The provider refused to run without one, and the
settings field was `required`, which is why the reporter had to invent a dummy
key. The key is now required only when the request targets the managed host, and
the `Authorization` header is omitted entirely when no key is set, matching
`_searXNGEngine` and `_youSearch`.

Behavior change worth calling out: previously, a malformed `AGENT_CRW_API_URL`
was logged and then silently ignored, leaving the managed endpoint in place, so
a self-hoster's query and API key went to the hosted service instead of the host
they configured. It now returns the "disabled" message instead.

No currently working configuration changes. The only setup that works on `main`
is an unset `AGENT_CRW_API_URL` plus a key, which still resolves to
`https://fastcrw.com/api/v1/search`, still sends `Authorization: Bearer <key>`,
and still parses the flat array.

### Visuals (if applicable)

Reproduced with the reporter's stack (`ghcr.io/us/crw:latest` plus
`searxng/searxng:latest`), running the plugin's own `_crwSearch` against it.

Before, matching the reported log line exactly:

```
REQUEST URL -> http://127.0.0.1:3999//v1/search
fastCRW Search Error: 404 - Not Found. params: {"auth":"local","q":"site:debian.org Debian latest stable release"}
```

After, same config, same engine:

```
@agent: I found 5 results - reviewing the results now. (~323 tokens)
  1. Debian Releases -> https://www.debian.org/releases/
  2. DebianReleases - Debian Wiki -> https://wiki.debian.org/DebianReleases
  3. Download Debian -> https://www.debian.org/distrib/
```

### Additional Information

`server/__tests__/utils/agents/aibitat/plugins/web-browsing.test.js` covers the
double-slash join, trailing slashes, whitespace, a reverse-proxy sub-path, a
query string, both response envelopes, the omitted `Authorization` header, the
managed host still requiring a key regardless of letter case, and an invalid
base URL not falling through to the managed endpoint.

### Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
