### PR TITLE
fix: require sql_query, not table_name

### DIFF
--- a/server/utils/agents/aibitat/plugins/sql-agent/query.js
+++ b/server/utils/agents/aibitat/plugins/sql-agent/query.js
@@ -57,7 +57,7 @@ module.exports.SqlAgentQuery = {
             },
             additionalProperties: false,
           },
-          required: ["database_id", "table_name"],
+          required: ["database_id", "sql_query"],
           handler: async function ({ database_id = "", sql_query = "" }) {
             this.super.handlerProps.log(`Using the sql-query tool.`);
             try {


### PR DESCRIPTION
## Pull Request Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

## Relevant Issues

resolves #6328

## What is in this change?

Corrects the `required` list on the `sql-query` agent tool. It named `table_name`, a field the tool does not declare, and left `sql_query` optional. The line was carried over from the `sql-get-table-schema` tool when the SQL agent first landed.

Now requires `database_id` and `sql_query`, matching the tool's declared properties and handler.

## Additional Information

The impact was smaller than the issue suggests. Only the Anthropic and Bedrock providers forward the plugin-level `required` list into the tool schema. For those, the model was told to send a nonexistent `table_name` and could omit the query. Every other provider ignores that list, so the tool behaved the same before and after for them. Nothing in the pipeline rejected calls over this mismatch, so it does not explain the "query shown but not executed" reports in #4023.

## Developer Validations

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [x] I have tested my code functionality
- [x] Docker build succeeds locally
