### PR TITLE
feat: add optional sentence-based document splitting

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -1154,6 +1154,13 @@ const TRANSLATIONS = {
     },
   },
   text: {
+    strategy: {
+      title: "Splitting strategy",
+      description:
+        "Sentence splitting keeps complete sentences together when they fit. Longer sentences use recursive splitting. Overlap includes only complete sentences that fit within the overlap limit. Applies to newly embedded documents; re-embed existing documents to use the new strategy.",
+      recursive: "Recursive (default)",
+      sentence: "Sentence",
+    },
     title: "Text splitting & Chunking Preferences",
     "desc-start":
       "Sometimes, you may want to change the default way that new documents are split and chunked before being inserted into your vector database.",

--- a/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
@@ -49,6 +49,7 @@ export default function EmbeddingTextSplitterPreference() {
         document.getElementById("text-splitter-chunking-form")
       );
       await Admin.updateSystemPreferences({
+        text_splitter_strategy: form.get("text_splitter_strategy"),
         text_splitter_chunk_size: isNullOrNaN(
           form.get("text_splitter_chunk_size")
         )
@@ -76,6 +77,7 @@ export default function EmbeddingTextSplitterPreference() {
         await Admin.systemPreferencesByFields([
           "text_splitter_chunk_size",
           "text_splitter_chunk_overlap",
+          "text_splitter_strategy",
           "max_embed_chunk_size",
         ])
       )?.settings;
@@ -129,6 +131,32 @@ export default function EmbeddingTextSplitterPreference() {
               </div>
 
               <div className="flex flex-col gap-y-4 mt-8">
+                <div className="flex flex-col max-w-[300px] gap-y-2">
+                  <label
+                    htmlFor="text-splitter-strategy"
+                    className="text-white text-sm font-semibold"
+                  >
+                    {t("text.strategy.title")}
+                  </label>
+                  <p className="text-xs text-white/60">
+                    {t("text.strategy.description")}
+                  </p>
+                  <select
+                    id="text-splitter-strategy"
+                    name="text_splitter_strategy"
+                    defaultValue={
+                      settings?.text_splitter_strategy || "recursive"
+                    }
+                    className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg block w-full p-2.5"
+                  >
+                    <option value="recursive">
+                      {t("text.strategy.recursive")}
+                    </option>
+                    <option value="sentence">
+                      {t("text.strategy.sentence")}
+                    </option>
+                  </select>
+                </div>
                 <div className="flex flex-col max-w-[300px]">
                   <div className="flex flex-col gap-y-2 mb-4">
                     <label className="text-white text-sm font-semibold block">

--- a/server/__tests__/utils/TextSplitter/sentence.test.js
+++ b/server/__tests__/utils/TextSplitter/sentence.test.js
@@ -1,0 +1,103 @@
+const { TextSplitter } = require("../../../utils/TextSplitter");
+
+describe("Sentence text splitting", () => {
+  const split = (text, config = {}) =>
+    new TextSplitter({
+      strategy: "sentence",
+      chunkSize: 30,
+      chunkOverlap: 0,
+      ...config,
+    }).splitText(text);
+
+  it("keeps sentences together instead of filling chunks with partial sentences", async () => {
+    expect(
+      await split("First sentence. Second sentence. Third sentence.")
+    ).toEqual(["First sentence.", "Second sentence.", "Third sentence."]);
+  });
+
+  it("groups consecutive sentences that fit", async () => {
+    expect(await split("One. Two. Three.")).toEqual(["One. Two. Three."]);
+  });
+
+  it("uses whole sentences for overlap without exceeding either limit", async () => {
+    const chunks = await split("One. Two. Three. Four.", {
+      chunkSize: 16,
+      chunkOverlap: 7,
+    });
+    expect(chunks).toEqual(["One. Two. Three.", "Three. Four."]);
+    expect(chunks.every((chunk) => chunk.length <= 16)).toBe(true);
+  });
+
+  it("does not overlap a sentence longer than the configured overlap", async () => {
+    expect(
+      await split("First sentence. Second sentence.", { chunkOverlap: 5 })
+    ).toEqual(["First sentence.", "Second sentence."]);
+  });
+
+  it("falls back for oversized sentences and retains following text", async () => {
+    const text =
+      "A sentence much longer than the configured chunk limit. Done.";
+    const chunks = await split(text, { chunkSize: 20 });
+    expect(chunks.every((chunk) => chunk.length <= 20)).toBe(true);
+    expect(chunks.join(" ")).toBe(text);
+  });
+
+  it("splits long unbroken text within the chunk limit", async () => {
+    const text = "x".repeat(95);
+    const chunks = await split(text, { chunkSize: 20 });
+    expect(chunks.map((chunk) => chunk.length)).toEqual([20, 20, 20, 20, 15]);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("handles Unicode sentence boundaries", async () => {
+    expect(await split("你好世界。再见世界。", { chunkSize: 6 })).toEqual([
+      "你好世界。",
+      "再见世界。",
+    ]);
+  });
+
+  it.each(["", " \n\t "])("does not embed empty content: %j", async (text) => {
+    expect(await split(text)).toEqual([]);
+  });
+
+  it("applies metadata and the embedding prefix once to every chunk", async () => {
+    const splitter = new TextSplitter({
+      strategy: "sentence",
+      chunkSize: 20,
+      chunkOverlap: 0,
+      chunkPrefix: "search_document: ",
+      chunkHeaderMeta: { sourceDocument: "Guide" },
+    });
+    const header = splitter.stringifyHeader();
+    expect(
+      await splitter.splitText("First sentence. Second sentence.")
+    ).toEqual([`${header}First sentence.`, `${header}Second sentence.`]);
+  });
+
+  it.each([
+    { chunkSize: 0 },
+    { chunkSize: 2.5 },
+    { chunkOverlap: -1 },
+    { chunkOverlap: 31 },
+  ])("rejects invalid sentence settings: %j", (config) => {
+    expect(
+      () =>
+        new TextSplitter({
+          strategy: "sentence",
+          chunkSize: 30,
+          chunkOverlap: 0,
+          ...config,
+        })
+    ).toThrow();
+  });
+
+  it("preserves the existing default strategy", async () => {
+    const text = "First sentence. Second sentence. Third sentence.";
+    const config = { chunkSize: 25, chunkOverlap: 5 };
+    const defaults = new TextSplitter(config);
+    const explicit = new TextSplitter({ ...config, strategy: "recursive" });
+    expect(await defaults.splitText(text)).toEqual(
+      await explicit.splitText(text)
+    );
+  });
+});

--- a/server/__tests__/utils/TextSplitter/settings.test.js
+++ b/server/__tests__/utils/TextSplitter/settings.test.js
@@ -1,0 +1,60 @@
+jest.mock("../../../utils/prisma", () => ({
+  system_settings: { upsert: jest.fn() },
+}));
+jest.mock("../../../utils/http", () => ({
+  isValidUrl: jest.fn(),
+  safeJsonParse: jest.fn(),
+}));
+jest.mock("../../../utils/boot/MetaGenerator", () => ({ MetaGenerator: {} }));
+jest.mock("../../../utils/vectorDbProviders/pgvector", () => ({
+  PGVector: {},
+}));
+jest.mock("../../../utils/EmbeddingEngines/native", () => ({
+  NativeEmbedder: {},
+}));
+jest.mock("../../../utils/helpers", () => ({
+  getBaseLLMProviderModel: jest.fn(),
+}));
+jest.mock(
+  "../../../utils/agents/aibitat/plugins/sql-agent/SQLConnectors/utils",
+  () => ({ ConnectionStringParser: {} })
+);
+jest.mock("../../../utils/files", () => ({
+  purgeEntireVectorCache: jest.fn(),
+}));
+
+const { SystemSettings } = require("../../../models/systemSettings");
+const prisma = require("../../../utils/prisma");
+const { purgeEntireVectorCache } = require("../../../utils/files");
+
+beforeEach(() => jest.clearAllMocks());
+
+it.each(["recursive", "sentence"])(
+  "persists %s and invalidates cached embeddings",
+  async (strategy) => {
+    expect(SystemSettings.publicFields).toContain("text_splitter_strategy");
+    expect(SystemSettings.supportedFields).toContain("text_splitter_strategy");
+    const result = await SystemSettings._updateSettings({
+      text_splitter_strategy: strategy,
+    });
+    expect(result).toEqual({ success: true, error: null });
+    expect(purgeEntireVectorCache).toHaveBeenCalledTimes(1);
+    expect(prisma.system_settings.upsert).toHaveBeenCalledWith({
+      where: { label: "text_splitter_strategy" },
+      update: { value: strategy },
+      create: { label: "text_splitter_strategy", value: strategy },
+    });
+  }
+);
+
+it("rejects an unknown strategy without purging or storing it", async () => {
+  const result = await SystemSettings._updateSettings({
+    text_splitter_strategy: "unknown",
+  });
+  expect(result).toEqual({
+    success: false,
+    error: "Text splitting strategy must be recursive or sentence.",
+  });
+  expect(purgeEntireVectorCache).not.toHaveBeenCalled();
+  expect(prisma.system_settings.upsert).not.toHaveBeenCalled();
+});

--- a/server/endpoints/admin.js
+++ b/server/endpoints/admin.js
@@ -393,6 +393,9 @@ function adminEndpoints(app) {
             case "text_splitter_chunk_overlap":
               requestedSettings[label] = setting?.value || null;
               break;
+            case "text_splitter_strategy":
+              requestedSettings[label] = setting?.value || "recursive";
+              break;
             case "max_embed_chunk_size":
               requestedSettings[label] =
                 embedder?.embeddingMaxChunkLength || 1000;

--- a/server/models/systemSettings.js
+++ b/server/models/systemSettings.js
@@ -43,6 +43,7 @@ const SystemSettings = {
     "support_email",
     "text_splitter_chunk_size",
     "text_splitter_chunk_overlap",
+    "text_splitter_strategy",
     "max_embed_chunk_size",
     "agent_search_provider",
     "agent_sql_connections",
@@ -74,6 +75,7 @@ const SystemSettings = {
 
     "text_splitter_chunk_size",
     "text_splitter_chunk_overlap",
+    "text_splitter_strategy",
     "agent_search_provider",
     "default_agent_skills",
     "disabled_agent_skills",
@@ -116,6 +118,15 @@ const SystemSettings = {
         console.error(`Failed to run validation function on footer_data`);
         return JSON.stringify([]);
       }
+    },
+    text_splitter_strategy: (update) => {
+      if (!["recursive", "sentence"].includes(update))
+        throw new Error(
+          "Text splitting strategy must be recursive or sentence."
+        );
+      const { purgeEntireVectorCache } = require("../utils/files");
+      purgeEntireVectorCache();
+      return update;
     },
     text_splitter_chunk_size: (update) => {
       try {

--- a/server/utils/TextSplitter/index.js
+++ b/server/utils/TextSplitter/index.js
@@ -27,6 +27,7 @@ class TextSplitter {
    * @param {string} [config.chunkPrefix = ""] - Prefix to be added to the start of each chunk.
    * @param {number} [config.chunkSize = 1000] - The size of each chunk.
    * @param {number} [config.chunkOverlap = 20] - The overlap between chunks.
+   * @param {"recursive"|"sentence"} [config.strategy = "recursive"] - How chunk boundaries are chosen.
    * @param {Object} [config.chunkHeaderMeta = null] - Metadata to be added to the start of each chunk - will come after the prefix.
    */
   constructor(config = {}) {
@@ -155,7 +156,9 @@ class TextSplitter {
    */
   #setSplitter(config = {}) {
     // if (!config?.splitByFilename) {// TODO do something when specific extension is present? }
-    return new RecursiveSplitter({
+    const Splitter =
+      config.strategy === "sentence" ? SentenceSplitter : RecursiveSplitter;
+    return new Splitter({
       chunkSize: isNaN(config?.chunkSize) ? 1_000 : Number(config?.chunkSize),
       chunkOverlap: isNaN(config?.chunkOverlap)
         ? 20
@@ -200,6 +203,57 @@ class RecursiveSplitter {
     return documents
       .filter((doc) => !!doc.pageContent)
       .map((doc) => doc.pageContent);
+  }
+}
+
+// Keep complete sentences together, with the recursive splitter handling oversized sentences.
+class SentenceSplitter {
+  constructor({ chunkSize, chunkOverlap, chunkHeader }) {
+    if (!Number.isInteger(chunkSize) || chunkSize <= 0)
+      throw new Error("Sentence chunk size must be a positive integer.");
+    if (
+      !Number.isInteger(chunkOverlap) ||
+      chunkOverlap < 0 ||
+      chunkOverlap > chunkSize
+    )
+      throw new Error(
+        "Sentence chunk overlap must be between zero and chunk size."
+      );
+    this.chunkSize = chunkSize;
+    this.chunkOverlap = chunkOverlap;
+    this.chunkHeader = chunkHeader || "";
+    this.segmenter = new Intl.Segmenter(undefined, { granularity: "sentence" });
+    this.fallback = new RecursiveSplitter({ chunkSize, chunkOverlap });
+  }
+
+  async _splitText(documentText) {
+    const chunks = [];
+    let sentences = [];
+    let length = 0;
+    for (const { segment } of this.segmenter.segment(documentText)) {
+      if (segment.trim().length === 0) continue;
+      if (segment.trim().length > this.chunkSize) {
+        if (sentences.length) chunks.push(sentences.join("").trim());
+        chunks.push(...(await this.fallback._splitText(segment)));
+        sentences = [];
+        length = 0;
+        continue;
+      }
+      const nextLength = segment.trimEnd().length;
+      if (sentences.length && length + nextLength > this.chunkSize) {
+        chunks.push(sentences.join("").trim());
+        while (
+          sentences.length &&
+          (length > this.chunkOverlap || length + nextLength > this.chunkSize)
+        ) {
+          length -= sentences.shift().length;
+        }
+      }
+      sentences.push(segment);
+      length += segment.length;
+    }
+    if (sentences.length) chunks.push(sentences.join("").trim());
+    return chunks.filter(Boolean).map((chunk) => `${this.chunkHeader}${chunk}`);
   }
 }
 

--- a/server/utils/vectorDbProviders/astra/index.js
+++ b/server/utils/vectorDbProviders/astra/index.js
@@ -207,6 +207,10 @@ class AstraDB extends VectorDatabase {
 
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: Math.min(
           7500,
           TextSplitter.determineMaxChunkSize(

--- a/server/utils/vectorDbProviders/chroma/index.js
+++ b/server/utils/vectorDbProviders/chroma/index.js
@@ -265,6 +265,10 @@ class Chroma extends VectorDatabase {
       // from vectordb.
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",

--- a/server/utils/vectorDbProviders/lance/index.js
+++ b/server/utils/vectorDbProviders/lance/index.js
@@ -350,6 +350,10 @@ class LanceDb extends VectorDatabase {
       // from vectordb.
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",

--- a/server/utils/vectorDbProviders/milvus/index.js
+++ b/server/utils/vectorDbProviders/milvus/index.js
@@ -212,6 +212,10 @@ class Milvus extends VectorDatabase {
 
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",

--- a/server/utils/vectorDbProviders/pgvector/index.js
+++ b/server/utils/vectorDbProviders/pgvector/index.js
@@ -596,6 +596,10 @@ class PGVector extends VectorDatabase {
       const { SystemSettings } = require("../../../models/systemSettings");
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",

--- a/server/utils/vectorDbProviders/pinecone/index.js
+++ b/server/utils/vectorDbProviders/pinecone/index.js
@@ -155,6 +155,10 @@ class PineconeDB extends VectorDatabase {
       // https://github.com/hwchase17/langchainjs/blob/2def486af734c0ca87285a48f1a04c057ab74bdf/langchain/src/vectorstores/pinecone.ts#L167
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",

--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -230,6 +230,10 @@ class QDrant extends VectorDatabase {
       // from vectordb.
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",

--- a/server/utils/vectorDbProviders/weaviate/index.js
+++ b/server/utils/vectorDbProviders/weaviate/index.js
@@ -272,6 +272,10 @@ class Weaviate extends VectorDatabase {
       // from vectordb.
       const EmbedderEngine = getEmbeddingEngineSelection();
       const textSplitter = new TextSplitter({
+        strategy: await SystemSettings.getValueOrFallback(
+          { label: "text_splitter_strategy" },
+          "recursive"
+        ),
         chunkSize: TextSplitter.determineMaxChunkSize(
           await SystemSettings.getValueOrFallback({
             label: "text_splitter_chunk_size",


### PR DESCRIPTION
### Pull Request Type
- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues
connect #5753

### Description

Adds an optional **Sentence** strategy to Text Splitting & Chunking Preferences. It groups complete sentences within the configured character limit, carries whole sentences within the overlap budget, and falls back to the existing recursive splitter for oversized sentences. Existing installations continue to use **Recursive** by default.

The preference is persisted and validated, invalidates the vector cache like the existing chunk-size settings, and is passed to the shared splitter by all eight vector database providers. Embedding prefixes and document metadata remain attached to every chunk. The settings UI explains that existing documents need to be re-embedded.

This is a focused first part of #5753: a global sentence strategy using the runtime's built-in `Intl.Segmenter`, with no new dependencies. Workspace-specific, document-type-specific, and semantic splitting are outside this PR.

### Visuals (if applicable)
The existing preferences form gains a labeled strategy selector and explanatory text. No browser screenshot is attached yet.

### Additional Information

This is a draft pending the contributor's personal code review, as requested by the contribution guide's AI-use policy. Codex implemented and tested the change at the contributor's request; independent human review is not claimed.

Validation:
- 23 targeted tests passed across splitter behavior and settings persistence/cache invalidation, including error cases, whole-sentence overlap, oversized input, Unicode boundaries, prefixes, and metadata.
- `yarn lint` passed across server, frontend, and collector.
- Frontend production build passed.
- `git diff --check` passed.
- Docker build was not run because the local Docker daemon is unavailable. Full server/integration suites and live embedding-provider checks were not run.

### Developer Validations
- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally
