### PR TITLE
Enable web-browsing by default

### DIFF
--- a/frontend/src/pages/Admin/Agents/WebSearchSelection/index.jsx
+++ b/frontend/src/pages/Admin/Agents/WebSearchSelection/index.jsx
@@ -21,6 +21,8 @@ import {
   ListMagnifyingGlass,
 } from "@phosphor-icons/react";
 import Toggle from "@/components/lib/Toggle";
+import { DefaultBadge } from "../Badges/default";
+import { useTranslation } from "react-i18next";
 import SearchProviderItem from "./SearchProviderItem";
 import WebSearchImage from "@/media/agents/scrape-websites.png";
 import {
@@ -156,9 +158,10 @@ export default function AgentWebSearchSelection({
   description,
   settings,
   toggleSkill,
-  enabled = false,
+  enabled = true,
   setHasChanges,
 }) {
+  const { t } = useTranslation();
   const searchInputRef = useRef(null);
   const [filteredResults, setFilteredResults] = useState([]);
   const [selectedProvider, setSelectedProvider] = useState("you-search");
@@ -218,6 +221,7 @@ export default function AgentWebSearchSelection({
             >
               {title}
             </label>
+            <DefaultBadge title={title} />
           </div>
           <Toggle
             size="lg"
@@ -232,6 +236,9 @@ export default function AgentWebSearchSelection({
         />
         <p className="text-theme-text-secondary text-opacity-60 text-xs font-medium py-1.5">
           {description}
+          <br />
+          <br />
+          {t("agent.skill.default_skill")}
         </p>
         <div hidden={!enabled}>
           <div className="relative">

--- a/frontend/src/pages/Admin/Agents/skills.jsx
+++ b/frontend/src/pages/Admin/Agents/skills.jsx
@@ -54,6 +54,12 @@ export const getDefaultSkills = (t) => ({
     image: ScrapeWebsitesImage,
     skill: "web-scraping",
   },
+  "web-browsing": {
+    title: t("agent.skill.web.title"),
+    description: t("agent.skill.web.description"),
+    component: AgentWebSearchSelection,
+    skill: "web-browsing",
+  },
 });
 
 /**
@@ -113,12 +119,6 @@ export const getConfigurableSkills = (
       image: GenerateImageImage,
     },
   }),
-  "web-browsing": {
-    title: t("agent.skill.web.title"),
-    description: t("agent.skill.web.description"),
-    component: AgentWebSearchSelection,
-    skill: "web-browsing",
-  },
   "sql-agent": {
     title: t("agent.skill.sql.title"),
     description: t("agent.skill.sql.description"),

--- a/server/__tests__/utils/boot/migrateWebBrowsingToDefault.test.js
+++ b/server/__tests__/utils/boot/migrateWebBrowsingToDefault.test.js
@@ -1,0 +1,164 @@
+process.env.STORAGE_DIR = __dirname;
+process.env.NODE_ENV = "test";
+
+const { SystemSettings } = require("../../../models/systemSettings");
+jest.mock("../../../models/systemSettings");
+
+const migrateWebBrowsingToDefault = require("../../../utils/boot/migrateWebBrowsingToDefault");
+
+const MIGRATION_LABEL = "__migration_web_browser_to_default";
+
+/**
+ * Build a SystemSettings mock backed by a simple label => value map so the
+ * migration reads/writes behave like the real upsert semantics.
+ */
+function mockSettings(initial = {}) {
+  const store = { ...initial };
+  SystemSettings.get = jest.fn(async ({ label }) =>
+    label in store ? { label, value: store[label] } : null
+  );
+  SystemSettings.getValueOrFallback = jest.fn(
+    async ({ label }, fallback) => store[label] ?? fallback
+  );
+  SystemSettings.isOnboardingComplete = jest.fn(
+    async () => store.onboarding_complete === "true"
+  );
+  SystemSettings._updateSettings = jest.fn(async (updates) => {
+    for (const [key, value] of Object.entries(updates)) {
+      // Mirror the real validators for skill lists: csv string -> JSON array string.
+      if (["default_agent_skills", "disabled_agent_skills"].includes(key)) {
+        store[key] = JSON.stringify(value.split(",").filter(Boolean));
+        continue;
+      }
+      store[key] = String(value);
+    }
+    return { success: true, error: null };
+  });
+  return store;
+}
+
+describe("migrateWebBrowsingToDefault", () => {
+  let logSpy;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => logSpy.mockRestore());
+
+  it("skips entirely when the migration marker already exists", async () => {
+    const store = mockSettings({
+      [MIGRATION_LABEL]: "true",
+      onboarding_complete: "true",
+      default_agent_skills: JSON.stringify(["web-browsing"]),
+    });
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(false);
+    expect(SystemSettings.isOnboardingComplete).not.toHaveBeenCalled();
+    expect(SystemSettings._updateSettings).not.toHaveBeenCalled();
+    expect(store.default_agent_skills).toBe(JSON.stringify(["web-browsing"]));
+  });
+
+  it("does not modify skills on a fresh instance but writes the marker", async () => {
+    const store = mockSettings({});
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(false);
+    expect(SystemSettings._updateSettings).toHaveBeenCalledTimes(1);
+    expect(SystemSettings._updateSettings).toHaveBeenCalledWith({
+      [MIGRATION_LABEL]: "true",
+    });
+    expect(store.default_agent_skills).toBeUndefined();
+    expect(store.disabled_agent_skills).toBeUndefined();
+  });
+
+  it("removes web-browsing from default_agent_skills when previously opted in", async () => {
+    const store = mockSettings({
+      onboarding_complete: "true",
+      default_agent_skills: JSON.stringify([
+        "create-chart",
+        "web-browsing",
+        "sql-agent",
+      ]),
+    });
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(true);
+    expect(JSON.parse(store.default_agent_skills)).toEqual([
+      "create-chart",
+      "sql-agent",
+    ]);
+    expect(store.disabled_agent_skills).toBeUndefined();
+    expect(store[MIGRATION_LABEL]).toBe("true");
+  });
+
+  it("adds web-browsing to disabled_agent_skills when previously not enabled", async () => {
+    const store = mockSettings({
+      onboarding_complete: "true",
+      default_agent_skills: JSON.stringify(["create-chart"]),
+      disabled_agent_skills: JSON.stringify(["rag-memory"]),
+    });
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(true);
+    expect(JSON.parse(store.default_agent_skills)).toEqual(["create-chart"]);
+    expect(JSON.parse(store.disabled_agent_skills)).toEqual([
+      "rag-memory",
+      "web-browsing",
+    ]);
+    expect(store[MIGRATION_LABEL]).toBe("true");
+  });
+
+  it("disables web-browsing when no skill settings exist at all on an onboarded instance", async () => {
+    const store = mockSettings({ onboarding_complete: "true" });
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(true);
+    expect(JSON.parse(store.disabled_agent_skills)).toEqual(["web-browsing"]);
+    expect(store[MIGRATION_LABEL]).toBe("true");
+  });
+
+  it("does not duplicate web-browsing if already present in disabled_agent_skills", async () => {
+    const store = mockSettings({
+      onboarding_complete: "true",
+      disabled_agent_skills: JSON.stringify(["web-browsing"]),
+    });
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(true);
+    expect(JSON.parse(store.disabled_agent_skills)).toEqual(["web-browsing"]);
+    expect(SystemSettings._updateSettings).toHaveBeenCalledTimes(1); // marker only
+  });
+
+  it("is idempotent across boots", async () => {
+    const store = mockSettings({
+      onboarding_complete: "true",
+      default_agent_skills: JSON.stringify(["web-browsing"]),
+    });
+
+    expect(await migrateWebBrowsingToDefault()).toBe(true);
+    expect(await migrateWebBrowsingToDefault()).toBe(false);
+    expect(JSON.parse(store.default_agent_skills)).toEqual([]);
+    expect(store.disabled_agent_skills).toBeUndefined();
+  });
+
+  it("returns false and does not write the marker if an error occurs", async () => {
+    mockSettings({ onboarding_complete: "true" });
+    SystemSettings.getValueOrFallback = jest
+      .fn()
+      .mockRejectedValue(new Error("db down"));
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const ran = await migrateWebBrowsingToDefault();
+
+    expect(ran).toBe(false);
+    expect(SystemSettings._updateSettings).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/server/models/scheduledJob.js
+++ b/server/models/scheduledJob.js
@@ -303,6 +303,11 @@ const ScheduledJob = {
         name: "Web Scraping",
         description: "Scrape content from web pages",
       },
+      {
+        id: "web-browsing",
+        name: "Web Browsing",
+        description: "Search and browse the web",
+      },
     ];
 
     // Configurable skills without sub-skills
@@ -311,11 +316,6 @@ const ScheduledJob = {
         id: "create-chart",
         name: "Create Charts",
         description: "Generate data visualization charts",
-      },
-      {
-        id: "web-browsing",
-        name: "Web Browsing",
-        description: "Search and browse the web",
       },
       {
         id: "sql-agent",

--- a/server/utils/agents/defaults.js
+++ b/server/utils/agents/defaults.js
@@ -11,6 +11,7 @@ const DEFAULT_SKILLS = [
   AgentPlugins.memory.name,
   AgentPlugins.docSummarizer.name,
   AgentPlugins.webScraping.name,
+  AgentPlugins.webBrowsing.name,
 ];
 
 // Skills that must never be injected when the instance is running in multi-user mode.

--- a/server/utils/boot/index.js
+++ b/server/utils/boot/index.js
@@ -5,6 +5,7 @@ const { CommunicationKey } = require("../comKey");
 const setupTelemetry = require("../telemetry");
 const eagerLoadContextWindows = require("./eagerLoadContextWindows");
 const markOnboarded = require("./markOnboarded");
+const migrateWebBrowsingToDefault = require("./migrateWebBrowsingToDefault");
 const { PushNotifications } = require("../PushNotifications");
 const { TelegramBotService } = require("../telegramBot");
 
@@ -31,6 +32,7 @@ function bootSSL(app, port = 3001) {
 
     server
       .listen(port, async () => {
+        await migrateWebBrowsingToDefault(); // must run before markOnboarded() so a fresh instance is not mistaken for an existing one.
         await markOnboarded();
         await setupTelemetry();
         new CommunicationKey(true);
@@ -64,6 +66,7 @@ function bootHTTP(app, port = 3001) {
 
   app
     .listen(port, async () => {
+      await migrateWebBrowsingToDefault(); // must run before markOnboarded() so a fresh instance is not mistaken for an existing one.
       await markOnboarded();
       await setupTelemetry();
       new CommunicationKey(true);

--- a/server/utils/boot/migrateWebBrowsingToDefault.js
+++ b/server/utils/boot/migrateWebBrowsingToDefault.js
@@ -1,0 +1,93 @@
+const { SystemSettings } = require("../../models/systemSettings");
+const { safeJsonParse } = require("../http");
+
+const WEB_BROWSING_SKILL = "web-browsing";
+const MIGRATION_LABEL = "__migration_web_browser_to_default";
+
+/**
+ * One-time boot migration for moving `web-browsing` from an opt-in configurable
+ * skill to a default-enabled skill.
+ *
+ * Existing instances must keep the exact behavior they had before upgrading:
+ * - If they had opted into web-browsing (present in `default_agent_skills`) we remove
+ *   it from that list since it is now on by default.
+ * - If they had not opted in, we add it to `disabled_agent_skills` so the skill does
+ *   not silently appear for them.
+ *
+ * Fresh instances (onboarding not complete) get the new default with no changes.
+ *
+ * IMPORTANT: this must run BEFORE `markOnboarded()` on boot. A fresh install can ship
+ * with env vars (JWT_SECRET, VECTOR_DB, etc.) that make the legacy onboarding patch mark
+ * the instance as onboarded on its very first boot, which would otherwise make this job
+ * treat a brand-new instance as an existing one and disable web-browsing for it. Reading
+ * `onboarding_complete` first means it only reflects the onboarding UI or a prior boot.
+ * The `__migration_web_browser_to_default` system setting is written once the job has
+ * run so it is skipped on every subsequent boot.
+ * @returns {Promise<boolean>} true if the migration was executed on this boot.
+ */
+async function migrateWebBrowsingToDefault() {
+  try {
+    const alreadyRan = await SystemSettings.get({ label: MIGRATION_LABEL });
+    if (!!alreadyRan) return false;
+
+    // Fresh install - nothing to migrate, but mark as ran so that we never
+    // touch this instance's settings once onboarding completes later on.
+    const onboarded = await SystemSettings.isOnboardingComplete();
+    if (onboarded !== true) {
+      await markMigrationComplete();
+      return false;
+    }
+
+    const enabledSkills = safeJsonParse(
+      await SystemSettings.getValueOrFallback(
+        { label: "default_agent_skills" },
+        "[]"
+      ),
+      []
+    );
+
+    if (enabledSkills.includes(WEB_BROWSING_SKILL)) {
+      await SystemSettings._updateSettings({
+        default_agent_skills: enabledSkills
+          .filter((skill) => skill !== WEB_BROWSING_SKILL)
+          .join(","),
+      });
+      console.log(
+        `\x1b[33m[WEB BROWSING MIGRATION]\x1b[0m ${WEB_BROWSING_SKILL} is now a default skill - removed from configured skills. You will not see this message again.`
+      );
+    } else {
+      const disabledSkills = safeJsonParse(
+        await SystemSettings.getValueOrFallback(
+          { label: "disabled_agent_skills" },
+          "[]"
+        ),
+        []
+      );
+      if (!disabledSkills.includes(WEB_BROWSING_SKILL))
+        await SystemSettings._updateSettings({
+          disabled_agent_skills: [...disabledSkills, WEB_BROWSING_SKILL].join(
+            ","
+          ),
+        });
+      console.log(
+        `\x1b[33m[WEB BROWSING MIGRATION]\x1b[0m ${WEB_BROWSING_SKILL} is now a default skill but was not previously enabled on this instance - it has been disabled to preserve existing behavior. You will not see this message again.`
+      );
+    }
+
+    await markMigrationComplete();
+    return true;
+  } catch (e) {
+    console.error(
+      "\x1b[31m[WEB BROWSING MIGRATION]\x1b[0m Error migrating web-browsing to a default skill",
+      e.message,
+      e
+    );
+    return false;
+  }
+}
+
+async function markMigrationComplete() {
+  await SystemSettings._updateSettings({ [MIGRATION_LABEL]: "true" });
+}
+
+module.exports = migrateWebBrowsingToDefault;


### PR DESCRIPTION
### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat (New feature)
- [ ] 🐛 fix (Bug fix)
- [ ] ♻️ refactor (Code refactoring without changing behavior)
- [ ] 💄 style (UI style changes)
- [x] 🔨 chore (Build, CI, maintenance)
- [ ] 📝 docs (Documentation updates)


### Description

## Web-browsing default-on migration matrix

The migration runs once at boot (before the legacy onboarding patch) and writes a `__migration_web_browser_to_default` system setting when done. If that row exists, nothing runs.

| # | `__migration_web_browser_to_default` | `onboarding_complete` | `default_agent_skills` | `disabled_agent_skills` | Action | Result for web-browsing |
|---|---|---|---|---|---|---|
| 1 | present | any | any | any | No-op | Unchanged |
| 2 | absent | not `true` (fresh instance) | any | any | Write marker only | **Enabled** (new default) |
| 3 | absent | `true` | contains `web-browsing` | any | Remove `web-browsing` from `default_agent_skills`, write marker | **Enabled** (same as before) |
| 4 | absent | `true` | does not contain `web-browsing` | does not contain `web-browsing` | Append `web-browsing` to `disabled_agent_skills`, write marker | **Disabled** (same as before) |
| 5 | absent | `true` | does not contain `web-browsing` | already contains `web-browsing` | Write marker only (no duplicate) | **Disabled** (same as before) |
| 6 | absent | `true` | row missing | row missing | Create `disabled_agent_skills = ["web-browsing"]`, write marker | **Disabled** (same as before) |
| 7 | absent | `true` | any | any | Error during migration → marker **not** written, retried next boot | Unchanged until a successful run |

### Notes

- Existing instances keep exactly the behavior they had before upgrading. Only fresh instances get the new default.
- The migration must run **before** `markOnboarded()`. A fresh install can ship `.env` values (`JWT_SECRET`, `VECTOR_DB`) that make the legacy patch mark the instance onboarded on first boot, which would otherwise wrongly hit row 4.
- Edge case: an instance upgrading directly from a release older than the onboarding DB flag (Jan 2026, #4926) has no `onboarding_complete` row and is treated as fresh (row 2), so web-browsing is enabled for it. The default engine is You.com with no API key required.
- Admins can toggle web-browsing at any time via **Admin → Agent Skills**; it now lives under default skills and is controlled by `disabled_agent_skills`.


<!-- Describe the changes in this PR that are impactful to the repo. What problem does it solve? -->


### Visuals (if applicable)

<!-- Add screenshots or screen recordings to demonstrate the changes, especially for UI updates. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->


### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (if applicable)
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
