### PR TITLE
fix: preserve max tokens in Generic OpenAI streaming

### DIFF
--- a/server/__tests__/utils/AiProviders/genericOpenAi/index.test.js
+++ b/server/__tests__/utils/AiProviders/genericOpenAi/index.test.js
@@ -174,3 +174,35 @@ describe("GenericOpenAiProvider (agent) attachment content", () => {
     });
   });
 });
+
+describe("GenericOpenAiProvider (agent) streaming options", () => {
+  it.each([
+    ["configured", "2048", 2048],
+    ["default", undefined, 1024],
+  ])("passes the %s max_tokens value to UnTooled streaming", async (_label, envValue, expected) => {
+    if (envValue === undefined) {
+      delete process.env.GENERIC_OPEN_AI_MAX_TOKENS;
+    } else {
+      process.env.GENERIC_OPEN_AI_MAX_TOKENS = envValue;
+    }
+
+    const provider = new GenericOpenAiProvider({ model: "test-model" });
+    provider.supportsNativeToolCalling = jest.fn().mockResolvedValue(false);
+    const create = jest
+      .spyOn(provider.client.chat.completions, "create")
+      .mockResolvedValue(
+        (async function* () {
+          yield { choices: [{ delta: { content: "response" } }] };
+        })()
+      );
+
+    await provider.stream([{ role: "user", content: "hello" }]);
+
+    expect(create).toHaveBeenCalledWith({
+      model: "test-model",
+      stream: true,
+      messages: [{ role: "user", content: "hello" }],
+      max_tokens: expected,
+    });
+  });
+});

--- a/server/utils/agents/aibitat/providers/genericOpenAi.js
+++ b/server/utils/agents/aibitat/providers/genericOpenAi.js
@@ -96,6 +96,7 @@ class GenericOpenAiProvider extends InheritMultiple([Provider, UnTooled]) {
       model: this.model,
       stream: true,
       messages,
+      max_tokens: this.maxTokens,
     });
   }
 


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [x] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [ ] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

Resolves #6330

### Description

Generic OpenAI agent requests using the UnTooled streaming fallback did not include the configured `GENERIC_OPEN_AI_MAX_TOKENS` value. The backend therefore applied its own default output limit, unlike the non-streaming path.

The streaming request now passes `max_tokens: this.maxTokens`. Regression tests cover both a configured value and the provider default.

### Visuals (if applicable)

Not applicable.

### Additional Information

This is a focused fix for the existing Generic OpenAI streaming request path. No live LLM or backend integration is required for the regression coverage.

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [x] I have tested my code functionality
- [ ] Docker build succeeds locally

Checks run: `cd server && yarn lint:check`; related Jest suites (16 tests); `git diff --check`.