### PR TITLE
fix: pin @qdrant/js-client-rest to 1.18.0 so lockfile-less builds keep search()

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "@modelcontextprotocol/sdk": "^1.24.3",
     "@pinecone-database/pinecone": "^2.0.1",
     "@prisma/client": "5.3.1",
-    "@qdrant/js-client-rest": "^1.9.0",
+    "@qdrant/js-client-rest": "1.18.0",
     "@vscode/ripgrep": "1.17.1",
     "@xenova/transformers": "^2.14.0",
     "@zilliz/milvus2-sdk-node": "2.3.5",

--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -25,6 +25,10 @@ class QDrant extends VectorDatabase {
       ...(process.env.QDRANT_API_KEY
         ? { apiKey: process.env.QDRANT_API_KEY }
         : {}),
+      // The client fires an extra `GET /` version probe on construction and
+      // warns when the server is more than one minor version away. We create a
+      // client per request, so skip it to avoid the noise and the extra call.
+      checkCompatibility: false,
     });
 
     const isAlive = (await client.api("cluster")?.clusterStatus())?.ok || false;

--- a/server/utils/vectorDbProviders/qdrant/index.js
+++ b/server/utils/vectorDbProviders/qdrant/index.js
@@ -25,10 +25,6 @@ class QDrant extends VectorDatabase {
       ...(process.env.QDRANT_API_KEY
         ? { apiKey: process.env.QDRANT_API_KEY }
         : {}),
-      // The client fires an extra `GET /` version probe on construction and
-      // warns when the server is more than one minor version away. We create a
-      // client per request, so skip it to avoid the noise and the extra call.
-      checkCompatibility: false,
     });
 
     const isAlive = (await client.api("cluster")?.clusterStatus())?.ok || false;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -409,11 +409,6 @@
     lodash.isundefined "^3.0.1"
     lodash.uniq "^4.5.0"
 
-"@fastify/busboy@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz"
-  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
-
 "@google/generative-ai@^0.1.1":
   version "0.1.3"
   resolved "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.1.3.tgz"
@@ -983,24 +978,18 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
   integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
-"@qdrant/js-client-rest@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.9.0.tgz"
-  integrity sha512-YiX/IskbRCoAY2ujyPDI6FBcO0ygAS4pgkGaJ7DcrJFh4SZV2XHs+u0KM7mO72RWJn1eJQFF2PQwxG+401xxJg==
+"@qdrant/js-client-rest@1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@qdrant/js-client-rest/-/js-client-rest-1.18.0.tgz#7595b3e4bbdee95bd1748467c02a20785e05133b"
+  integrity sha512-/0dqX5uV9chC1DnYSnU4gNMrDqse/pt6hHg3Rqqpl5isH7xl1xSNvffjzBoxycDD79luWn7Ho6Rh/61sOs5DNw==
   dependencies:
     "@qdrant/openapi-typescript-fetch" "1.2.6"
-    "@sevinf/maybe" "0.5.0"
-    undici "~5.28.4"
+    undici "^6.24.0"
 
 "@qdrant/openapi-typescript-fetch@1.2.6":
   version "1.2.6"
   resolved "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz"
   integrity sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==
-
-"@sevinf/maybe@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/@sevinf/maybe/-/maybe-0.5.0.tgz"
-  integrity sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg==
 
 "@sideway/address@^4.1.5":
   version "4.1.5"
@@ -7465,12 +7454,10 @@ undici@^6.19.5:
   resolved "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz"
   integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
 
-undici@~5.28.4:
-  version "5.28.4"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz"
-  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
+undici@^6.24.0:
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.1.tgz#aa9d2c44aef3840bef80216f2a50f337543a3fbd"
+  integrity sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #6270
closes #6287

### Description
The desktop bundler installs the merged server/collector deps without a lockfile, so ^1.9.0 floated to 1.19.0, which removed client.search() and broke every Qdrant retrieval with 'e.search is not a function' (#6270). Docker and dev installs stayed on 1.9.0 via yarn.lock.
    
Pin to 1.18.0: the last release that still ships search(), supports Node 18, and talks to current Qdrant servers. 1.19.0 also raised the engine floor to Node 22, which the Docker image does not meet.
  
<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
