### PR TITLE
feat: make Serper base URL configurable via AGENT_SERPER_DEV_BASE_URL

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -448,6 +448,7 @@ GID='1000'
 
 #------ Serper.dev ----------- https://serper.dev/
 # AGENT_SERPER_DEV_KEY=
+# AGENT_SERPER_DEV_BASE_URL= # optional, defaults to https://google.serper.dev
 
 #------ Bing Search ----------- https://portal.azure.com/
 # AGENT_BING_SEARCH_API_KEY=

--- a/server/.env.example
+++ b/server/.env.example
@@ -454,6 +454,7 @@ STT_PROVIDER="native"
 
 #------ Serper.dev ----------- https://serper.dev/
 # AGENT_SERPER_DEV_KEY=
+# AGENT_SERPER_DEV_BASE_URL= # optional, defaults to https://google.serper.dev
 
 #------ Bing Search ----------- https://portal.azure.com/
 # AGENT_BING_SEARCH_API_KEY=

--- a/server/utils/agents/aibitat/plugins/web-browsing.js
+++ b/server/utils/agents/aibitat/plugins/web-browsing.js
@@ -511,8 +511,11 @@ const webBrowsing = {
                 query.length > 100 ? `${query.slice(0, 100)}...` : query
               }"`
             );
+            const serperBaseUrl = (
+              process.env.AGENT_SERPER_DEV_BASE_URL || "https://google.serper.dev"
+            ).replace(/\/+$/, "");
             const { response, error } = await fetch(
-              "https://google.serper.dev/search",
+              `${serperBaseUrl}/search`,
               {
                 method: "POST",
                 headers: {

--- a/server/utils/helpers/updateENV.js
+++ b/server/utils/helpers/updateENV.js
@@ -606,6 +606,10 @@ const KEY_MAPPING = {
     envKey: "AGENT_SERPER_DEV_KEY",
     checks: [],
   },
+  AgentSerperApiUrl: {
+    envKey: "AGENT_SERPER_DEV_BASE_URL",
+    checks: [],
+  },
   AgentBingSearchApiKey: {
     envKey: "AGENT_BING_SEARCH_API_KEY",
     checks: [],


### PR DESCRIPTION
The Serper endpoint is hardcoded in the web-browsing agent plugin:

```js
const { response, error } = await fetch(
  "https://google.serper.dev/search",
```

Anyone who needs that request to go elsewhere has to patch the file and carry the patch across upgrades. It comes up in a few ordinary situations: an egress proxy on a locked-down network, a regional endpoint for latency or data residency, and pointing the agent at a local mock during development so tests do not make live calls.

### Approach

This follows the convention already in the codebase. `updateENV.js` registers `AgentSearXNGApiUrl → AGENT_SEARXNG_API_URL`, a provider URL sitting next to its key — so Serper gets the same treatment:

```js
AgentSerperApiKey: {
  envKey: "AGENT_SERPER_DEV_KEY",
  checks: [],
},
AgentSerperApiUrl: {
  envKey: "AGENT_SERPER_DEV_BASE_URL",
  checks: [],
},
```

and the plugin reads it with the current URL as the default:

```js
const serperBaseUrl = (
  process.env.AGENT_SERPER_DEV_BASE_URL || "https://google.serper.dev"
).replace(/\/+$/, "");
```

### Files

- `server/utils/agents/aibitat/plugins/web-browsing.js` — use the variable
- `server/utils/helpers/updateENV.js` — register it
- `server/.env.example`, `docker/.env.example` — document it next to the key

Ten added lines, no new dependency. Trailing slashes are stripped so `https://host`, `https://host/` and `https://host///` all behave the same, and an unset or empty value resolves to the current endpoint — behaviour is unchanged unless the variable is set.

Happy to add a field to the Web Search admin screen in a follow-up if you would like it configurable from the UI rather than only through the environment.