### PR TITLE
fix: clean document_vectors rows on Lance/PGVector delete

### DIFF
--- a/server/__tests__/utils/vectorDbProviders/deleteDocumentFromNamespace/documentVectorsCleanup.test.js
+++ b/server/__tests__/utils/vectorDbProviders/deleteDocumentFromNamespace/documentVectorsCleanup.test.js
@@ -1,0 +1,66 @@
+jest.mock("../../../../../models/vectors", () => ({
+  DocumentVectors: {
+    where: jest.fn(),
+    deleteIds: jest.fn(),
+  },
+}));
+
+const { DocumentVectors } = require("../../../../../models/vectors");
+const { LanceDb } = require("../../../../../utils/vectorDbProviders/lance");
+const { PGVector } = require("../../../../../utils/vectorDbProviders/pgvector");
+const { QDrant } = require("../../../../../utils/vectorDbProviders/qdrant");
+
+describe("deleteDocumentFromNamespace cleans document_vectors rows", () => {
+  const knownDocuments = [
+    { id: 1, vectorId: "v-1" },
+    { id: 2, vectorId: "v-2" },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    DocumentVectors.where.mockResolved(knownDocuments);
+    DocumentVectors.deleteIds.mockResolved(true);
+  });
+
+  it("Lance deletes DocumentVectors row ids after removing vectors", async () => {
+    const lance = new LanceDb();
+    const table = { delete: jest.fn().mockResolved(undefined) };
+    lance.connect = jest.fn().mockResolved({
+
+      client: { openTable: jest.fn().mockResolved(table) },
+    });
+    lance.namespaceExists = jest.fn().mockResolved(true);
+
+    await lance.deleteDocumentFromNamespace("ws", "doc-1");
+
+    expect(table.delete).toHaveBeenCalled();
+    expect(DocumentVectors.deleteIds).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("PGVector deletes DocumentVectors row ids after removing vectors", async () => {
+    const pg = new PGVector();
+    const connection = {
+      query: jest.fn().mockResolved(undefined),
+      end: jest.fn().mockResolved(undefined),
+    };
+    pg.connect = jest.fn().mockResolved(connection);
+    pg.namespaceExists = jest.fn().mockResolved(true);
+    pg.logger = jest.fn();
+
+    await pg.deleteDocumentFromNamespace("ws", "doc-1");
+
+    expect(DocumentVectors.deleteIds).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("QDrant still deletes DocumentVectors row ids (parity baseline)", async () => {
+    const qdrant = new QDrant();
+    const client = { delete: jest.fn().mockResolved(undefined) };
+    qdrant.connect = jest.fn().mockResolved({ client });
+    qdrant.namespaceExists = jest.fn().mockResolved(true);
+
+    await qdrant.deleteDocumentFromNamespace("ws", "doc-1");
+
+    expect(client.delete).toHaveBeenCalled();
+    expect(DocumentVectors.deleteIds).toHaveBeenCalledWith([1, 2]);
+  });
+});

--- a/server/utils/vectorDbProviders/lance/index.js
+++ b/server/utils/vectorDbProviders/lance/index.js
@@ -300,12 +300,12 @@ class LanceDb extends VectorDatabase {
 
     const { DocumentVectors } = require("../../../models/vectors");
     const table = await client.openTable(namespace);
-    const vectorIds = (await DocumentVectors.where({ docId })).map(
-      (record) => record.vectorId
-    );
+    const knownDocuments = await DocumentVectors.where({ docId });
+    if (knownDocuments.length === 0) return;
 
-    if (vectorIds.length === 0) return;
+    const vectorIds = knownDocuments.map((record) => record.vectorId);
     await table.delete(`id IN (${vectorIds.map((v) => `'${v}'`).join(",")})`);
+    await DocumentVectors.deleteIds(knownDocuments.map((doc) => doc.id));
     return true;
   }
 

--- a/server/utils/vectorDbProviders/pgvector/index.js
+++ b/server/utils/vectorDbProviders/pgvector/index.js
@@ -685,11 +685,10 @@ class PGVector extends VectorDatabase {
         );
 
       const { DocumentVectors } = require("../../../models/vectors");
-      const vectorIds = (await DocumentVectors.where({ docId })).map(
-        (record) => record.vectorId
-      );
-      if (vectorIds.length === 0) return;
+      const knownDocuments = await DocumentVectors.where({ docId });
+      if (knownDocuments.length === 0) return;
 
+      const vectorIds = knownDocuments.map((record) => record.vectorId);
       try {
         await connection.query(`BEGIN`);
         for (const vectorId of vectorIds)
@@ -703,6 +702,7 @@ class PGVector extends VectorDatabase {
         throw err;
       }
 
+      await DocumentVectors.deleteIds(knownDocuments.map((doc) => doc.id));
       this.logger(
         `Deleted ${vectorIds.length} vectors from namespace ${namespace}`
       );


### PR DESCRIPTION
## What
`deleteDocumentFromNamespace` on Lance and PGVector deleted the vectors but never called `DocumentVectors.deleteIds`, unlike qdrant/pinecone/chroma/etc.

`jobs/sync-watched-documents.js` calls that path directly (bypassing `Document.removeDocuments`), so each watched-doc refresh leaked a full generation of stale `document_vectors` rows.

## Fix
After deleting vectors, call `DocumentVectors.deleteIds` with the row ids — same pattern as qdrant.

## Test
- `server/__tests__/utils/vectorDbProviders/deleteDocumentFromNamespace/documentVectorsCleanup.test.js` (Lance + PGVector + qdrant parity)

Fixes #6301