### PR TITLE
feat: show per-message token usage in chat metrics

### DIFF
--- a/frontend/__tests__/formatTokenUsage.test.mjs
+++ b/frontend/__tests__/formatTokenUsage.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import formatTokenUsage from "../src/utils/chat/formatTokenUsage.js";
+
+test("formats input and output token counts", () => {
+  assert.equal(
+    formatTokenUsage({ prompt_tokens: 1200, completion_tokens: 340 }),
+    "Input: 1,200 | Output: 340 tokens"
+  );
+});
+
+test("preserves zero token counts", () => {
+  assert.equal(
+    formatTokenUsage({ prompt_tokens: 0, completion_tokens: 0 }),
+    "Input: 0 | Output: 0 tokens"
+  );
+});
+
+test("does not invent counts for missing fields", () => {
+  assert.equal(
+    formatTokenUsage({ prompt_tokens: 1200 }),
+    "Input: 1,200 tokens"
+  );
+  assert.equal(
+    formatTokenUsage({ completion_tokens: 340 }),
+    "Output: 340 tokens"
+  );
+});
+
+test("returns an empty string when token usage is unavailable", () => {
+  assert.equal(formatTokenUsage(), "");
+  assert.equal(formatTokenUsage(null), "");
+  assert.equal(formatTokenUsage({ duration: 2, outputTps: 10 }), "");
+});
+
+test("ignores invalid counts while preserving a valid count", () => {
+  for (const value of [
+    undefined,
+    null,
+    -1,
+    1.5,
+    NaN,
+    Infinity,
+    "1200",
+    Number.MAX_SAFE_INTEGER + 1,
+  ]) {
+    assert.equal(
+      formatTokenUsage({ prompt_tokens: value, completion_tokens: 0 }),
+      "Output: 0 tokens"
+    );
+    assert.equal(
+      formatTokenUsage({ prompt_tokens: 0, completion_tokens: value }),
+      "Input: 0 tokens"
+    );
+  }
+});

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/RenderMetrics/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/RenderMetrics/index.jsx
@@ -1,5 +1,6 @@
 import { formatDateTimeAsMoment } from "@/utils/directories";
 import { formatDuration, numberWithCommas } from "@/utils/numbers";
+import formatTokenUsage from "@/utils/chat/formatTokenUsage";
 import React, { useEffect, useState, useContext } from "react";
 import { isMobile } from "react-device-detect";
 const MetricsContext = React.createContext();
@@ -30,17 +31,18 @@ function getAutoShowMetrics() {
 }
 
 /**
- * Build the metrics string for a given metrics object
- * - Model name
- * - Duration and output TPS
- * - Timestamp
- * @param {metrics: {duration:number, outputTps: number, model?: string, timestamp?: number}} metrics
+ * Build the metrics string for a given metrics object.
+ * @param {Object} metrics
+ * @param {string} tokenUsage
  * @returns {string}
  */
-function buildMetricsString(metrics = {}) {
+function buildMetricsString(metrics = {}, tokenUsage = "") {
   return [
     metrics?.model ? metrics.model : "",
-    `${formatDuration(metrics.duration)} (${formatTps(metrics.outputTps)} tok/s)`,
+    metrics?.duration && metrics?.outputTps
+      ? `${formatDuration(metrics.duration)} (${formatTps(metrics.outputTps)} tok/s)`
+      : "",
+    tokenUsage,
     metrics?.timestamp
       ? formatDateTimeAsMoment(metrics.timestamp, "MMM D, h:mm A")
       : "",
@@ -103,7 +105,12 @@ export default function RenderMetrics({ metrics = {} }) {
   // Inherit the showMetricsAutomatically state from the MetricsProvider so the state is shared across all chats
   const { showMetricsAutomatically, setShowMetricsAutomatically } =
     useContext(MetricsContext);
-  if (!metrics?.duration || !metrics?.outputTps || isMobile) return null;
+  const tokenUsage = formatTokenUsage(metrics);
+  const hasPerformanceMetrics = Boolean(
+    metrics?.duration && metrics?.outputTps
+  );
+
+  if (isMobile || (!hasPerformanceMetrics && !tokenUsage)) return null;
 
   return (
     <button
@@ -118,7 +125,7 @@ export default function RenderMetrics({ metrics = {} }) {
       className={`border-none flex md:justify-end items-center gap-x-[8px] -ml-7 ${showMetricsAutomatically ? "opacity-100" : "opacity-0"} md:group-hover:opacity-100 transition-all duration-300`}
     >
       <p className="cursor-pointer text-xs font-mono text-zinc-400 light:text-slate-500">
-        {buildMetricsString(metrics)}
+        {buildMetricsString(metrics, tokenUsage)}
       </p>
     </button>
   );

--- a/frontend/src/utils/chat/formatTokenUsage.js
+++ b/frontend/src/utils/chat/formatTokenUsage.js
@@ -1,0 +1,17 @@
+import { numberWithCommas } from "../numbers.js";
+
+/**
+ * Format available prompt and completion token counts.
+ * @param {Object|null} metrics
+ * @returns {string}
+ */
+export default function formatTokenUsage(metrics = {}) {
+  const parts = [
+    ["Input", metrics?.prompt_tokens],
+    ["Output", metrics?.completion_tokens],
+  ]
+    .filter(([, value]) => Number.isSafeInteger(value) && value >= 0)
+    .map(([label, value]) => `${label}: ${numberWithCommas(value)}`);
+
+  return parts.length > 0 ? `${parts.join(" | ")} tokens` : "";
+}


### PR DESCRIPTION
### Pull Request Type

- [x] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

connect #6314

### Description

Display `Input: 1,200 | Output: 340 tokens` in the existing per-message chat metrics row using the backend's stored prompt/completion metrics. Counts appear when metrics arrive, normally at completion of a streamed response, and are available when loading saved history. This does not add an incrementing counter during generation.

## Changes

- Format available token counts, preserving zero and omitting missing or invalid values.
- Allow the metrics row to display token usage even when duration or throughput is unavailable.
- Preserve the existing visibility toggle and mobile hiding behavior.
- Add five tests for the formatting and boundary cases without additional dependencies.

### Visuals (if applicable)

Browser screenshots and live chat verification are pending; this PR is a draft.

### Additional Information

Validation performed with Node v24.11.1 and the existing local dependencies:

- Passed: `node --test frontend/__tests__/formatTokenUsage.test.mjs` (5 tests). These use Node's built-in runner and are not collected by the existing root Jest command.
- Passed: `yarn --cwd frontend lint:check`.
- Passed: `yarn --cwd frontend build` (existing large-chunk warnings).
- Passed: six ad hoc server-render smoke checks against the actual component with date/device/storage mocked: token-only metrics, zero output, empty/null metrics, legacy performance metrics, combined metrics, and mobile hiding.
- Passed: `git diff --check`.
- `yarn lint:ci` stops at 5 formatting errors in unchanged backend files: `server/endpoints/workspaces.js`, `server/utils/AiProviders/foundry/models.js`, and `server/utils/agents/aibitat/plugins/create-files/pdf/create-pdf-file.js`.
- Live provider chat, browser interaction/history reload, Node 18 validation, and Docker build remain pending.

Counts may be reported or estimated by existing backend adapters. This does not change token accounting or public APIs. Documentation changes are not applicable.

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
